### PR TITLE
Make background grey as default for screens, white for the home page

### DIFF
--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -20,8 +20,12 @@
 }
 
 html, body {
-  background: var(--white);
+  background: var(--light-grey);
   color: var(--gray-darkest);
+}
+
+.template--index {
+  background: var(--white);
 }
 
 .demo-banner {
@@ -116,7 +120,7 @@ a, .button--link {
 
 /* Same as .slab--grey, named to be used more generically */
 .background-grey {
-  background-color: #F7F5F4;
+  background-color: var(--light-grey);
 }
 
 /* Index */

--- a/src/main/resources/templates/gcc/onboarding-getting-started.html
+++ b/src/main/resources/templates/gcc/onboarding-getting-started.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{fragments/head :: head(title=#{onboarding-getting-started.title})}"></head>
-<body class="background-grey">
+<body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
   <section class="slab slab--grey">

--- a/src/main/resources/templates/gcc/pilot-offboard.html
+++ b/src/main/resources/templates/gcc/pilot-offboard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{fragments/head :: head(title=#{pilot-offboard.title})}"></head>
-<body class="background-grey">
+<body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
   <section class="slab slab--grey">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{fragments/head :: head(title=#{index.title})}"></head>
-<body class="template--static-page">
+<body class="template--index template--static-page">
 <div class="page-wrapper">
   <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
   <main id="content" role="main" class="slab slab--white padding-top-0 spacing-below-0">


### PR DESCRIPTION
[#186713028](https://www.pivotaltracker.com/story/show/186713028)

- So that we don't have to define the background every time we make a new screen