### PR TITLE
Refactor Icon fragments

### DIFF
--- a/src/main/java/org/ilgcc/app/GccDevController.java
+++ b/src/main/java/org/ilgcc/app/GccDevController.java
@@ -1,0 +1,31 @@
+package org.ilgcc.app;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Controller responsible for handling development environment specific requests. It is active only when the application is
+ * running in the `dev` profile.
+ */
+@Controller
+@EnableAutoConfiguration
+@Slf4j
+@Profile("dev")
+@RequestMapping("gcc-dev")
+public class GccDevController {
+
+  /**
+   * Handles the GET request to `dev/icons`. This method renders a page that displays the current icons available in the
+   * development environment.
+   *
+   * @return The name of the HTML page that shows the icons.
+   */
+  @GetMapping("/icons")
+  String getIcons() {
+    return "fragments/gcc-icons";
+  }
+}

--- a/src/main/java/org/ilgcc/app/GccDevController.java
+++ b/src/main/java/org/ilgcc/app/GccDevController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class GccDevController {
 
   /**
-   * Handles the GET request to `dev/icons`. This method renders a page that displays the current icons available in the
+   * Handles the GET request to `gcc-dev/icons`. This method renders a page that displays the current icons available in the
    * development environment.
    *
    * @return The name of the HTML page that shows the icons.

--- a/src/main/resources/templates/fragments/gcc-icons.html
+++ b/src/main/resources/templates/fragments/gcc-icons.html
@@ -1,5 +1,5 @@
 <article th:fragment="icons-list">
-  <h1>Icons</h1>
+  <h1>GCC Icons</h1>
   <table>
     <thead>
     <tr>
@@ -279,4 +279,6 @@
     </tr>
     </tbody>
   </table>
+  <hr/>
+  <th:block th:replace="~{fragments/icons :: icons-list}"/>
 </article>


### PR DESCRIPTION
#### ✍️ Description
Adding dev-only endpoint for viewing all available icons --> "/gcc-dev/icons"

