### PR TITLE
Add parent-partner-info-service screen

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -65,6 +65,8 @@ public class Gcc extends FlowInputs {
     private String parentPartnerPhoneNumber;
     @Email(regexp = RegexUtils.EMAIL_REGEX, message = "{errors.invalid-email}")
     private String parentPartnerEmail;
+    private String parentPartnerIsServing;
+    private String parentPartnerInMilitaryReserveOrNationalGuard;
     private String phoneNumber;
     private String streetAddress;
     private String city;

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -79,7 +79,6 @@ flow:
     nextScreens:
       - name: parent-partner-info-service
   parent-partner-info-service:
-    condition: SkipTemplate
     nextScreens:
       - name: parent-partner-info-disability
   parent-partner-info-disability:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -227,7 +227,10 @@ parent-contact.prefer.communicate.paperless=I only want to be contacted by email
 parent-partner-contact.title=How can we contact them?
 parent-partner-contact.phone.number=What is your phone number?
 parent-partner-contact.email=What is your email address?
-#parent-partner-info-service
+parent-partner-info-service.title=Are they a service member?
+parent-partner-info-service.subtext=Service members who are found eligible for child care assistance will have a $0 co-pay.
+parent-partner-info-service.serving-question=Are they serving in the active military?
+parent-partner-info-service.reserves-or-guard-question=Are they in the military reserves or the national guard?
 #parent-partner-info-disability
 #parent-other-family
 #parent-add-adults

--- a/src/main/resources/templates/gcc/parent-partner-info-service.html
+++ b/src/main/resources/templates/gcc/parent-partner-info-service.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{parent-partner-info-service.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,11 +8,29 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/gcc-icons :: shield}"></th:block>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-partner-info-service.title}, subtext=#{parent-partner-info-service.subtext})}"/>
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-                <!-- Put inputs here -->
+              <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                  radioFieldset(inputName='parentPartnerIsServing',
+                  label=#{parent-partner-info-service.serving-question},
+                  content=~{::radioOptions1})}">
+                <th:block th:ref="radioOptions1">
+                  <th:block th:replace="~{fragments/inputs/radio :: radio(inputName='parentPartnerIsServing', value='Yes', label=#{general.inputs.yes})}"/>
+                  <th:block th:replace="~{fragments/inputs/radio :: radio(inputName='parentPartnerIsServing', value='No', label=#{general.inputs.no})}"/>
+                </th:block>
+              </th:block>
+              <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                  radioFieldset(inputName='parentPartnerInMilitaryReserveOrNationalGuard',
+                  label=#{parent-partner-info-service.reserves-or-guard-question},
+                  content=~{::radioOptions2})}">
+                <th:block th:ref="radioOptions2">
+                  <th:block th:replace="~{fragments/inputs/radio :: radio(inputName='parentPartnerInMilitaryReserveOrNationalGuard', value='Yes', label=#{general.inputs.yes})}"/>
+                  <th:block th:replace="~{fragments/inputs/radio :: radio(inputName='parentPartnerInMilitaryReserveOrNationalGuard', value='No', label=#{general.inputs.no})}"/>
+                </th:block>
+              </th:block>
             </div>
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -84,6 +84,9 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     // parent-partner-contact
     assertThat(testPage.getTitle()).isEqualTo("How can we contact them?");
     testPage.clickContinue();
+    // parent-partner-info-service
+    assertThat(testPage.getTitle()).isEqualTo("Are they a service member?");
+    testPage.clickContinue();
 
     //children-info-intro
     assertThat(testPage.getTitle()).isEqualTo("Your Children");


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
[#187108143](https://www.pivotaltracker.com/story/show/187108143)

#### ✍️ Description
Adds the `parent-partner-info-service` screen.

#### 📷 Design reference
[Figma](https://www.figma.com/file/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?type=design&node-id=1190%3A34083&mode=design&t=4kcRfQUWjGIYWbTT-1)

![parent-partner-info-service](https://github.com/codeforamerica/il-gcc-form-flow/assets/9101728/b77c50bf-4f8b-4d6e-9539-c7eee61da346)




#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [X] Added relevant tests
- [x] Meets acceptance criteria
