### PR TITLE
Adding "parent-confirm-address" screen - no address found

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -2,10 +2,10 @@ package org.ilgcc.app.inputs;
 
 import formflow.library.data.FlowInputs;
 import formflow.library.utils.RegexUtils;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.format.annotation.NumberFormat;
 
 import java.util.List;
 
@@ -82,6 +82,8 @@ public class Gcc extends FlowInputs {
     private List<String> parentGender;
     private List<String> parentRaceEthnicity;
 
+    private String parentConfirmSuggestedAddress;
+    
     @NotBlank(message = "{errors.provide-first-name}")
     private String childFirstName;
     @NotBlank(message = "{errors.provide-last-name}")

--- a/src/main/java/org/ilgcc/app/submission/actions/FormatParentConfirmationAddress.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FormatParentConfirmationAddress.java
@@ -1,0 +1,35 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class FormatParentConfirmationAddress implements Action {
+
+  @Override
+  public void run(Submission submission) {
+    Map<String, Object> inputData = submission.getInputData();
+    // TODO check if mailing addr is different than home addr
+    var parentHomeStreetAddress1 = (String) inputData.get("parentHomeStreetAddress1");
+    var parentHomeStreetAddress2 = (String) inputData.get("parentHomeStreetAddress2");
+    var parentHomeCity = (String) inputData.get("parentHomeCity");
+    var parentHomeState = (String) inputData.get("parentHomeState");
+    var parentHomeZipCode = (String) inputData.get("parentHomeZipCode");
+
+    List<String> addressLines = new ArrayList<>();
+    addressLines.add(parentHomeStreetAddress1);
+    addressLines.add(parentHomeStreetAddress2);
+    addressLines.add("%s, %s".formatted(parentHomeCity, parentHomeState));
+    addressLines.add(parentHomeZipCode);
+
+    inputData.put("addressLines", addressLines);
+
+    // TODO redirect based on - selected homeless (mailing), mailing address different than home (mailing), mailing is the same as home (home)
+    inputData.put("redirectPage", "parent-home-address");
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -49,7 +49,7 @@ flow:
     nextScreens:
       - name: parent-confirm-address
   parent-confirm-address:
-    condition: SkipTemplate
+    beforeDisplayAction: FormatParentConfirmationAddress
     nextScreens:
       - name: parent-contact
   parent-contact:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -194,6 +194,14 @@ parent-home-address.homelessness=I am currently experiencing homelessness
 #parent-mailing-address
 #
 #parent-confirm-address
+parent-confirm-address.title=Parent
+parent-confirm-address.header=Confirm your address
+parent-confirm-address.note-addr-not-found=We couldn't find your address. To make sure you get mail from us, you may edit your address or keep going.
+parent-confirm-address.note-suggested-addr=We updated the address you entered. If correct, please use the suggested address.
+parent-confirm-address.address-you-entered=Address you entered
+parent-confirm-address.suggested-address=Suggested address
+parent-confirm-address.edit-address=Edit my address
+parent-confirm-address.use-address=Use this address
 #parent-contact
 parent-contact.title=Parent Contact
 parent-contact.header=What is your contact information?

--- a/src/main/resources/templates/gcc/parent-confirm-address.html
+++ b/src/main/resources/templates/gcc/parent-confirm-address.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{parent-confirm-address.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,14 +8,43 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-confirm-address.header})}"/>
+        <div class="notice--warning spacing-below-60" th:text="#{parent-confirm-address.note-addr-not-found}"></div>
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-                <!-- Put inputs here -->
+              <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                    radioFieldset(inputName='parentConfirmSuggestedAddress',
+                    ariaLabel='header',
+                    content=~{::addressOptions})}">
+                <th:block th:ref="addressOptions">
+                  <div class="grid__item address-validation">
+                    <label th:for="original-address"
+                           class="radio-button"
+                           id="original-address-label">
+                      <p class="spacing-below-15"
+                         th:text="#{parent-confirm-address.address-you-entered}"></p>
+                      <th:block th:each="addressLine : ${inputData.get('addressLines')}">
+                        <div th:text="${addressLine}"></div>
+                      </th:block>
+                      <input type="radio"
+                             th:name="${inputName}" id="original-address"
+                             th:value="false"
+                             th:checked="true">
+                    </label>
+                  </div>
+                </th:block>
+              </th:block>
             </div>
             <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              <div>
+                <a th:href="'/flow/gcc/' + ${inputData.get('redirectPage')}"
+                   th:text="#{parent-confirm-address.edit-address}"
+                   class="button button--primary spacing-below-25"
+                   id="edit-address-link"></a>
+              </div>
+              <th:block
+                  th:replace="~{fragments/inputs/submitButtonSecondary :: submitButton(text=#{parent-confirm-address.use-address})}"/>
             </div>
           </th:block>
         </th:block>

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -55,6 +55,9 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.selectFromDropdown("parentHomeState", "CA - California");
     testPage.enter("parentHomeZipCode", "94103");
     testPage.clickContinue();
+    // parent-confirm-address
+    assertThat(testPage.getHeader()).isEqualTo("Confirm your address");
+    testPage.clickButton("Use this address");
     // parent-contact
     assertThat(testPage.getTitle()).isEqualTo("Parent Contact");
     testPage.clickElementById("parentContactPreferCommunicate-mail-label");

--- a/src/test/java/org/ilgcc/app/utils/Page.java
+++ b/src/test/java/org/ilgcc/app/utils/Page.java
@@ -29,13 +29,16 @@ public class Page {
     return driver.getTitle();
   }
 
+  public String getHeader() {
+    checkForBadMessageKeys();
+    String header = driver.findElement(By.id("header")).getText();
+    percy.snapshot(header);
+    return header;
+  }
+
   private void checkForBadMessageKeys() {
     assertThat(driver.getTitle()).doesNotContain("??");
     assertThat(driver.findElement(By.xpath("/html")).getText()).doesNotContain("??");
-  }
-
-  public String getHeader() {
-    return driver.findElement(By.tagName("h1")).getText();
   }
 
   public void goBack() {


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
PT#187108114

#### ✍️ Description
Adding "parent-confirm-address" screen with home-address when smarty-streets does not find a suggested address

Follow-up
- Check if mailing address is different than home address and use that instead
- Design for when smarty-streets does find an address

#### 📷 Design reference
<img width="221" alt="Screenshot 2024-03-06 at 1 55 43 PM" src="https://github.com/codeforamerica/il-gcc-form-flow/assets/72890349/80a735e7-282c-4a22-bc74-3ca13a5c4324">


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [ ] Meets acceptance criteria
