### PR TITLE
Adding "parent-no-permanent-address" page

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/conditions/ParentIsExperiencingHomelessness.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ParentIsExperiencingHomelessness.java
@@ -4,12 +4,13 @@ import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class ParentIsExperiencingHomelessness implements Condition {
 
   @Override
   public Boolean run(Submission submission) {
-    return submission.getInputData().getOrDefault("parentHomeExperiencingHomelessness", "false").equals("true");
+    return submission.getInputData().getOrDefault("parentHomeExperiencingHomelessness[]", "no").equals(List.of("yes"));
   }
-
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/ParentIsExperiencingHomelessness.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ParentIsExperiencingHomelessness.java
@@ -1,0 +1,15 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ParentIsExperiencingHomelessness implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    return submission.getInputData().getOrDefault("parentHomeExperiencingHomelessness", "false").equals("true");
+  }
+
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -43,7 +43,11 @@ flow:
 #      - name: parent-home-address
   parent-home-address:
     nextScreens:
+      - name: parent-no-permanent-address
+        condition: ParentIsExperiencingHomelessness
       - name: parent-mailing-address
+  parent-no-permanent-address:
+    nextScreens: null
   parent-mailing-address:
     condition: SkipTemplate
     nextScreens:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -192,7 +192,12 @@ parent-info-service.reserves-or-guard-question=Are you in the Military Reserves 
 parent-home-address.title=What is your home address?
 parent-home-address.homelessness=I am currently experiencing homelessness
 #parent-mailing-address
-#
+#parent-no-permanent-address
+parent-no-permanent-address.title=Parent
+parent-no-permanent-address.header=Okay, we just need a place to send you mail about your case.
+parent-no-permanent-address.subtext=This could be a friend or family member's address or a PO Box.
+parent-no-permanent-address.has-place-to-get-mail=I have a place to get mail
+parent-no-permanent-address.contact-by-email=Contact me by email instead.
 #parent-confirm-address
 parent-confirm-address.title=Parent
 parent-confirm-address.header=Confirm your address

--- a/src/main/resources/templates/gcc/parent-no-permanent-address.html
+++ b/src/main/resources/templates/gcc/parent-no-permanent-address.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{parent-no-permanent-address.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block
+            th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-no-permanent-address.header}, subtext=#{parent-no-permanent-address.subtext})}"/>
+        <div class="form-card__footer">
+          <div>
+            <a th:href="'/flow/' + ${flow} + '/parent-mailing-address'"
+               th:text="#{parent-no-permanent-address.has-place-to-get-mail}"
+               class="button button--primary spacing-below-35" id="place-to-get-mail-link"></a>
+          </div>
+          <div>
+            <a th:href="'/flow/' + ${flow} + '/parent-contact'"
+               th:text="#{parent-no-permanent-address.contact-by-email}"
+               id="contact-by-email"></a>
+          </div>
+        </div>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/test/java/org/ilgcc/app/journeys/CcapStartDateTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/CcapStartDateTest.java
@@ -33,7 +33,7 @@ public class CcapStartDateTest extends AbstractMockMvcTest {
               "childDateOfBirthMonth", List.of("10"),
               "childDateOfBirthDay", List.of("10"),
               "childDateOfBirthYear", List.of("2015")))
-          .getResponse().getRedirectedUrl().split("=")[1];
+          .split("=")[1];
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/src/test/java/org/ilgcc/app/journeys/ParentAddressTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ParentAddressTest.java
@@ -1,0 +1,43 @@
+package org.ilgcc.app.journeys;
+
+import org.ilgcc.app.utils.AbstractMockMvcTest;
+import org.ilgcc.app.utils.FormScreen;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParentAddressTest extends AbstractMockMvcTest {
+
+  @Test
+  void testNoPermanentAddress() throws Exception {
+    var screen = postToParentHomeAddressPage(true);
+
+    assertThat(screen.getHeader()).isEqualTo("Okay, we just need a place to send you mail about your case.");
+  }
+
+  private FormScreen postToParentHomeAddressPage(String streetAddress, String city, String state, String zipcode) throws Exception {
+    Map<String, List<String>> params = Map.of(
+        "parentHomeStreetAddress1", List.of(streetAddress),
+//        "parentHomeStreetAddress2", List.of(apt),
+        "parentHomeCity", List.of(city),
+        "parentHomeState", List.of(state),
+        "parentHomeZipCode", List.of(zipcode)
+
+    );
+    return new FormScreen(postToUrl(formatUrl("parent-home-address"), params));
+  }
+
+  private FormScreen postToParentHomeAddressPage(boolean noPermanentAddress) throws Exception {
+    String postUrl = formatUrl("parent-home-address");
+    Map<String, List<String>> params = Map.of("parentHomeExperiencingHomelessness[]", noPermanentAddress ? List.of("yes") : emptyList());
+    return new FormScreen(postAndGetRedirect(postUrl, params));
+  }
+
+  private String formatUrl(String pageName) {
+    return "/flow/gcc/%s".formatted(pageName);
+  }
+}

--- a/src/test/java/org/ilgcc/app/utils/FormScreen.java
+++ b/src/test/java/org/ilgcc/app/utils/FormScreen.java
@@ -63,6 +63,10 @@ public class FormScreen {
     return html.title();
   }
 
+  public String getHeader() {
+    return html.getElementById("header").text();
+  }
+
   public String getInputValue(String inputName) {
     return html.select("input[name='%s']".formatted(inputName)).attr("value");
   }


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
PT#187108114

#### ✍️ Description
Adding navigational "parent-no-permanent-address" page 

Not in this PR:
- Skipping tests for now since they depend on the completion of address screens

#### 📷 Design reference
<img width="255" alt="Screenshot 2024-03-05 at 5 00 12 PM" src="https://github.com/codeforamerica/il-gcc-form-flow/assets/72890349/4599f388-80f0-486b-a9c8-0ac9f9c3149f">


