### PR TITLE
Adding "parent-add-adult-details" page

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -120,6 +120,16 @@ public class Gcc extends FlowInputs {
     private String hasAdultDependents;
 
     @NotBlank(message = "{errors.provide-first-name}")
+    private String adultDependentFirstName;
+
+    @NotBlank(message = "{errors.provide-last-name}")
+    private String adultDependentLastName;
+
+    private String adultDependentBirthdateDay;
+    private String adultDependentBirthdateMonth;
+    private String adultDependentBirthdateYear;
+
+    @NotBlank(message = "{errors.provide-first-name}")
     private String childFirstName;
     @NotBlank(message = "{errors.provide-last-name}")
     private String childLastName;

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateAdultDependentBirthdate.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateAdultDependentBirthdate.java
@@ -1,0 +1,14 @@
+package org.ilgcc.app.submission.actions;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ValidateAdultDependentBirthdate extends ValidateBirthdate {
+
+  public ValidateAdultDependentBirthdate(MessageSource messageSource) {
+    super(messageSource, "adultDependentBirthdate", "adultDependentBirthdate");
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -93,11 +93,12 @@ flow:
       - name: children-info-intro
   parent-add-adults:
     nextScreens:
-      - name: parent-add-adults-detail
-  parent-add-adults-detail:
-    condition: SkipTemplate
-    nextScreens:
       - name: parent-intro-family-info
+  parent-add-adults-detail:
+    subflow: adultDependents
+    crossFieldValidationAction: ValidateAdultDependentBirthdate
+    nextScreens:
+      - name: parent-add-adults
   parent-intro-family-info:
     nextScreens:
       - name: children-info-intro
@@ -308,11 +309,18 @@ flow:
     nextScreens: null
   children-delete:
     nextScreens: null
+  delete-person:
+    nextScreens: null
 subflows:
   children:
     entryScreen: children-add
     iterationStartScreen: children-info-basic
     reviewScreen: children-add
     deleteConfirmationScreen: children-delete
+  adultDependents:
+    entryScreen: parent-add-adults
+    iterationStartScreen: parent-add-adults-detail
+    reviewScreen: parent-add-adults
+    deleteConfirmationScreen: delete-person
 landmarks:
   firstScreen: onboarding-getting-started

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -46,6 +46,9 @@ general.year.validation=Make sure you entered the correct year.
 
 general.date.label=Enter the date (month / day / year).
 
+general.question.their-first-name=What is their first name?*
+general.question.their-last-name=What is their last name?*
+general.question.their-date-of-birth=What is their date of birth?*
 
 general.week.Monday=Monday
 general.week.Tuesday=Tuesday
@@ -248,11 +251,8 @@ parent-qualifying-partner.question-live-together=Do you live together?*
 #parent-partner-info-basic
 parent-partner-info-basic.title=Partner Info
 parent-partner-info-basic.header=Tell us about your partner
-parent-partner-info-basic.first.name=What is their first name?*
 parent-partner-info-basic.first.name.help=Legally as it appears on their ID
-parent-partner-info-basic.last.name=What is their last name?*
 parent-partner-info-basic.last.name.help=Legally as it appears on their ID
-parent-partner-info-basic.birth.date=What is their birth date?*
 parent-partner-info-basic.birth.date.help=Please select the month and enter the day and year.
 parent-partner-info-basic.ssn=What is their social security number?
 parent-partner-info-basic.ssn.help=This is optional. If you have one, we recommend including it so your case can be processed more quickly.
@@ -276,8 +276,11 @@ parent-other-family.subtext=This might include elderly parents or someone with a
 parent-add-adults.title=Parent
 parent-add-adults.header=Add adult family members who you financially support.
 parent-add-adults.subtext=Only include people who live with you. These people will be added to your application.
+parent-add-adults.your-adult-dependents=Your Adult Dependents
 parent-add-adults.add-member=Add family member
 parent-add-adults.im-done=I'm done
+#
+parent-add-adults-detail.title=Parent
 #parent-intro-family-info
 parent-intro-family-info.title=Parent Intro Family Info
 parent-intro-family-info.header=We've collected all the guardian information.
@@ -298,9 +301,6 @@ children-add.thats-all=That is all my children
 #
 children-info-basic.title=Children Info
 children-info-basic.header=Add your child
-children-info-basic.first-name-question=What is their first name?*
-children-info-basic.last-name-question=What is their last name?*
-children-info-basic.dob-question=What is their date of birth?*
 children-info-basic.financial-assistance-question=Do you need financial assistance for their care?*
 children-info-basic.financial-assistance-help-text=By selecting yes, you will add them to this application with {0}.
 #children-ccap-info

--- a/src/main/resources/templates/gcc/children-info-basic.html
+++ b/src/main/resources/templates/gcc/children-info-basic.html
@@ -16,14 +16,14 @@
             <div class="form-card__content">
               <th:block th:replace="~{fragments/inputs/text ::
                 text(inputName='childFirstName',
-                label=#{children-info-basic.first-name-question})}"/>
+                label=#{general.question.their-first-name})}"/>
               <th:block th:replace="~{fragments/inputs/text ::
                 text(inputName='childLastName',
-                label=#{children-info-basic.last-name-question})}"/>
+                label=#{general.question.their-last-name)}"/>
               <th:block th:replace="~{fragments/inputs/date ::
                 date(inputName='childDateOfBirth',
                 groupName='childDateOfBirth',
-                label=#{children-info-basic.dob-question})}"/>
+                label=#{general.question.their-date-of-birth})}"/>
               <th:block th:replace="~{fragments/inputs/radioFieldset ::
                   radioFieldset(inputName='needFinancialAssistanceForChild',
                   label=#{children-info-basic.financial-assistance-question},

--- a/src/main/resources/templates/gcc/children-info-basic.html
+++ b/src/main/resources/templates/gcc/children-info-basic.html
@@ -19,7 +19,7 @@
                 label=#{general.question.their-first-name})}"/>
               <th:block th:replace="~{fragments/inputs/text ::
                 text(inputName='childLastName',
-                label=#{general.question.their-last-name)}"/>
+                label=#{general.question.their-last-name})}"/>
               <th:block th:replace="~{fragments/inputs/date ::
                 date(inputName='childDateOfBirth',
                 groupName='childDateOfBirth',

--- a/src/main/resources/templates/gcc/parent-add-adults-detail.html
+++ b/src/main/resources/templates/gcc/parent-add-adults-detail.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{parent-add-adults-detail.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,11 +8,20 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-add-adults.add-member})}"/>
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-                <!-- Put inputs here -->
+              <th:block th:replace="~{fragments/inputs/text ::
+                text(inputName='adultDependentFirstName',
+                label=#{general.question.their-first-name})}"/>
+              <th:block th:replace="~{fragments/inputs/text ::
+                text(inputName='adultDependentLastName',
+                label=#{general.question.their-last-name})}"/>
+              <th:block th:replace="~{fragments/inputs/date ::
+                date(inputName='adultDependentBirthdate',
+                groupName='adultDependentBirthdate',
+                label=#{general.question.their-date-of-birth})}"/>
             </div>
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>

--- a/src/main/resources/templates/gcc/parent-partner-info-basic.html
+++ b/src/main/resources/templates/gcc/parent-partner-info-basic.html
@@ -14,8 +14,8 @@
           <th:block th:ref="formContent" th:with="genderOptions=${T(org.ilgcc.app.utils.GenderOption).values()}">
 
             <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerFirstName', helpText=#{parent-partner-info-basic.first.name.help}, label=#{parent-partner-info-basic.first.name})}"/>
-              <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerLastName', helpText=#{parent-partner-info-basic.last.name.help}, label=#{parent-partner-info-basic.last.name})}"/>
+              <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerFirstName', helpText=#{parent-partner-info-basic.first.name.help}, label=#{general.question.their-first-name})}"/>
+              <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerLastName', helpText=#{parent-partner-info-basic.last.name.help}, label=#{general.question.their-last-name})}"/>
               <th:block th:replace="~{fragments/inputs/date :: date(inputName='parentPartnerBirth', groupName='parentPartnerBirth', label=#{parent-partner-info-basic.birth.date})}"/>
               <th:block th:replace="~{fragments/inputs/ssn :: ssn(inputName='parentPartnerSSN', helpText=#{parent-partner-info-basic.ssn.help}, label=#{parent-partner-info-basic.ssn})}"/>
               <th:block th:replace="~{fragments/inputs/checkboxFieldset ::

--- a/src/main/resources/templates/gcc/parent-partner-info-basic.html
+++ b/src/main/resources/templates/gcc/parent-partner-info-basic.html
@@ -16,7 +16,7 @@
             <div class="form-card__content">
               <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerFirstName', helpText=#{parent-partner-info-basic.first.name.help}, label=#{general.question.their-first-name})}"/>
               <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerLastName', helpText=#{parent-partner-info-basic.last.name.help}, label=#{general.question.their-last-name})}"/>
-              <th:block th:replace="~{fragments/inputs/date :: date(inputName='parentPartnerBirth', groupName='parentPartnerBirth', label=#{parent-partner-info-basic.birth.date})}"/>
+              <th:block th:replace="~{fragments/inputs/date :: date(inputName='parentPartnerBirth', groupName='parentPartnerBirth', label=#{general.question.their-date-of-birth})}"/>
               <th:block th:replace="~{fragments/inputs/ssn :: ssn(inputName='parentPartnerSSN', helpText=#{parent-partner-info-basic.ssn.help}, label=#{parent-partner-info-basic.ssn})}"/>
               <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
                   checkboxFieldset(inputName='parentPartnerGender',

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -131,6 +131,15 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     // parent-add-adults
     assertThat(testPage.getHeader()).isEqualTo("Add adult family members who you financially support.");
     testPage.clickButton("Add family member");
+    // parent-add-adult-details
+    assertThat(testPage.getHeader()).isEqualTo("Add family member");
+    testPage.enter("adultDependentFirstName", "ada");
+    testPage.enter("adultDependentLastName", "dolt");
+    testPage.enter("adultDependentBirthdateMonth", "1");
+    testPage.enter("adultDependentBirthdateDay", "13");
+    testPage.enter("adultDependentBirthdateYear", "2010");
+    testPage.clickContinue();
+    testPage.clickButton("I'm done");
     // parent-intro-family-info
     assertThat(testPage.getTitle()).isEqualTo("Parent Intro Family Info");
     testPage.clickButton("Continue to next section");


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
PT#186901269

#### ✍️ Description
- Adding "parent-add-adult-details" page
- Consolidate some duplicate message properties (might be something we integrate back into FFL)

Follow-up
- Delete functionality for parent list
- Mixpanel tracking
- Date helper-text (requires some a11y discussion)

#### 📷 Design reference
[Figma link](https://www.figma.com/file/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?type=design&node-id=1190-41094&mode=design&t=iWKag0lNjgyL8vGi-0)

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria
