### PR TITLE
WIP - Create `parent-mailing-address` screen

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -50,7 +50,16 @@ public class Gcc extends FlowInputs {
     private String parentContactPhoneNumber;
     @Email(message = "{errors.invalid-email}", regexp = RegexUtils.EMAIL_REGEX)
     private String parentContactEmail;
-
+    private Boolean parentMailingAddressSameAsHomeAddress;
+    @NotBlank(message = "{errors.provide-street}")
+    private String parentMailingStreetAddress1;
+    private String parentMailingStreetAddress2;
+    @NotBlank(message = "{errors.provide-city}")
+    private String parentMailingCity;
+    @NotBlank(message = "{errors.provide-state}")
+    private String parentMailingState;
+    @NotBlank(message = "{errors.provide-zip}")
+    private String parentMailingZipCode;
     private List<String> parentContactPreferCommunicate;
 
     private String phoneNumber;

--- a/src/main/java/org/ilgcc/app/submission/actions/FormatParentConfirmationAddress.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FormatParentConfirmationAddress.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.submission.actions;
 
 import formflow.library.config.submission.Action;
 import formflow.library.data.Submission;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -15,21 +16,25 @@ public class FormatParentConfirmationAddress implements Action {
   public void run(Submission submission) {
     Map<String, Object> inputData = submission.getInputData();
     // TODO check if mailing addr is different than home addr
-    var parentHomeStreetAddress1 = (String) inputData.get("parentHomeStreetAddress1");
-    var parentHomeStreetAddress2 = (String) inputData.get("parentHomeStreetAddress2");
-    var parentHomeCity = (String) inputData.get("parentHomeCity");
-    var parentHomeState = (String) inputData.get("parentHomeState");
-    var parentHomeZipCode = (String) inputData.get("parentHomeZipCode");
+    var parentMailingStreetAddress1 = (String) inputData.get("parentMailingStreetAddress1");
+    var parentMailingStreetAddress2 = (String) inputData.get("parentMailingStreetAddress2");
+    var parentMailingCity = (String) inputData.get("parentMailingCity");
+    var parentMailingState = (String) inputData.get("parentMailingState");
+    var parentMailingZipCode = (String) inputData.get("parentMailingZipCode");
 
     List<String> addressLines = new ArrayList<>();
-    addressLines.add(parentHomeStreetAddress1);
-    addressLines.add(parentHomeStreetAddress2);
-    addressLines.add("%s, %s".formatted(parentHomeCity, parentHomeState));
-    addressLines.add(parentHomeZipCode);
+    addressLines.add(parentMailingStreetAddress1);
+    addressLines.add(parentMailingStreetAddress2);
+    addressLines.add("%s, %s".formatted(parentMailingCity, parentMailingState));
+    addressLines.add(parentMailingZipCode);
 
     inputData.put("addressLines", addressLines);
 
     // TODO redirect based on - selected homeless (mailing), mailing address different than home (mailing), mailing is the same as home (home)
-    inputData.put("redirectPage", "parent-home-address");
+    if(SubmissionUtilities.parentIsExperiencingHomelessness(inputData)){
+      inputData.put("redirectPage", "parent-mailing-address");
+    }else{
+      inputData.put("redirectPage", "parent-home-address");
+    }
   }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/ParentIsExperiencingHomelessness.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ParentIsExperiencingHomelessness.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.submission.conditions;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,6 +12,6 @@ public class ParentIsExperiencingHomelessness implements Condition {
 
   @Override
   public Boolean run(Submission submission) {
-    return submission.getInputData().getOrDefault("parentHomeExperiencingHomelessness[]", "no").equals(List.of("yes"));
+    return SubmissionUtilities.parentIsExperiencingHomelessness(submission.getInputData());
   }
 }

--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -31,6 +31,15 @@ public class SubmissionUtilities {
     return submission.getInputData().get(PROGRAM_SCHEDULE).toString();
   }
 
+  /**
+   *
+   * @param inputData a JSON object of user inputs
+   * @return true or false
+   */
+  public static boolean parentIsExperiencingHomelessness(Map<String, Object> inputData) {
+    return inputData.getOrDefault("parentHomeExperiencingHomelessness[]", "no").equals(List.of("yes"));
+  }
+
   public static List<Map<String, Object>> getCompleteIterations(Submission submission, String subflow) {
     var iterations = (List<Map<String, Object>>) submission.getInputData().getOrDefault(subflow, emptyList());
     return iterations.stream()

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -49,7 +49,6 @@ flow:
   parent-no-permanent-address:
     nextScreens: null
   parent-mailing-address:
-    condition: SkipTemplate
     nextScreens:
       - name: parent-confirm-address
   parent-confirm-address:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -192,6 +192,8 @@ parent-info-service.reserves-or-guard-question=Are you in the Military Reserves 
 parent-home-address.title=What is your home address?
 parent-home-address.homelessness=I am currently experiencing homelessness
 #parent-mailing-address
+parent-mailing-address.title=Parent Mailing Address
+parent-mailing-address.header=Where can we send your mail?
 #parent-no-permanent-address
 parent-no-permanent-address.title=Parent
 parent-no-permanent-address.header=Okay, we just need a place to send you mail about your case.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -194,6 +194,8 @@ parent-home-address.homelessness=I am currently experiencing homelessness
 #parent-mailing-address
 parent-mailing-address.title=Parent Mailing Address
 parent-mailing-address.header=Where can we send your mail?
+parent-mailing-address.same-as-home-address=Same as my home address
+#
 #parent-no-permanent-address
 parent-no-permanent-address.title=Parent
 parent-no-permanent-address.header=Okay, we just need a place to send you mail about your case.

--- a/src/main/resources/templates/fragments/gcc-icons.html
+++ b/src/main/resources/templates/fragments/gcc-icons.html
@@ -306,6 +306,26 @@
         </svg>
       </td>
     </tr>
+    <tr>
+      <td>mail</td>
+      <td>
+        <svg th:fragment="mail" width="100" height="75" viewBox="0 0 100 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <g clip-path="url(#clip0_1199_41355)">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M19.7894 33.777C20.7392 23.5204 20.2149 12.2543 28.0882 5.59909C36.1615 -1.2251 47.6387 -0.763551 57.9697 1.50406C68.4313 3.80034 78.2399 8.66379 83.7732 17.8218C90.0313 28.1793 93.7695 41.113 88.4755 51.9935C83.1963 62.8436 70.4027 66.2598 58.7169 69.3187C46.3241 72.5628 31.6402 77.9786 22.1853 69.3461C12.945 60.9095 18.6366 46.2261 19.7894 33.777Z" fill="#769BF3"/>
+            <rect x="24.5" y="16.5" width="59" height="40.2117" rx="4.5" fill="white" stroke="#121111" stroke-width="3"/>
+            <path d="M54.6819 43.22L27.5588 17.6458H81.353L54.6819 43.22Z" fill="#CADAFF"/>
+            <path d="M26.647 17.6458L54.2298 43.22L81.3529 17.6458" stroke="#121111" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="1" y1="-1" x2="27.5687" y2="-1" transform="matrix(-0.734041 0.679105 -0.703166 -0.711026 47.6174 35.283)" stroke="#121111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="1" y1="-1" x2="26.9773" y2="-1" transform="matrix(0.749557 0.66194 -0.68645 0.727177 60.3826 37.9287)" stroke="#121111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </g>
+          <defs>
+            <clipPath id="clip0_1199_41355">
+              <rect width="100" height="75" fill="white"/>
+            </clipPath>
+          </defs>
+        </svg>
+      </td>
+    </tr>
     </tbody>
   </table>
   <hr/>

--- a/src/main/resources/templates/gcc/parent-mailing-address.html
+++ b/src/main/resources/templates/gcc/parent-mailing-address.html
@@ -64,18 +64,12 @@
     const $parentHomeState = inputData['parentHomeState']
     const $parentHomeZipCode = inputData['parentHomeZipCode']
 
-    //  homelessness [true] -> blank fields... add to fields
-
-
-    //  home address -> fields -> fields should be copied
     function toggleMailingAddress() {
       const $mailingAddressFields = $('#address-fields');
       console.log(inputData['parentFirstName']);
       $mailingAddressFields.toggleClass('hidden');
       if ($mailingAddressFields.is(':hidden')){
         copyMailingAddressFromHomeAddress(inputData);
-      }else {
-        setMailingAddressFieldsToBlankOrIgnoreCurrentValues(inputData);
       }
     }
     //On page load
@@ -94,7 +88,6 @@
       const $parentHomeCity = inputData['parentHomeCity']
       const $parentHomeState = inputData['parentHomeState']
       const $parentHomeZipCode = inputData['parentHomeZipCode']
-      console.log($parentHomeCity);
 
       //verify Street Address1 is present in the home address, then copy the values to
       if ($.trim($parentHomeStreetAddress1) !== ''){
@@ -104,10 +97,6 @@
         $parentMailingState.val($parentHomeState);
         $parentMailingZipCode.val($parentHomeZipCode);
       }
-    }
-    //get current values and
-    function setMailingAddressFieldsToBlankOrIgnoreCurrentValues(inputData){
-
     }
   });
 </script>

--- a/src/main/resources/templates/gcc/parent-mailing-address.html
+++ b/src/main/resources/templates/gcc/parent-mailing-address.html
@@ -58,11 +58,6 @@
 
     //Get Home Address
     let inputData = [[${inputData}]];
-    const $parentHomeStreetAddress1 = inputData['parentHomeStreetAddress1']
-    const $parentHomeStreetAddress2 = inputData['parentHomeStreetAddress2']
-    const $parentHomeCity = inputData['parentHomeCity']
-    const $parentHomeState = inputData['parentHomeState']
-    const $parentHomeZipCode = inputData['parentHomeZipCode']
 
     function toggleMailingAddress() {
       const $mailingAddressFields = $('#address-fields');

--- a/src/main/resources/templates/gcc/parent-mailing-address.html
+++ b/src/main/resources/templates/gcc/parent-mailing-address.html
@@ -14,11 +14,14 @@
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/checkbox ::
+              <div th:unless="${T(org.ilgcc.app.utils.SubmissionUtilities).parentIsExperiencingHomelessness(fieldData)}">
+                <th:block th:replace="~{fragments/inputs/checkbox ::
                  checkbox(inputName='parentMailingAddressSameAsHomeAddress',
-                   label=#{parent-home-address.homelessness},
+                   label=#{parent-mailing-address.same-as-home-address},
                    value='yes'
                  )}"/>
+              </div>
+
               <div id="address-fields" th:insert="~{fragments/inputs/address ::
                                 address(
                                   streetAddressLabel=#{general.street-address},
@@ -26,7 +29,7 @@
                                   cityLabel=#{general.city},
                                   stateLabel=#{general.state},
                                   zipCodeLabel=#{general.zip-code},
-                                  validate='false',
+                                  validate='true',
                                   inputName='parentMailing'
                                 )}">
 
@@ -53,13 +56,26 @@
     const $parentMailingState = $('#parentMailingState')
     const $parentMailingZipCode = $('#parentMailingZipCode')
 
+    //Get Home Address
+    let inputData = [[${inputData}]];
+    const $parentHomeStreetAddress1 = inputData['parentHomeStreetAddress1']
+    const $parentHomeStreetAddress2 = inputData['parentHomeStreetAddress2']
+    const $parentHomeCity = inputData['parentHomeCity']
+    const $parentHomeState = inputData['parentHomeState']
+    const $parentHomeZipCode = inputData['parentHomeZipCode']
+
+    //  homelessness [true] -> blank fields... add to fields
+
+
+    //  home address -> fields -> fields should be copied
     function toggleMailingAddress() {
       const $mailingAddressFields = $('#address-fields');
+      console.log(inputData['parentFirstName']);
       $mailingAddressFields.toggleClass('hidden');
       if ($mailingAddressFields.is(':hidden')){
-        copyMailingAddressFromHomeAddress();
+        copyMailingAddressFromHomeAddress(inputData);
       }else {
-        setMailingAddressFieldsToBlankOrIgnoreCurrentValues();
+        setMailingAddressFieldsToBlankOrIgnoreCurrentValues(inputData);
       }
     }
     //On page load
@@ -70,14 +86,28 @@
     //On checkbox state change
     $parentMailingAddressSameAsHomeCheckbox.change(function (){
       toggleMailingAddress();
-
     });
-    function copyMailingAddressFromHomeAddress () {
-      $parentMailingStreetAddress1.val('');
+    function copyMailingAddressFromHomeAddress (inputData) {
+      //Get Home Address
+      const $parentHomeStreetAddress1 = inputData['parentHomeStreetAddress1']
+      const $parentHomeStreetAddress2 = inputData['parentHomeStreetAddress2']
+      const $parentHomeCity = inputData['parentHomeCity']
+      const $parentHomeState = inputData['parentHomeState']
+      const $parentHomeZipCode = inputData['parentHomeZipCode']
+      console.log($parentHomeCity);
+
+      //verify Street Address1 is present in the home address, then copy the values to
+      if ($.trim($parentHomeStreetAddress1) !== ''){
+        $parentMailingStreetAddress1.val($parentHomeStreetAddress1);
+        $parentMailingStreetAddress2.val($parentHomeStreetAddress2);
+        $parentMailingCity.val($parentHomeCity);
+        $parentMailingState.val($parentHomeState);
+        $parentMailingZipCode.val($parentHomeZipCode);
+      }
     }
     //get current values and
-    function setMailingAddressFieldsToBlankOrIgnoreCurrentValues(){
-      $parentMailingStreetAddress1.text()
+    function setMailingAddressFieldsToBlankOrIgnoreCurrentValues(inputData){
+
     }
   });
 </script>

--- a/src/main/resources/templates/gcc/parent-mailing-address.html
+++ b/src/main/resources/templates/gcc/parent-mailing-address.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{parent-mailing-address.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,11 +8,17 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/gcc-icons :: mail}"></th:block>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-mailing-address.header})}"/>
+        
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-                <!-- Put inputs here -->
+                <th:block th:replace="~{fragments/inputs/address ::
+                                  address(
+                                    validate=,
+                                    inputName=''
+                                  )}"/>
             </div>
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>

--- a/src/main/resources/templates/gcc/parent-mailing-address.html
+++ b/src/main/resources/templates/gcc/parent-mailing-address.html
@@ -10,15 +10,27 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:replace="~{fragments/gcc-icons :: mail}"></th:block>
         <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-mailing-address.header})}"/>
-        
+
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-                <th:block th:replace="~{fragments/inputs/address ::
-                                  address(
-                                    validate=,
-                                    inputName=''
-                                  )}"/>
+              <th:block th:replace="~{fragments/inputs/checkbox ::
+                 checkbox(inputName='parentMailingAddressSameAsHomeAddress',
+                   label=#{parent-home-address.homelessness},
+                   value='yes'
+                 )}"/>
+              <div id="address-fields" th:insert="~{fragments/inputs/address ::
+                                address(
+                                  streetAddressLabel=#{general.street-address},
+                                  streetAddress2Label=#{general.street-address-2},
+                                  cityLabel=#{general.city},
+                                  stateLabel=#{general.state},
+                                  zipCodeLabel=#{general.zip-code},
+                                  validate='false',
+                                  inputName='parentMailing'
+                                )}">
+
+              </div>
             </div>
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
@@ -30,5 +42,44 @@
   </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
+<script th:inline="javascript">
+  $(document).ready(function () {
+    const $parentMailingAddressSameAsHomeCheckbox = $('#parentMailingAddressSameAsHomeAddress-yes')
+
+    //Mailing Address input fields
+    const $parentMailingStreetAddress1 = $('#parentMailingStreetAddress1')
+    const $parentMailingStreetAddress2 = $('#parentMailingStreetAddress2')
+    const $parentMailingCity = $('#parentMailingCity')
+    const $parentMailingState = $('#parentMailingState')
+    const $parentMailingZipCode = $('#parentMailingZipCode')
+
+    function toggleMailingAddress() {
+      const $mailingAddressFields = $('#address-fields');
+      $mailingAddressFields.toggleClass('hidden');
+      if ($mailingAddressFields.is(':hidden')){
+        copyMailingAddressFromHomeAddress();
+      }else {
+        setMailingAddressFieldsToBlankOrIgnoreCurrentValues();
+      }
+    }
+    //On page load
+    //We want to hide inputs if the
+    if($parentMailingAddressSameAsHomeCheckbox.is(':checked')){
+      toggleMailingAddress();
+    }
+    //On checkbox state change
+    $parentMailingAddressSameAsHomeCheckbox.change(function (){
+      toggleMailingAddress();
+
+    });
+    function copyMailingAddressFromHomeAddress () {
+      $parentMailingStreetAddress1.val('');
+    }
+    //get current values and
+    function setMailingAddressFieldsToBlankOrIgnoreCurrentValues(){
+      $parentMailingStreetAddress1.text()
+    }
+  });
+</script>
 </body>
 </html>

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -55,6 +55,9 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.selectFromDropdown("parentHomeState", "CA - California");
     testPage.enter("parentHomeZipCode", "94103");
     testPage.clickContinue();
+    // parent-mailing-address
+    assertThat(testPage.getTitle()).isEqualTo("Parent Mailing Address");
+    testPage.clickContinue();
     // parent-confirm-address
     assertThat(testPage.getHeader()).isEqualTo("Confirm your address");
     testPage.clickButton("Use this address");

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -57,6 +57,21 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
     // parent-mailing-address
     assertThat(testPage.getTitle()).isEqualTo("Parent Mailing Address");
+    testPage.goBack();
+    //parent-home-address
+    assertThat(testPage.getTitle()).isEqualTo("What is your home address?");
+    testPage.clickElementById("parentHomeExperiencingHomelessness-yes");
+    testPage.clickContinue();
+    //parent-home-address
+    assertThat(testPage.getTitle()).isEqualTo("Parent");
+    testPage.clickButton("I have a place to get mail");
+    // parent-mailing-address
+    assertThat(testPage.getTitle()).isEqualTo("Parent Mailing Address");
+    testPage.enter("parentMailingStreetAddress1", "972 Mission St");
+    testPage.enter("parentMailingStreetAddress2", "5th floor");
+    testPage.enter("parentMailingCity", "San Francisco");
+    testPage.selectFromDropdown("parentMailingState", "CA - California");
+    testPage.enter("parentMailingZipCode", "94103");
     testPage.clickContinue();
     // parent-confirm-address
     assertThat(testPage.getHeader()).isEqualTo("Confirm your address");


### PR DESCRIPTION

#### 🔗 Pivotal Tracker ticket
[#187108114](https://www.pivotaltracker.com/story/show/187108114)

#### ✍️ Description
* `parent-mailing-address` screen was added.  Mailing address fields are hidden when a users select `Same as home address`.  Values from the home address are copied to the mailing address when `Same as home address` checkbox is selected.  
* Mailing address is validated
* `parent-confirmation-screen-1` is updated to match figma

#### 📷 Design reference
[Figma](https://www.figma.com/file/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?type=design&node-id=1190-34036&mode=design&t=FAySXKvBrlW5S7tN-4)

##### With `Same as home address` Checkbox
![image](https://github.com/codeforamerica/il-gcc-form-flow/assets/46062709/0a4af922-f78d-4c97-82a2-59dc50c74a3c)

##### Without `Same as home address` Checkbox
![image](https://github.com/codeforamerica/il-gcc-form-flow/assets/46062709/c959fe09-c34c-4630-83ea-b854f410fd80)


#### ✅ Completion tasks


- [x] Added relevant tests
- [ ] Meets acceptance criteria
