### PR TITLE
Remove comments in run-tests that aren't needed

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -5,11 +5,6 @@ on:
     branches: [ main ]
   pull_request:
 
-# What do these envs do?
-#env:
-#  USERNAME: ${{ secrets.GPR_USER }}
-#  TOKEN: ${{ secrets.GPR_KEY }}
-
 jobs:
   test:
     name: Run unit tests
@@ -57,15 +52,6 @@ jobs:
           status: ${{ job.status }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-# Disabling for now as it's not critical, we couldn't get the repo added in Deepsource web app
-#      - name: Report results to DeepSource
-#        continue-on-error: true
-#        if: ${{ steps.test.conclusion == 'success' }}
-#        run: |
-#          curl https://deepsource.io/cli | sh
-#          ./bin/deepsource report --analyzer test-coverage --key java --value-file ./build/reports/jacoco/test/jacocoTestReport.xml
-#        env:
-#          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
       - name: Cleanup Gradle Cache
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
It's confirmed that we don't need these comments for the tests to run.