### PR TITLE
Fixing flow logic

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/conditions/NeedsFinancialAssistanceForChild.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/NeedsFinancialAssistanceForChild.java
@@ -1,0 +1,14 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.ilgcc.app.utils.SubmissionUtilities;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NeedsFinancialAssistanceForChild implements Condition {
+
+  public Boolean run(Submission submission) {
+    return submission.getInputData().getOrDefault("needFinancialAssistanceForChild", "No").equals("Yes");
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -88,6 +88,8 @@ flow:
   children-info-basic:
     nextScreens:
       - name: children-ccap-info
+        condition: NeedsFinancialAssistanceForChild
+      - name: activities-add-ed-program
   children-ccap-info:
     nextScreens:
       - name: children-ccap-in-care


### PR DESCRIPTION
Follow-up of #39 - The rest of the children screens should be skipped if a client answers "yes" to the question "Do you need financial assistance for their child care?"
