### PR TITLE
Update label for the `None of the above` checkbox to read as `None of…

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -105,10 +105,13 @@ public class Gcc extends FlowInputs {
 
     private String activitiesClassStartTimeThursday;
     private String activitiesClassEndTimeThursday;
-
     private String activitiesClassStartTimeFriday;
-
     private String activitiesClassEndTimeFriday;
+    private String activitiesClassStartTimeSaturday;
+    private String activitiesClassEndTimeSaturday;
+    private String activitiesClassStartTimeSunday;
+    private String activitiesClassEndTimeSunday;
+
 
     @Pattern(regexp = "\\d{3}-\\d{2}-\\d{4}", message = "{errors.invalid-ssn}")
     private String parentSsn;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -373,7 +373,7 @@ activities-add-jobs.subtext.add-jobs-list=We will ask for your income and work s
 #activities-employer-name
 activities-employer-name.title=Activities Employer Name
 activities-employer-name.header=What is the employer or company name?
-activities-employer-name.subtext=If you are self-employed, then enter your own name or your profession. For example: barber, dog walker, etc.
+activities-employer-name.subtext=If yes, you can submit work-related expenses later in this application that can help with eligibility.
 #activities-employer-address
 activities-employer-address.title=Activities Employer Address
 activities-employer-address.header=Employer information

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -364,7 +364,7 @@ activities-parent-type.other-follow-up=Please tell us why you need child care.
 #activities-add-jobs
 activities-add-jobs.title=Activities Add Jobs
 activities-add-jobs.header=Let's start by adding your jobs,
-activities-add-jobs.subtext=You will add one job at a time. We'll ask for your income and schedule for each of your jobs.
+activities-add-jobs.subtext=You will add one job at a time. We'll ask for your work schedule for each of your jobs.
 activities-add-jobs.add-a-job=Add a job
 activities-add-jobs.your-jobs=Your Jobs
 activities-add-jobs.this-is-all-my-jobs=That is all my jobs

--- a/src/main/resources/templates/gcc/activities-self-employment.html
+++ b/src/main/resources/templates/gcc/activities-self-employment.html
@@ -15,7 +15,7 @@
             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+              <th:block th:replace="~{fragments/inputs/overrides/yesOrNo :: yesOrNo(
                  inputName='isSelfEmployed',
                  ariaDescribe='header')}"/>
             </div>

--- a/src/main/resources/templates/gcc/delete-job.html
+++ b/src/main/resources/templates/gcc/delete-job.html
@@ -31,7 +31,7 @@
                   th:action="'/flow/' + ${flow} + '/' + ${subflow} + '/' + ${param.uuid} + '/delete'">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton( text=#{delete-job.yes})}"/>
             </form>
-            <a class="button spacing-above-35" th:href="'/flow/' + ${flow} + '/parent-add-adults'"
+            <a class="button spacing-above-35" th:href="'/flow/' + ${flow} + '/activities-add-jobs'"
                th:text="#{delete-job.no}"></a>
           </div>
         </main>

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -274,6 +274,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     //activities-class-weekly-schedule
     assertThat(testPage.getTitle()).isEqualTo("Weekly Class Schedule");
     testPage.clickElementById("weeklySchedule-Monday");
+    testPage.clickElementById("weeklySchedule-Sunday");
     testPage.clickContinue();
 
     //activities-class-hourly-schedule


### PR DESCRIPTION
… the above`

Also fixes yes/no screen button id



#### 🔗 Pivotal Tracker ticket
[#186714238]()

#### ✍️ Description
Fixes bugs:
1. The subheading on the activities-self-employment screen should read "If yes, you can submit work-related expenses later in this application that can help with eligibility."

2. When selecting "No, keep it" on the jobs delete screen, I get bumped to the start of the adult dependent subflow. I expected to go back to the add jobs screen.

3. The button_click events firing on the activities-self-employment screen are firing without an element id property to indicate which button on the screen the user is clicking.
#### 📷 Design reference

![image](https://github.com/codeforamerica/il-gcc-form-flow/assets/46062709/6ddde31b-73e9-43e0-9dc7-35ac559f0c8e)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
