### PR TITLE
Formatting grouped weekdays

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
@@ -7,10 +7,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -21,17 +18,20 @@ public class SetWeeklyScheduleGroup implements Action {
 
   public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
 
+  public static final String DISPLAY_LABEL = "displayWeeklySchedule";
+
   public SetWeeklyScheduleGroup(MessageSource messageSource) {
     this.messageSource = messageSource;
   }
 
   @Override
   public void run(Submission submission) {
-    if (!submission.getInputData().containsKey("weeklySchedule[]")) {
+    Map<String, Object> inputData = submission.getInputData();
+    if (!inputData.containsKey("weeklySchedule[]")) {
       return;
     }
 
-    var weeklySchedule = new ArrayList<>((List<String>) submission.getInputData().get("weeklySchedule[]"));
+    var weeklySchedule = new ArrayList<>((List<String>) inputData.get("weeklySchedule[]"));
     var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
     String firstDay = null, lastDay = null;
     Locale locale = LocaleContextHolder.getLocale();
@@ -39,26 +39,20 @@ public class SetWeeklyScheduleGroup implements Action {
     Iterator<String> iter = WEEKDAYS.iterator();
     while (iter.hasNext() && !weeklySchedule.isEmpty()) {
       String day = iter.next();
-      if (weeklySchedule.contains(day)) {
+      if (weeklySchedule.remove(day)) {
         if (firstDay == null) {
           firstDay = messageSource.getMessage("general.week." + day, null, locale);
         } else {
           lastDay = messageSource.getMessage("general.week." + day, null, locale);
         }
-        weeklySchedule.remove(day);
       } else if (firstDay != null) {
         var displayDays = formatWeekdaysSeparated(sortedDays, locale);
-        submission.getInputData().put("displayWeeklySchedule", displayDays);
+        inputData.put(DISPLAY_LABEL, displayDays);
         return;
       }
     }
 
-    if (lastDay != null) {
-      submission.getInputData().put("displayWeeklySchedule", "%s-%s".formatted(firstDay, lastDay));
-      return;
-    }
-
-    submission.getInputData().put("displayWeeklySchedule", firstDay);
+    inputData.put(DISPLAY_LABEL, lastDay == null ? firstDay : "%s-%s".formatted(firstDay, lastDay));
   }
 
   private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {

--- a/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
@@ -1,0 +1,69 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class SetWeeklyScheduleGroup implements Action {
+
+  private final MessageSource messageSource;
+
+  public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+
+  public SetWeeklyScheduleGroup(MessageSource messageSource) {
+    this.messageSource = messageSource;
+  }
+
+  @Override
+  public void run(Submission submission) {
+    if (!submission.getInputData().containsKey("weeklySchedule[]")) {
+      return;
+    }
+
+    var weeklySchedule = new ArrayList<>((List<String>) submission.getInputData().get("weeklySchedule[]"));
+    var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
+    String firstDay = null, lastDay = null;
+    Locale locale = LocaleContextHolder.getLocale();
+
+    Iterator<String> iter = WEEKDAYS.iterator();
+    while (iter.hasNext() && !weeklySchedule.isEmpty()) {
+      String day = iter.next();
+      if (weeklySchedule.contains(day)) {
+        if (firstDay == null) {
+          firstDay = messageSource.getMessage("general.week." + day, null, locale);
+        } else {
+          lastDay = messageSource.getMessage("general.week." + day, null, locale);
+        }
+        weeklySchedule.remove(day);
+      } else if (firstDay != null) {
+        var displayDays = formatWeekdaysSeparated(sortedDays, locale);
+        submission.getInputData().put("displayWeeklySchedule", displayDays);
+        return;
+      }
+    }
+
+    if (lastDay != null) {
+      submission.getInputData().put("displayWeeklySchedule", "%s-%s".formatted(firstDay, lastDay));
+      return;
+    }
+
+    submission.getInputData().put("displayWeeklySchedule", firstDay);
+  }
+
+  private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
+    return sortedDays.stream()
+        .map(d -> messageSource.getMessage("general.week." + d, null, locale))
+        .collect(Collectors.joining(", "));
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -230,6 +230,7 @@ flow:
     nextScreens:
       - name: activities-class-hourly-schedule
   activities-class-hourly-schedule:
+    beforeDisplayAction: SetWeeklyScheduleGroup
     nextScreens:
       - name: activities-ed-program-dates
   activities-ed-program-dates:

--- a/src/main/resources/templates/gcc/activities-class-hourly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-class-hourly-schedule.html
@@ -23,7 +23,7 @@
             <div class="form-card__content" th:with="isSameEveryDay=${!#lists.isEmpty(fieldData.get('activitiesClassHoursSameEveryDay[]'))}">
               <th:block th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='activitiesClassHoursSameEveryDay', value='Yes', label=#{activities-class-hourly-schedule.class.hours.same.every.day}, toggleVisibility='#activitiesWeekly')}" />
               <div id="grouped-days" th:class="${isSameEveryDay ? '' : 'hidden'}">
-                <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName='activitiesClassStartTimeAllDays', endInputName='activitiesClassEndTimeAllDays', label=#{general.week.All})}" />
+                <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName='activitiesClassStartTimeAllDays', endInputName='activitiesClassEndTimeAllDays', label=${fieldData.get('displayWeeklySchedule')})}" />
               </div>
               <div id="individual-days" th:class="${isSameEveryDay ? 'hidden' : ''}">
                 <th:block th:each="day: ${fieldData['weeklySchedule[]']}">

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -140,7 +140,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 
     //activities-class-weekly-schedule
     assertThat(testPage.getTitle()).isEqualTo("Weekly Class Schedule");
-    assertThat(testPage.getElementText("weeklySchedule-Monday-label")).isEqualTo("Monday");
+    testPage.clickElementById("weeklySchedule-Monday");
     testPage.clickContinue();
 
     //activities-class-hourly-schedule

--- a/src/test/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroupTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroupTest.java
@@ -1,0 +1,92 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.data.Submission;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.context.MessageSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+class SetWeeklyScheduleGroupTest {
+
+  private SetWeeklyScheduleGroup action;
+
+  @BeforeEach
+  void setup() {
+    MessageSource messageSource = Mockito.mock(MessageSource.class);
+    action = new SetWeeklyScheduleGroup(messageSource);
+
+    Stream.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+        .forEach(d -> when(messageSource.getMessage(eq("general.week." + d), any(), any())).thenReturn(d));
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.ilgcc.app.submission.actions.SetWeeklyScheduleGroupTest#consecutiveDaysArgs")
+  void shouldShortenConsecutiveDays(List<String> weeklySchedule, String expected) {
+    Submission submission = new SubmissionTestBuilder()
+        .with("weeklySchedule[]", weeklySchedule)
+        .build();
+    action.run(submission);
+
+    assertThat(submission.getInputData().get("displayWeeklySchedule")).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.ilgcc.app.submission.actions.SetWeeklyScheduleGroupTest#dispersedDaysArgs")
+  void shouldListDispersedDays(List<String> weeklySchedule, String expected) {
+    Submission submission = new SubmissionTestBuilder()
+        .with("weeklySchedule[]", weeklySchedule)
+        .build();
+    action.run(submission);
+
+    assertThat(submission.getInputData().get("displayWeeklySchedule")).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.ilgcc.app.submission.actions.SetWeeklyScheduleGroupTest#unsortedDays")
+  void shouldSortWeekdays(List<String> weeklySchedule, String expected) {
+    Submission submission = new SubmissionTestBuilder()
+        .with("weeklySchedule[]", weeklySchedule)
+        .build();
+    action.run(submission);
+
+    assertThat(submission.getInputData().get("displayWeeklySchedule")).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> consecutiveDaysArgs() {
+    return Stream.of(
+        Arguments.of(List.of("Monday", "Tuesday", "Wednesday"), "Monday-Wednesday"),
+        Arguments.of(List.of("Wednesday", "Thursday", "Friday", "Saturday"), "Wednesday-Saturday"),
+        Arguments.of(List.of("Friday", "Saturday", "Sunday"), "Friday-Sunday"),
+        Arguments.of(List.of("Tuesday", "Wednesday"), "Tuesday-Wednesday")
+    );
+  }
+
+  private static Stream<Arguments> dispersedDaysArgs() {
+    return Stream.of(
+        Arguments.of(List.of("Monday", "Wednesday"), "Monday, Wednesday"),
+        Arguments.of(List.of("Wednesday", "Thursday", "Saturday"), "Wednesday, Thursday, Saturday"),
+        Arguments.of(List.of("Sunday"), "Sunday"),
+        Arguments.of(List.of("Tuesday", "Sunday"), "Tuesday, Sunday")
+    );
+  }
+
+  private static Stream<Arguments> unsortedDays() {
+    return Stream.of(
+        Arguments.of(List.of("Friday", "Wednesday"), "Wednesday, Friday"),
+        Arguments.of(List.of("Wednesday", "Thursday", "Tuesday"), "Tuesday-Thursday"),
+        Arguments.of(List.of("Sunday", "Saturday", "Friday"), "Friday-Sunday"),
+        Arguments.of(List.of("Tuesday", "Monday"), "Monday-Tuesday")
+    );
+  }
+}

--- a/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
@@ -1,0 +1,18 @@
+package org.ilgcc.app.utils;
+
+import formflow.library.data.Submission;
+
+public class SubmissionTestBuilder {
+
+  private final Submission submission = new Submission();
+
+  public Submission build() {
+    return submission;
+  }
+
+
+  public SubmissionTestBuilder with(String key, Object value) {
+    submission.getInputData().put(key, value);
+    return this;
+  }
+}


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
Follow-up of PT#186900938

#### ✍️ Description
Adding an action to format the weekly schedule selection from the previous page - this will be shown when the client selects the "hours are the same" checkbox

From Carl
> If they are not continuous in any way, we should just list each day separately.

#### 📷 Design reference
<img width="319" alt="Screenshot 2024-02-29 at 8 21 23 AM" src="https://github.com/codeforamerica/il-gcc-form-flow/assets/72890349/4530c4f6-b398-4525-9d5c-29a5ecbedb6b">


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria
