### PR TITLE
Add label to children-start-date

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -31,6 +31,7 @@ general.eligibility-table.row-5.family=6 people
 general.eligibility-table.row-5.income=$6,973
 general.button.continue=Continue
 general.to=to
+general.date.label=Enter the date (month / day / year).
 
 general.week.Monday=Monday
 general.week.Tuesday=Tuesday

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -349,3 +349,7 @@ p.normal {
 .time-input.form-width--short {
   flex: 1;
 }
+
+#ccapStartDate .text--help {
+  display: none;
+}

--- a/src/main/resources/templates/gcc/children-ccap-start-date.html
+++ b/src/main/resources/templates/gcc/children-ccap-start-date.html
@@ -15,7 +15,7 @@
       <input type="hidden" th:name="current_uuid" th:value="${fieldData.get('uuid')}">
       <th:block th:replace="~{fragments/inputs/date ::
     date(inputName='ccapStart',
-    label='',
+    label=#{general.date.label},
     ariaLabel='header',
     groupName='ccapStartDate')}"/>
     </th:block>


### PR DESCRIPTION
- visually hide helper text

#### 🔗 Pivotal Tracker ticket
[#186822601](https://www.pivotaltracker.com/story/show/186822601)

#### ✍️ Description
Fix design feedback on `children-ccap-start-date`

Feedback:
![Screenshot 2024-02-28 at 4 41 25 PM](https://github.com/codeforamerica/il-gcc-form-flow/assets/9101728/959e7944-d08d-4488-b324-295abdf70c8a)

Result of this PR:
![2024-03-05 at 16 56 51@2x](https://github.com/codeforamerica/il-gcc-form-flow/assets/9101728/a8829805-af68-4544-ac97-bba102c14e4e)


#### 📷 Design reference
[Figma screen](https://www.figma.com/file/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?type=design&node-id=1190%3A34116&mode=design&t=jFe0OFD0ddpMRllL-1)
