### PR TITLE
Only showing stack-trace in dev env 🍖 

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,3 +1,6 @@
+form-flow:
+  error:
+    show-stack-trace: true
 management:
   endpoints:
     enabled-by-default: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,7 +48,6 @@ form-flow:
       domain: 'mail.forms-starter.cfa-platforms.org'
       sender-email: 'UBI Demo <demo@mail.forms-starter.cfa-platforms.org>'
   error:
-    show-stack-trace: true
     pretty-print-packages: formflow,ilgcc
 spring:
   profiles:


### PR DESCRIPTION
Update config so that non-dev environments have an error page instead of showing the stack trace