### PR TITLE
Adding support for "none of the above" in checkboxFieldset

### DIFF
--- a/src/main/java/org/ilgcc/app/utils/GenderOption.java
+++ b/src/main/java/org/ilgcc/app/utils/GenderOption.java
@@ -5,8 +5,7 @@ public enum GenderOption implements InputOption {
   MALE("general.inputs.male"),
   FEMALE("general.inputs.female"),
   NONBINARY("general.inputs.non-binary"),
-  TRANSGENDER("general.inputs.transgender"),
-  NO_ANSWER("general.inputs.prefer-not-to-answer");
+  TRANSGENDER("general.inputs.transgender");
 
   private final String label;
 

--- a/src/main/resources/templates/fragments/inputs/checkboxFieldset.html
+++ b/src/main/resources/templates/fragments/inputs/checkboxFieldset.html
@@ -6,6 +6,7 @@
       hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
       hasOptions=${options != null},
       hasContent=${!hasOptions},
+      hasNoneOfTheAboveOption=${!#strings.isEmpty(noneOfTheAboveLabel)},
       hasError=${
         errorMessages != null &&
         errorMessages.get(inputName) != null &&
@@ -39,6 +40,10 @@
               value=${option.getValue()},
               label=${#strings.isEmpty(option.getLabel()) ? null : #messages.msg(option.getLabel())},
               checkboxHelpText=${#strings.isEmpty(option.getHelpText()) ? null : #messages.msg(option.getHelpText())})}"/>
+        </th:block>
+        <th:block th:if="${hasNoneOfTheAboveOption}">
+          <th:block th:replace="~{fragments/inputs/checkboxInSet ::
+            checkboxInSet(inputName=${inputName}, value='NONE', label=${noneOfTheAboveLabel}, noneOfTheAbove=true)}"/>
         </th:block>
       </th:block>
       <th:block

--- a/src/main/resources/templates/gcc/children-ccap-info.html
+++ b/src/main/resources/templates/gcc/children-ccap-info.html
@@ -20,7 +20,8 @@
               <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
                   checkboxFieldset(inputName='childGender',
                     label=#{children-ccap-info.gender-question},
-                    options=${genderOptions})}"/>
+                    options=${genderOptions},
+                    noneOfTheAboveLabel=#{general.inputs.prefer-not-to-answer})}"/>
 
               <th:block th:replace="~{fragments/inputs/radioFieldset ::
                   radioFieldset(inputName='childHasDisability',


### PR DESCRIPTION
Follow-up of #72 

Added `noneOfTheAboveLabel` param for checkboxFieldsets

```html
<th:block th:replace="~{fragments/inputs/checkboxFieldset ::
    checkboxFieldset(inputName='childGender',
              label=#{children-ccap-info.gender-question},
              options=${genderOptions},
              noneOfTheAboveLabel=#{general.inputs.prefer-not-to-answer})}"/>
```