### PR TITLE
Auto assign PR author

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,10 @@
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 0
+
+# Run on draft pull requests
+runOnDraft: true

--- a/.github/workflows/auto-assignee.yaml
+++ b/.github/workflows/auto-assignee.yaml
@@ -1,0 +1,14 @@
+name: 'Auto Assignee'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-assignee:
+    name: Add author as assignee in GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          addAssignees: author
+          runOnDraft: true

--- a/.github/workflows/auto-assignee.yaml
+++ b/.github/workflows/auto-assignee.yaml
@@ -10,5 +10,4 @@ jobs:
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          addAssignees: author
-          runOnDraft: true
+          configuration-path: '.github/auto_assign.yml'


### PR DESCRIPTION
#### ✍️ Description
I like having the Assignee in GitHub be the author of a PR. It helps with filters PR and branches withing GitHub. This GitHub Action automatically sets the assignee as the author of the pull request on opening, so no one has to remember to do it manually.

Here is [documentation for `kentaro-m/auto-assign-action`](https://github.com/marketplace/actions/auto-assign-action).