### PR TITLE
Update label for the `None of the above` checkbox to read as `None of…

### DIFF
--- a/src/main/resources/templates/gcc/unearned-income-source.html
+++ b/src/main/resources/templates/gcc/unearned-income-source.html
@@ -17,7 +17,7 @@
                   checkboxFieldset(inputName='unearnedIncomeSource',
                   label='',
                   ariaLabel='header',
-                  noneOfTheAboveLabel=#{general.none-added},
+                  noneOfTheAboveLabel=#{general.inputs.none-of-the-above},
                   options=${incomeOptions})}">
               </th:block>
             </div>


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
[#186714238](https://www.pivotaltracker.com/story/show/186714238)

#### ✍️ Description
Fix these problems:
1.  Last checkbox option on unearned-income-source scree reads "None added". This should be "None of the above"
2.  Some checkboxes on the unearned-income-source screen are read by the screen reader as "Invalid data, unchecked".

#### 📷 Design reference

#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
