### PR TITLE
Add child delete confirmation screen (design from ffsa)

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -249,6 +249,8 @@ flow:
       - name: doc-upload-confirm
   doc-upload-confirm:
     nextScreens: null
+  children-delete:
+    nextScreens: null
 subflows:
   children:
     entryScreen: children-add

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -196,6 +196,14 @@ children-childcare-weekly-schedule.header=What days is {0} in child care?
 children-ccap-child-other-ed.title=CCAP Child Other
 children-ccap-child-other-ed.header=Does {0} attend any other school or education program during the day?
 #
+child-delete-confirmation.title=Delete child
+child-delete-confirmation.header=You are about to delete {0}.
+child-delete-confirmation.is-that-okay=Is that okay?
+child-delete-confirmation.yes=Yes, delete it
+child-delete-confirmation.no=No, keep it
+delete-confirmation-back-redirect.header=This entry has already been deleted
+delete-confirmation-back-redirect.button=Return to the screen I was on before
+#
 #activities-parent-intro
 #activities-parent-type
 #activities-add-jobs

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -195,7 +195,7 @@ children-childcare-weekly-schedule.header=What days is {0} in child care?
 #children-ccap-child-other-ed
 children-ccap-child-other-ed.title=CCAP Child Other
 children-ccap-child-other-ed.header=Does {0} attend any other school or education program during the day?
-#
+# placeholder copy
 child-delete-confirmation.title=Delete child
 child-delete-confirmation.header=You are about to delete {0}.
 child-delete-confirmation.is-that-okay=Is that okay?

--- a/src/main/resources/templates/gcc/children-add.html
+++ b/src/main/resources/templates/gcc/children-add.html
@@ -23,7 +23,7 @@
                     <span class="space-between">
                       <span class="child-name" th:text="|${child.childFirstName} ${child.childLastName}|"/>
                       <span class="text--small spacing-below-0 spacing-right-25">
-                        <a th:href="'/flow/' + ${flow} + '/children/' + ${child.uuid} + '/child-delete-confirmation'"
+                        <a th:href="'/flow/' + ${flow} + '/children/' + ${child.uuid} + '/deleteConfirmation'"
                            th:text="#{general.delete}"
                            class="subflow-delete"
                            th:id="'delete-iteration-' + ${child.uuid}"></a>

--- a/src/main/resources/templates/gcc/children-delete.html
+++ b/src/main/resources/templates/gcc/children-delete.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{child-delete-confirmation.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <th:block th:if="${noEntryToDelete != null}">
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block
+              th:replace="~{fragments/cardHeader :: cardHeader(header=#{delete-confirmation-back-redirect.header})}"/>
+          <div class="form-card__footer" th:with="subflowIsEmpty=${subflowIsEmpty != null}">
+            <a class="button button--primary"
+               th:href="${subflowIsEmpty ? entryScreen : reviewScreen}"
+               th:text="#{delete-confirmation-back-redirect.button}"></a>
+          </div>
+        </main>
+      </th:block>
+      <th:block th:if="${noEntryToDelete == null}">
+        <main
+            th:with="name=${session.entryToDelete.get('childFirstName') + ' ' + session.entryToDelete.get('childLastName')}"
+            id="content" role="main" class="form-card spacing-above-35">
+          <div class="form-card__content">
+            <th:block th:replace="~{fragments/icons :: 'deleteDocument'}"></th:block>
+            <h1 class="h2"
+                th:text="#{child-delete-confirmation.header(${name})}"></h1>
+            <h2 th:text="#{child-delete-confirmation.is-that-okay}"></h2>
+          </div>
+          <div class="form-card__footer">
+            <form method="post"
+                  th:action="'/flow/' + ${flow} + '/' + ${subflow} + '/' + ${param.uuid} + '/delete'">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{child-delete-confirmation.yes})}"/>
+            </form>
+            <a class="button spacing-above-35" th:href="'/flow/' + ${flow} + '/children-add'"
+               th:text="#{child-delete-confirmation.no}"></a>
+          </div>
+        </main>
+      </th:block>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>
+


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
[#186822601](https://www.pivotaltracker.com/story/show/186822601)

#### ✍️ Description
I wanted to get the subflow delete functionality working. We can update the design once we have it.

- Not following a design, as they're not ready yet
- Taking from [form flow starter app delete confirmation](https://github.com/codeforamerica/form-flow-starter-app/blob/main/src/main/resources/templates/ubi/incomeDeleteConfirmation.html)
- Delete functionality is working

#### 📷 What is looks like (same design as FFSA)
![2024-02-27 at 16 41 42@2x](https://github.com/codeforamerica/il-gcc-form-flow/assets/9101728/8f08abe4-ce62-43e5-a4d1-7302f1f45daf)
