### PR TITLE
Adding parent-partner-ed screens

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -3,10 +3,7 @@ package org.ilgcc.app.inputs;
 import formflow.library.data.FlowInputs;
 import formflow.library.data.annotations.Phone;
 import formflow.library.utils.RegexUtils;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import org.hibernate.validator.constraints.Length;
 
 import java.util.List;
@@ -14,18 +11,17 @@ import java.util.List;
 public class Gcc extends FlowInputs {
 
     private String lang;
-    @NotBlank
-    private String schoolName;
-    @NotBlank(message = "{activities-ed-program-type.validationMessage}")
-    private String educationType;
-    @NotBlank
-    private String dayCareChoice;
-    @NotBlank(message = "{activities-ed-program-method.validationMessage}")
-    private String programTaught;
-    @NotBlank(message = "{activities-ed-program-method.validationMessage}")
-    private String programSchedule;
-    private String languageRead;
-    private String languageSpeak;
+  @NotBlank(message = "{errors.provide-program-name}")
+  private String schoolName;
+  @NotBlank(message = "{errors.select-one-option}")
+  private String educationType;
+  @NotBlank
+  private String dayCareChoice;
+  private String programTaught;
+  @NotBlank(message = "{errors.select-yes-or-no}")
+  private String programSchedule;
+  private String languageRead;
+  private String languageSpeak;
     @NotBlank(message = "{errors.provide-first-name}")
     private String parentFirstName;
     @NotBlank(message = "{errors.provide-last-name}")
@@ -116,7 +112,6 @@ public class Gcc extends FlowInputs {
     private String activitiesClassStartTimeSunday;
     private String activitiesClassEndTimeSunday;
 
-
     @Pattern(regexp = "\\d{3}-\\d{2}-\\d{4}", message = "{errors.invalid-ssn}")
     private String parentSsn;
     private List<String> parentGender;
@@ -152,7 +147,7 @@ public class Gcc extends FlowInputs {
     private String childHasDisability;
     private String childIsUsCitizen;
     private String childInCare;
-
+  @NotEmpty(message = "{errors.select-at-least-one-day}")
     private List<String> weeklySchedule;
     @Pattern(regexp = "^(0[1-9]|[12][0-9]|3[01])$", message = "{general.day.validation}")
     private String activitiesProgramStartDay;
@@ -200,8 +195,70 @@ public class Gcc extends FlowInputs {
 
     private List<String> unearnedIncomePrograms;
     private String unearnedIncomeAssetsMoreThanOneMillionDollars;
-    private String current_uuid;
+  private String current_uuid;
 
+  @NotBlank(message = "{errors.select-one-option}")
+  private String partnerEducationType;
+  @NotBlank(message = "{errors.provide-program-name}")
+  private String partnerProgramName;
+  @Phone(message = "{errors.invalid-phone-number}")
+  private String partnerEdPhoneNumber;
+  private String partnerEdStreetAddress;
+  private String partnerEdCity;
+  private String partnerEdState;
+  @Pattern(regexp = "^\\d{5,}$", message = "{errors.invalid-zipcode}")
+  private String partnerEdZipCode;
+  private String partnerProgramTaught;
+  @NotBlank(message = "{errors.select-yes-or-no}")
+  private String partnerProgramSchedule;
+
+  @NotEmpty(message = "{errors.select-at-least-one-day}")
+  private List<String> partnerClassWeeklySchedule;
+  private String partnerClassHoursSameEveryDay;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeAllDays;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeAllDays;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeMonday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeMonday;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeTuesday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeTuesday;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeWednesday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeWednesday;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeThursday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeThursday;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeFriday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeFriday;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeSaturday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeSaturday;
+  @NotBlank(message = "{errors.validate.start.time}")
+  private String partnerClassStartTimeSunday;
+  @NotBlank(message = "{errors.validate.end.time}")
+  private String partnerClassEndTimeSunday;
+  @Pattern(regexp = "^(0[1-9]|[12][0-9]|3[01])$", message = "{general.day.validation}")
+  private String partnerProgramStartDay;
+  @Pattern(regexp = "^(0?[1-9]|1[0-2])$", message = "{general.month.validation}")
+  private String partnerProgramStartMonth;
+  @Pattern(regexp = "^(19|20)\\d{2}$", message = "{general.year.validation}")
+  private String partnerProgramStartYear;
+  @Pattern(regexp = "^(0[1-9]|[12][0-9]|3[01])$", message = "{general.day.validation}")
+  private String partnerProgramEndDay;
+  @Pattern(regexp = "^(0?[1-9]|1[0-2])$", message = "{general.month.validation}")
+  private String partnerProgramEndMonth;
+  @Pattern(regexp = "^(19|20)\\d{2}$", message = "{general.year.validation}")
+  private String partnerProgramEndYear;
     private List<String> unearnedIncomeSource;
     private String unearnedIncomeRental;
     private String unearnedIncomeDividends;

--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -84,6 +84,7 @@ public class Gcc extends FlowInputs {
     private String parentPartnerBirthMonth;
     private String parentPartnerBirthYear;
     private List<String> parentPartnerGender;
+    @Phone(message = "{errors.invalid-phone-number}")
     private String phoneNumber;
     private String streetAddress;
     private String city;

--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -91,25 +91,37 @@ public class Gcc extends FlowInputs {
     @Pattern(regexp = "^\\d{5,}$", message = "{errors.invalid-zipcode}")
     private String zipCode;
     private String activitiesClassHoursSameEveryDay;
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeAllDays;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeAllDays;
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeMonday;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeMonday;
-
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeTuesday;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeTuesday;
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeWednesday;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeWednesday;
-
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeThursday;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeThursday;
-
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeFriday;
-
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeFriday;
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeSaturday;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeSaturday;
+    @NotBlank(message = "{errors.validate.start.time}")
     private String activitiesClassStartTimeSunday;
+    @NotBlank(message = "{errors.validate.end.time}")
     private String activitiesClassEndTimeSunday;
 
     @Pattern(regexp = "\\d{3}-\\d{2}-\\d{4}", message = "{errors.invalid-ssn}")

--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -11,17 +11,17 @@ import java.util.List;
 public class Gcc extends FlowInputs {
 
     private String lang;
-  @NotBlank(message = "{errors.provide-program-name}")
-  private String schoolName;
-  @NotBlank(message = "{errors.select-one-option}")
-  private String educationType;
-  @NotBlank
-  private String dayCareChoice;
-  private String programTaught;
-  @NotBlank(message = "{errors.select-yes-or-no}")
-  private String programSchedule;
-  private String languageRead;
-  private String languageSpeak;
+    @NotBlank(message = "{errors.provide-program-name}")
+    private String schoolName;
+    @NotBlank(message = "{errors.select-one-option}")
+    private String educationType;
+    @NotBlank(message = "{errors.choose-provider}")
+    private String dayCareChoice;
+    private String programTaught;
+    @NotBlank(message = "{errors.select-yes-or-no}")
+    private String programSchedule;
+    private String languageRead;
+    private String languageSpeak;
     @NotBlank(message = "{errors.provide-first-name}")
     private String parentFirstName;
     @NotBlank(message = "{errors.provide-last-name}")
@@ -147,7 +147,7 @@ public class Gcc extends FlowInputs {
     private String childHasDisability;
     private String childIsUsCitizen;
     private String childInCare;
-  @NotEmpty(message = "{errors.select-at-least-one-day}")
+    @NotEmpty(message = "{errors.select-at-least-one-day}")
     private List<String> weeklySchedule;
     @Pattern(regexp = "^(0[1-9]|[12][0-9]|3[01])$", message = "{general.day.validation}")
     private String activitiesProgramStartDay;
@@ -195,70 +195,64 @@ public class Gcc extends FlowInputs {
 
     private List<String> unearnedIncomePrograms;
     private String unearnedIncomeAssetsMoreThanOneMillionDollars;
-  private String current_uuid;
+    private String current_uuid;
 
-  @NotBlank(message = "{errors.select-one-option}")
-  private String partnerEducationType;
-  @NotBlank(message = "{errors.provide-program-name}")
-  private String partnerProgramName;
-  @Phone(message = "{errors.invalid-phone-number}")
-  private String partnerEdPhoneNumber;
-  private String partnerEdStreetAddress;
-  private String partnerEdCity;
-  private String partnerEdState;
-  @Pattern(regexp = "^\\d{5,}$", message = "{errors.invalid-zipcode}")
-  private String partnerEdZipCode;
-  private String partnerProgramTaught;
-  @NotBlank(message = "{errors.select-yes-or-no}")
-  private String partnerProgramSchedule;
+    @NotBlank(message = "{errors.select-one-option}")
+    private String partnerEducationType;
+    @NotBlank(message = "{errors.provide-program-name}")
+    private String partnerProgramName;
+    @Phone(message = "{errors.invalid-phone-number}")
+    private String partnerEdPhoneNumber;
+    private String partnerEdStreetAddress;
+    private String partnerEdCity;
+    private String partnerEdState;
+    @Pattern(regexp = "^\\d{5,}$", message = "{errors.invalid-zipcode}")
+    private String partnerEdZipCode;
+    private String partnerProgramTaught;
+    @NotBlank(message = "{errors.select-yes-or-no}")
+    private String partnerProgramSchedule;
 
-  @NotEmpty(message = "{errors.select-at-least-one-day}")
-  private List<String> partnerClassWeeklySchedule;
-  private String partnerClassHoursSameEveryDay;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeAllDays;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeAllDays;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeMonday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeMonday;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeTuesday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeTuesday;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeWednesday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeWednesday;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeThursday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeThursday;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeFriday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeFriday;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeSaturday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeSaturday;
-  @NotBlank(message = "{errors.validate.start.time}")
-  private String partnerClassStartTimeSunday;
-  @NotBlank(message = "{errors.validate.end.time}")
-  private String partnerClassEndTimeSunday;
-  @Pattern(regexp = "^(0[1-9]|[12][0-9]|3[01])$", message = "{general.day.validation}")
-  private String partnerProgramStartDay;
-  @Pattern(regexp = "^(0?[1-9]|1[0-2])$", message = "{general.month.validation}")
-  private String partnerProgramStartMonth;
-  @Pattern(regexp = "^(19|20)\\d{2}$", message = "{general.year.validation}")
-  private String partnerProgramStartYear;
-  @Pattern(regexp = "^(0[1-9]|[12][0-9]|3[01])$", message = "{general.day.validation}")
-  private String partnerProgramEndDay;
-  @Pattern(regexp = "^(0?[1-9]|1[0-2])$", message = "{general.month.validation}")
-  private String partnerProgramEndMonth;
-  @Pattern(regexp = "^(19|20)\\d{2}$", message = "{general.year.validation}")
-  private String partnerProgramEndYear;
+    @NotEmpty(message = "{errors.select-at-least-one-day}")
+    private List<String> partnerClassWeeklySchedule;
+    private String partnerClassHoursSameEveryDay;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeAllDays;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeAllDays;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeMonday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeMonday;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeTuesday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeTuesday;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeWednesday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeWednesday;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeThursday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeThursday;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeFriday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeFriday;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeSaturday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeSaturday;
+    @NotBlank(message = "{errors.validate.start.time}")
+    private String partnerClassStartTimeSunday;
+    @NotBlank(message = "{errors.validate.end.time}")
+    private String partnerClassEndTimeSunday;
+    private String partnerProgramStartDay;
+    private String partnerProgramStartMonth;
+    private String partnerProgramStartYear;
+    private String partnerProgramEndDay;
+    private String partnerProgramEndMonth;
+    private String partnerProgramEndYear;
     private List<String> unearnedIncomeSource;
     private String unearnedIncomeRental;
     private String unearnedIncomeDividends;

--- a/src/main/java/org/ilgcc/app/submission/actions/SetClassWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetClassWeeklyScheduleGroup.java
@@ -1,0 +1,33 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class SetClassWeeklyScheduleGroup extends SetWeeklyScheduleGroup {
+
+  public SetClassWeeklyScheduleGroup(MessageSource messageSource) {
+    super(messageSource);
+  }
+
+  @Override
+  protected List<String> getWeeklySchedule(Submission submission) {
+    Map<String, Object> inputData = submission.getInputData();
+    if (!inputData.containsKey("weeklySchedule[]")) {
+      return null;
+    }
+    return new ArrayList<>((List<String>) inputData.get("weeklySchedule[]"));
+  }
+
+  @Override
+  protected List<String> getWeeklySchedule(Submission submission, String id) {
+    throw new IllegalStateException("Not implemented");
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SetPartnerClassWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetPartnerClassWeeklyScheduleGroup.java
@@ -1,0 +1,33 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class SetPartnerClassWeeklyScheduleGroup extends SetWeeklyScheduleGroup {
+
+  public SetPartnerClassWeeklyScheduleGroup(MessageSource messageSource) {
+    super(messageSource);
+  }
+
+  @Override
+  protected List<String> getWeeklySchedule(Submission submission) {
+    Map<String, Object> inputData = submission.getInputData();
+    if (!inputData.containsKey("partnerClassWeeklySchedule[]")) {
+      return null;
+    }
+    return new ArrayList<>((List<String>) inputData.get("partnerClassWeeklySchedule[]"));
+  }
+
+  @Override
+  protected List<String> getWeeklySchedule(Submission submission, String id) {
+    throw new IllegalStateException("Not implemented");
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
@@ -5,32 +5,46 @@ import formflow.library.data.Submission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
-@Component
-public class SetWeeklyScheduleGroup implements Action {
-
-  private final MessageSource messageSource;
+public abstract class SetWeeklyScheduleGroup implements Action {
 
   public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
-
   public static final String DISPLAY_LABEL = "displayWeeklySchedule";
+  private final MessageSource messageSource;
 
   public SetWeeklyScheduleGroup(MessageSource messageSource) {
     this.messageSource = messageSource;
   }
 
+  protected abstract List<String> getWeeklySchedule(Submission submission);
+
+  protected abstract List<String> getWeeklySchedule(Submission submission, String id);
+
   @Override
   public void run(Submission submission) {
-    Map<String, Object> inputData = submission.getInputData();
-    if (!inputData.containsKey("weeklySchedule[]")) {
+    var weeklySchedule = getWeeklySchedule(submission);
+    setFormattedDisplayGroup(submission, weeklySchedule);
+  }
+
+  @Override
+  public void run(Submission submission, String id) {
+    var weeklySchedule = getWeeklySchedule(submission, id);
+    setFormattedDisplayGroup(submission, weeklySchedule);
+  }
+
+  private void setFormattedDisplayGroup(Submission submission, List<String> weeklySchedule) {
+    if (weeklySchedule == null) {
       return;
     }
-    var weeklySchedule = new ArrayList<>((List<String>) inputData.get("weeklySchedule[]"));
+
+    Map<String, Object> inputData = submission.getInputData();
     var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
     String firstDay = null, lastDay = null;
     Locale locale = LocaleContextHolder.getLocale();

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateProgramDates.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateProgramDates.java
@@ -33,17 +33,17 @@ public class ValidateProgramDates extends VerifyDate {
     var startDay = (String) inputData.get(INPUT_NAME_START + "Day");
     var startMonth = (String) inputData.get(INPUT_NAME_START + "Month");
     var startYear = (String) inputData.get(INPUT_NAME_START + "Year");
-    Map<String, List<String>> errorMessages = validateProgramDates(startMonth, startDay, startYear);
+    Map<String, List<String>> errorMessages = validateProgramDates(INPUT_NAME_START, startMonth, startDay, startYear);
 
     var endDay = (String) inputData.get(INPUT_NAME_END + "Day");
     var endMonth = (String) inputData.get(INPUT_NAME_END + "Month");
     var endYear = (String) inputData.get(INPUT_NAME_END + "Year");
-    errorMessages.putAll(validateProgramDates(endMonth, endDay, endYear));
+    errorMessages.putAll(validateProgramDates(INPUT_NAME_END, endMonth, endDay, endYear));
 
     return errorMessages;
   }
 
-  private Map<String, List<String>> validateProgramDates(String month, String day, String year) {
+  private Map<String, List<String>> validateProgramDates(String prefix, String month, String day, String year) {
     Map<String, List<String>> errorMessages = new HashMap<>();
     var dateString = String.format("%s/%s/%s", month, day, year);
     if (!dateString.equals("//")) {
@@ -54,15 +54,15 @@ public class ValidateProgramDates extends VerifyDate {
 
       Locale locale = LocaleContextHolder.getLocale();
       if (month.isBlank()) {
-        errorMessages.put(INPUT_NAME_START + "Month", List.of(messageSource.getMessage("general.month.validation", null, locale)));
+        errorMessages.put(prefix + "Month", List.of(messageSource.getMessage("general.month.validation", null, locale)));
       }
 
       if (year.isBlank()) {
-        errorMessages.put(INPUT_NAME_START + "Year", List.of(messageSource.getMessage("general.year.validation", null, locale)));
+        errorMessages.put(prefix + "Year", List.of(messageSource.getMessage("general.year.validation", null, locale)));
       }
 
       if (errorMessages.isEmpty() && isDateInvalid(dateString)) {
-        errorMessages.put(INPUT_NAME_START + "Date", List.of(messageSource.getMessage("errors.invalid-date-format", null, locale)));
+        errorMessages.put(prefix, List.of(messageSource.getMessage("errors.invalid-date-format", null, locale)));
       }
     }
     return errorMessages;

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateProgramDates.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateProgramDates.java
@@ -64,6 +64,10 @@ public class ValidateProgramDates extends VerifyDate {
       if (errorMessages.isEmpty() && isDateInvalid(dateString)) {
         errorMessages.put(prefix, List.of(messageSource.getMessage("errors.invalid-date-format", null, locale)));
       }
+
+      if (errorMessages.isEmpty() && isBetweenNowAndMinDate(dateString)) {
+        errorMessages.put(prefix, List.of(messageSource.getMessage("errors.invalid-birthdate-range", null, locale)));
+      }
     }
     return errorMessages;
   }

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateProgramDates.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateProgramDates.java
@@ -1,0 +1,70 @@
+package org.ilgcc.app.submission.actions;
+
+
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class ValidateProgramDates extends VerifyDate {
+
+  final MessageSource messageSource;
+
+  private final String INPUT_NAME_START = "partnerProgramStart";
+  private final String INPUT_NAME_END = "partnerProgramEnd";
+
+  public ValidateProgramDates(MessageSource messageSource) {
+    this.messageSource = messageSource;
+  }
+
+  @Override
+  public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {
+    Map<String, Object> inputData = formSubmission.getFormData();
+
+    var startDay = (String) inputData.get(INPUT_NAME_START + "Day");
+    var startMonth = (String) inputData.get(INPUT_NAME_START + "Month");
+    var startYear = (String) inputData.get(INPUT_NAME_START + "Year");
+    Map<String, List<String>> errorMessages = validateProgramDates(startMonth, startDay, startYear);
+
+    var endDay = (String) inputData.get(INPUT_NAME_END + "Day");
+    var endMonth = (String) inputData.get(INPUT_NAME_END + "Month");
+    var endYear = (String) inputData.get(INPUT_NAME_END + "Year");
+    errorMessages.putAll(validateProgramDates(endMonth, endDay, endYear));
+
+    return errorMessages;
+  }
+
+  private Map<String, List<String>> validateProgramDates(String month, String day, String year) {
+    Map<String, List<String>> errorMessages = new HashMap<>();
+    var dateString = String.format("%s/%s/%s", month, day, year);
+    if (!dateString.equals("//")) {
+      // Day field is not required, but we want to check for valid date
+      if (day.isBlank()) {
+        dateString = String.format("%s/01/%s", month, year);
+      }
+
+      Locale locale = LocaleContextHolder.getLocale();
+      if (month.isBlank()) {
+        errorMessages.put(INPUT_NAME_START + "Month", List.of(messageSource.getMessage("general.month.validation", null, locale)));
+      }
+
+      if (year.isBlank()) {
+        errorMessages.put(INPUT_NAME_START + "Year", List.of(messageSource.getMessage("general.year.validation", null, locale)));
+      }
+
+      if (errorMessages.isEmpty() && isDateInvalid(dateString)) {
+        errorMessages.put(INPUT_NAME_START + "Date", List.of(messageSource.getMessage("errors.invalid-date-format", null, locale)));
+      }
+    }
+    return errorMessages;
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/PartnerInSchool.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/PartnerInSchool.java
@@ -1,0 +1,20 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+@Component
+public class PartnerInSchool implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    List<String> reasonsForChildcareNeed = (List<String>) submission.getInputData()
+        .getOrDefault("activitiesParentPartnerChildcareReason[]", emptyList());
+    return reasonsForChildcareNeed.contains("SCHOOL");
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/PartnerIsWorking.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/PartnerIsWorking.java
@@ -1,0 +1,20 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+@Component
+public class PartnerIsWorking implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    List<String> reasonsForChildcareNeed = (List<String>) submission.getInputData()
+        .getOrDefault("activitiesParentPartnerChildcareReason[]", emptyList());
+    return reasonsForChildcareNeed.contains("WORKING");
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/PartnersClassesAreTaughtOnSchedule.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/PartnersClassesAreTaughtOnSchedule.java
@@ -1,0 +1,15 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartnersClassesAreTaughtOnSchedule implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    return "No".equals(submission.getInputData().get("partnerProgramSchedule"));
+  }
+
+}

--- a/src/main/java/org/ilgcc/app/utils/DayOfWeekOption.java
+++ b/src/main/java/org/ilgcc/app/utils/DayOfWeekOption.java
@@ -1,0 +1,33 @@
+package org.ilgcc.app.utils;
+
+public enum DayOfWeekOption implements InputOption {
+
+  Monday("general.week.Monday"),
+  Tuesday("general.week.Tuesday"),
+  Wednesday("general.week.Wednesday"),
+  Thursday("general.week.Thursday"),
+  Friday("general.week.Friday"),
+  Saturday("general.week.Saturday"),
+  Sunday("general.week.Sunday");
+
+  private final String label;
+
+  DayOfWeekOption(String label) {
+    this.label = label;
+  }
+
+  @Override
+  public String getLabel() {
+    return label;
+  }
+
+  @Override
+  public String getValue() {
+    return this.name();
+  }
+
+  @Override
+  public String getHelpText() {
+    return null;
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -213,19 +213,50 @@ flow:
     nextScreens:
       - name: activities-class-hourly-schedule
   activities-class-hourly-schedule:
-    beforeDisplayAction: SetWeeklyScheduleGroup
+    beforeDisplayAction: SetClassWeeklyScheduleGroup
     nextScreens:
       - name: activities-ed-program-dates
   activities-ed-program-dates:
     crossFieldValidationAction: ValidateMonthYearActivitiesProgram
     nextScreens:
       - name: activities-partner-add-job
+        condition: PartnerIsWorking
+      - name: activities-partner-add-ed-program
+        condition: PartnerInSchool
+      - name: unearned-income-intro
   activities-partner-add-job:
     condition: SkipTemplate
     nextScreens:
       - name: activities-partner-add-ed-program
   activities-partner-add-ed-program:
-    condition: SkipTemplate
+    nextScreens:
+      - name: activities-partner-ed-program-type
+  activities-partner-ed-program-type:
+    nextScreens:
+      - name: activities-partner-ed-program-name
+  activities-partner-ed-program-name:
+    nextScreens:
+      - name: activities-partner-ed-program-info
+  activities-partner-ed-program-info:
+    nextScreens:
+      - name: activities-partner-ed-program-method
+  activities-partner-ed-program-method:
+    nextScreens:
+      - name: activities-partner-next-class-schedule
+        condition: PartnersClassesAreTaughtOnSchedule
+      - name: activities-partner-class-weekly-schedule
+  activities-partner-next-class-schedule:
+    nextScreens:
+      - name: activities-partner-class-weekly-schedule
+  activities-partner-class-weekly-schedule:
+    nextScreens:
+      - name: activities-partner-class-hourly-schedule
+  activities-partner-class-hourly-schedule:
+    beforeDisplayAction: SetPartnerClassWeeklyScheduleGroup
+    nextScreens:
+      - name: activities-partner-ed-program-dates
+  activities-partner-ed-program-dates:
+    crossFieldValidationAction: ValidateProgramDates
     nextScreens:
       - name: unearned-income-intro
   unearned-income-intro:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -82,7 +82,12 @@ errors.provide-street=Please provide a street address.
 errors.provide-city=Please provide a city.
 errors.provide-state=Please choose the state.
 errors.provide-zip=Please enter a zip code with 5 digits.
+errors.provide-program-name=Please provide a program name.
+errors.select-one-option=Please select one option
+errors.select-at-least-one-day=Please select at least one day
+errors.select-yes-or-no=Please select "Yes" or "No" to continue.
 errors.required-financial-assistance=Please answer whether you need child care assistance funding for this child
+errors.invalid-date-format=Make sure the date you entered is in this format: mm/dd/yyyy
 errors.invalid-birthdate-format=Make sure the birthdate you entered is in this format: mm/dd/yyyy
 errors.invalid-birthdate-range=Make sure the date you entered is between 01/01/1901 and today.
 errors.invalid-ssn=Make sure the SSN has 9 digits.
@@ -413,8 +418,11 @@ activities-work-commute-time.subheader=Your travel time will be added to your wo
 activities-work-commute-time.default.option=Select commute time
 #activities-add-jobs-list
 #activities-add-ed-program
+activities-ed-program.title=School or training program
 activities-add-ed-program.header=Tell us about your school or training program.
 activities-add-ed-program.subtext=We will ask for program info and class schedule. You may be asked to submit your GPA at the end of the semester.
+activities-partner-add-ed-program.header=Now tell us about {0}''s school or training program.
+activities-partner-add-ed-program.subtext=We will ask for program info and class schedule. You may be asked to submit their GPA at the end of the semester.
 #activities-ed-program-type
 activities-ed-program-type.header=What type of school or training are you enrolled in?
 activities-ed-program-type.belowPostSecondary=Below post-secondary
@@ -425,7 +433,7 @@ activities-ed-program-type.college=2-4 Year College
 activities-ed-program-type.graduate=Graduate School
 activities-ed-program-type.tanf=TANF Work Training
 activities-ed-program-type.other=Other
-activities-ed-program-type.validationMessage=Please select one option
+activities-partner-ed-program-type.header=What type of school or training is {0} enrolled in?
 #activities-ed-program-name
 activities-ed-program-name.schoolNamePlaceholder=School name
 activities-ed-program-name.header=What is the school or training program name?*
@@ -433,31 +441,41 @@ activities-ed-program-name.header=What is the school or training program name?*
 activities-ed-program-info.header=Program information
 activities-ed-program-info.description=You can skip questions that are not relevant to your program.
 activities-ed-program-info.phone-number=What's their phone number?
+activities-partner-ed-program-info.description=You can skip questions that are not relevant to this program.
 #activities-ed-program-method
-activities-ed-program-method.title=Learning style
+activities-ed-program-method.header=Learning style
 activities-ed-program-method.description=This information helps us better understand your schedule.
-activities-ed-program-method.program.header=How is the program taught?
+activities-ed-program-method.program.header=How are your classes taught?
 activities-ed-program-method.program.online=Online
 activities-ed-program-method.program.inperson=In-Person
 activities-ed-program-method.program.hybrid=Hybrid (Online and In-Person)
-activities-ed-program-method.schedule.header=Are your classes taught on a schedule?
-activities-ed-program-method.validationMessage=Please select one option
+activities-ed-program-method.schedule.header=Are your classes taught on a schedule?*
+activities-partner-ed-program-method.description=This information helps us better understand {0}''s schedule.
+activities-partner-ed-program-method.program.header=How are {0}''s classes taught?
+activities-partner-ed-program-method.schedule.header=Are {0}''s classes taught on a schedule?*
 
 #activities-next-class-schedule
 activities-next-class-schedule.header=Next, we'll ask about your class schedule.
 activities-next-class-schedule.description=<b>Since your class schedule is flexible</b>, please select the days and times you plan to take classes or study while your child is in daycare.
 activities-next-class-schedule.skip=Skip because I don't need child care coverage during class time.
+activities-partner-next-class-schedule.header=Next, we''ll ask about {0}''s class schedule.
+activities-partner-next-class-schedule.description=<b>Since {0}''s class schedule is flexible</b>, please select the days and times you plan to take classes or study while your child is in daycare.
 
 #activities-class-weekly-schedule
 activities-class-weekly-schedule.title=Weekly Class Schedule
 activities-class-weekly-schedule.header=What days do you take classes?
 activities-class-weekly-schedule.subtext=If it varies, choose the days you typically take classes that you need child care coverage for.
+activities-partner-class-weekly-schedule.header=What days does {0} take classes?
+activities-partner-class-weekly-schedule.subtext=If it varies, choose the days {0} typically take classes that you need child care coverage for.
 
 #activities-class-hourly-schedule
 activities-class-hourly-schedule.title=Hourly Class Schedule
 activities-class-hourly-schedule.header=What time are you in classes?
-activities-class-hourly-schedule.description=Select the time you start and finish class.
-activities-class-hourly-schedule.class.hours.same.every.day=My class hours are the same every day.
+activities-class-hourly-schedule.subtext=Select the time you start and finish class.
+activities-class-hourly-schedule.hours-are-the-same=My class hours are the same every day.
+activities-partner-class-hourly-schedule.header=What time is {0} in classes?
+activities-partner-class-hourly-schedule.subtext=Select the time {0} starts and finishes class.
+activities-partner-class-hourly-schedule.hours-are-the-same=Their class hours are the same every day.
 
 #activities-ed-program-dates
 activities-ed-program-dates.title=Time of Program
@@ -465,6 +483,7 @@ activities-ed-program-dates.header=How long will you be enrolled in this program
 activities-ed-program-dates.subtext=If you don't know exact dates, you can skip or just enter the month and year.
 activities-ed-program-dates.term-start-date=Term Start Date
 activities-ed-program-dates.term-end-date=Term End Date
+activities-partner-ed-program-dates.header=How long will {0} be enrolled in this program?
 #activities-partner-add-job
 #activities-partner-add-ed-program
 #

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -86,6 +86,7 @@ errors.provide-program-name=Please provide a program name.
 errors.select-one-option=Please select one option
 errors.select-at-least-one-day=Please select at least one day
 errors.select-yes-or-no=Please select "Yes" or "No" to continue.
+errors.choose-provider=Please choose a provider from the list or select "none of the above".
 errors.required-financial-assistance=Please answer whether you need child care assistance funding for this child
 errors.invalid-date-format=Make sure the date you entered is in this format: mm/dd/yyyy
 errors.invalid-birthdate-format=Make sure the birthdate you entered is in this format: mm/dd/yyyy

--- a/src/main/resources/templates/fragments/screens/activities-add-ed-program.html
+++ b/src/main/resources/templates/fragments/screens/activities-add-ed-program.html
@@ -1,0 +1,26 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=#{activities-ed-program.title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/gcc-icons :: mortarboard}"></th:block>
+          <th:block
+              th:replace="~{fragments/cardHeader :: cardHeader}"/>
+          <div class="form-card__content"></div>
+          <div class="form-card__footer">
+            <th:block th:replace="~{fragments/continueButton :: continue}"/>
+          </div>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-class-hourly-schedule.html
+++ b/src/main/resources/templates/fragments/screens/activities-class-hourly-schedule.html
@@ -1,0 +1,40 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <th:block th:replace="~{fragments/head :: head(title=#{activities-class-hourly-schedule.title})}"/>
+  <th:block th:replace="~{fragments/toggleWeeklyFields :: toggleWeeklyFields}"/>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${programName})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent">
+              <div class="form-card__content">
+                <th:block th:replace="~{fragments/inputs/checkbox :: checkbox(value='Yes', label=${sameHoursLabel})}"/>
+                <div id="grouped-days" th:class="${isSameEveryDay ? '' : 'hidden'}">
+                  <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName=${inputNamePrefix} + 'StartTimeAllDays', endInputName=${inputNamePrefix} + 'EndTimeAllDays', label=${fieldData.get('displayWeeklySchedule')})}"/>
+                </div>
+                <div id="individual-days" th:class="${isSameEveryDay ? 'hidden' : ''}">
+                  <th:block th:each="day: ${selectedDays}">
+                    <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName=${inputNamePrefix} + 'StartTime' + ${day}, endInputName=${inputNamePrefix} + 'EndTime' + ${day}, label=#{${'general.week.' + day}})}"/>
+                  </th:block>
+                </div>
+              </div>
+              <div class="form-card__footer">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-class-weekly-schedule.html
+++ b/src/main/resources/templates/fragments/screens/activities-class-weekly-schedule.html
@@ -1,0 +1,35 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=#{activities-class-weekly-schedule.title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${programName})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent"
+                      th:with="dayOfWeekOptions=${T(org.ilgcc.app.utils.DayOfWeekOption).values()}">
+              <div class="form-card__content">
+                <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
+                  checkboxFieldset(
+                    ariaLabel='header',
+                    options=${dayOfWeekOptions})}"/>
+              </div>
+              <div class="form-card__footer">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-ed-program-dates.html
+++ b/src/main/resources/templates/fragments/screens/activities-ed-program-dates.html
@@ -1,0 +1,38 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=#{activities-ed-program-dates.title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${programName})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader(subtext=#{activities-ed-program-dates.subtext})}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent">
+              <div class="form-card__content">
+                <th:block th:replace="~{fragments/inputs/date :: date(
+                  inputName=${startDateInputName},
+                  groupName=${startDateInputName},
+                  label=#{activities-ed-program-dates.term-start-date})}"/>
+                <th:block th:replace="~{fragments/inputs/date :: date(
+                  inputName=${endDateInputName},
+                  groupName=${endDateInputName},
+                  label=#{activities-ed-program-dates.term-end-date})}"/>
+              </div>
+              <div class="form-card__footer">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-ed-program-info.html
+++ b/src/main/resources/templates/fragments/screens/activities-ed-program-info.html
@@ -1,0 +1,42 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=#{activities-ed-program.title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${programName})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-ed-program-info.header})}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent">
+              <div class="form-card__content">
+                <th:block
+                    th:replace="~{fragments/inputs/phone :: phone(inputName=${phoneNumberInputName}, label=#{activities-ed-program-info.phone-number})}"/>
+                <th:block
+                    th:replace="~{fragments/inputs/text :: text(inputName=${streetAddressInputName}, label=#{general.street-address})}"/>
+                <th:block
+                    th:replace="~{fragments/inputs/text :: text(inputName=${cityInputName}, label=#{general.city})}"/>
+                <th:block th:replace="~{fragments/inputs/state ::
+                  state(inputName='state',
+                  label=#{general.state})}"/>
+                <th:block
+                    th:replace="~{fragments/inputs/text :: text(inputName=${zipCodeInputName}, label=#{general.zip-code})}"/>
+              </div>
+              <div class="form-card__footer">
+                <th:block
+                    th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-ed-program-method.html
+++ b/src/main/resources/templates/fragments/screens/activities-ed-program-method.html
@@ -1,0 +1,57 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=#{activities-ed-program-method.header})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${programName})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-ed-program-method.header})}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent">
+              <div class="form-card__content">
+                <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                              radioFieldset(inputName=${programTaughtInputName},
+                              label=${programTaughtLabel},
+                              ariaLabel='header',
+                              content=~{::radioOptionsProgramTaught},
+                              )}">
+                  <th:block th:ref="radioOptionsProgramTaught">
+                    <th:block
+                        th:replace="~{fragments/inputs/radio :: radio(inputName=${programTaughtInputName}, value='Online',  label=#{activities-ed-program-method.program.online})}"/>
+                    <th:block
+                        th:replace="~{fragments/inputs/radio :: radio(inputName=${programTaughtInputName}, value='In-Person', label=#{activities-ed-program-method.program.inperson})}"/>
+                    <th:block
+                        th:replace="~{fragments/inputs/radio :: radio(inputName=${programTaughtInputName}, value='Hybrid (Online and In-Person)', label=#{activities-ed-program-method.program.hybrid})}"/>
+                  </th:block>
+                </th:block>
+                <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                              radioFieldset(inputName=${programScheduleInputName},
+                              label=${programScheduleLabel},
+                              content=~{::radioOptionsProgramSchedule})}">
+                  <th:block th:ref="radioOptionsProgramSchedule">
+                    <th:block
+                        th:replace="~{fragments/inputs/radio :: radio(inputName=${programScheduleInputName}, value='Yes',  label=#{general.inputs.yes})}"/>
+                    <th:block
+                        th:replace="~{fragments/inputs/radio :: radio(inputName=${programScheduleInputName}, value='No', label=#{general.inputs.no})}"/>
+                  </th:block>
+                </th:block>
+              </div>
+              <div class="form-card__footer">
+                <th:block
+                    th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-ed-program-name.html
+++ b/src/main/resources/templates/fragments/screens/activities-ed-program-name.html
@@ -1,0 +1,18 @@
+<th:block th:fragment="screen">
+  <th:block
+      th:replace="~{fragments/screens/screenWithOneInput ::
+        screenWithOneInput(
+          title=#{activities-ed-program.title},
+          header=#{activities-ed-program-name.header},
+          iconFragment=~{fragments/gcc-icons :: mortarboard},
+          buttonLabel=#{general.button.continue},
+          formAction=${formAction},
+          inputContent=~{::inputContent})}">
+    <th:block th:ref="inputContent">
+      <th:block th:replace="~{fragments/inputs/text ::
+        text(
+          ariaLabel='header',
+          placeholder=#{activities-ed-program-name.schoolNamePlaceholder})}"/>
+    </th:block>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-ed-program-type.html
+++ b/src/main/resources/templates/fragments/screens/activities-ed-program-type.html
@@ -1,0 +1,32 @@
+<th:block th:fragment="screen">
+  <th:block
+      th:replace="~{fragments/screens/screenWithOneInput ::
+        screenWithOneInput(
+          title=#{activities-ed-program.title},
+          iconFragment=~{fragments/gcc-icons :: mortarboard},
+          buttonLabel=#{general.button.continue},
+          formAction=${formAction},
+          inputContent=~{::inputContent})}">
+    <th:block th:ref="inputContent">
+      <th:block
+          th:replace="~{fragments/inputs/radioFieldset :: radioFieldset(ariaLabel='header', content=~{::radioOptions})}">
+        <th:block th:ref="radioOptions">
+          <th:block th:replace="~{fragments/inputs/radio :: radio(value='belowPostSecondary', label=#{activities-ed-program-type.belowPostSecondary},
+                        radioHelpText=#{activities-ed-program-type.belowPostSecondary.secondPart})}"/>
+          <th:block
+              th:replace="~{fragments/inputs/radio :: radio(value='highSchool', label=#{activities-ed-program-type.highSchool})}"/>
+          <th:block
+              th:replace="~{fragments/inputs/radio :: radio(value='vocational', label=#{activities-ed-program-type.vocational})}"/>
+          <th:block
+              th:replace="~{fragments/inputs/radio :: radio(value='college', label=#{activities-ed-program-type.college})}"/>
+          <th:block
+              th:replace="~{fragments/inputs/radio :: radio(value='graduateSchool', label=#{activities-ed-program-type.graduate})}"/>
+          <th:block
+              th:replace="~{fragments/inputs/radio :: radio(value='tanf', label=#{activities-ed-program-type.tanf})}"/>
+          <th:block
+              th:replace="~{fragments/inputs/radio :: radio(value='other', label=#{activities-ed-program-type.other})}"/>
+        </th:block>
+      </th:block>
+    </th:block>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/fragments/screens/activities-next-class-schedule.html
+++ b/src/main/resources/templates/fragments/screens/activities-next-class-schedule.html
@@ -1,0 +1,30 @@
+<th:block th:fragment="screen">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=#{activities-ed-program.title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <th:block th:replace="~{fragments/toolbar :: toolbar}"/>
+    <section class="slab">
+      <div class="grid">
+        <th:block th:replace="~{fragments/goBack :: goBackLink}"/>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="~{fragments/gcc-icons :: linedDocument}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader}"/>
+          <div class="notice--warning">
+            <p class="notice-text" th:utext="${notice}"></p>
+          </div>
+          <div class="form-card__footer">
+            <th:block th:replace="~{fragments/continueButton :: continue}"/>
+            </br>
+            <a id="skip-coverage-during-classtime" th:href="${skipLink}"
+               th:text="#{activities-next-class-schedule.skip}"></a>
+          </div>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/toggleWeeklyFields.html
+++ b/src/main/resources/templates/fragments/toggleWeeklyFields.html
@@ -1,0 +1,23 @@
+<script th:fragment="toggleWeeklyFields" type="text/javascript">
+    $(document).ready(function () {
+        function toggleFields() {
+            $('#grouped-days').toggleClass('hidden');
+            $('#individual-days').toggleClass('hidden');
+            disableFields()
+        }
+
+        function disableFields() {
+            const isGrouped = $('#individual-days').hasClass('hidden')
+            $('#grouped-days :input').prop('disabled', !isGrouped);
+            $('#individual-days :input').prop('disabled', isGrouped);
+        }
+
+        // on load
+        disableFields()
+
+        // On checkbox change
+        $('input[type=checkbox]').change(function () {
+            toggleFields();
+        });
+    });
+</script>

--- a/src/main/resources/templates/gcc/activities-add-ed-program.html
+++ b/src/main/resources/templates/gcc/activities-add-ed-program.html
@@ -1,23 +1,7 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title= #{activities-add-ed-program.header})}"></head>
-<body>
-<div class="page-wrapper">
-    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-    <section class="slab">
-        <div class="grid">
-            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
-                <th:block th:replace="~{fragments/gcc-icons :: mortarboard}"></th:block>
-                <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-add-ed-program.header}, subtext=#{activities-add-ed-program.subtext})}"/>
-                <div class="form-card__content"></div>
-                <div class="form-card__footer">
-                    <th:block th:replace="~{fragments/continueButton :: continue}"/>
-                </div>
-            </main>
-        </div>
-    </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-add-ed-program ::
+      screen(
+        header=#{activities-add-ed-program.header},
+        subtext=#{activities-add-ed-program.subtext}
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-class-hourly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-class-hourly-schedule.html
@@ -1,45 +1,13 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{activities-class-hourly-schedule.title})}"></head>
-<script th:inline="javascript">
-    $(document).ready(function () {
-        $('#activitiesClassHoursSameEveryDay-Yes').change(function () {
-            $('#grouped-days').toggleClass('hidden');
-            $('#individual-days').toggleClass('hidden');
-        });
-    });
-</script>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.schoolName})}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-class-hourly-schedule.header}, subtext=#{activities-class-hourly-schedule.description})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content" th:with="isSameEveryDay=${!#lists.isEmpty(fieldData.get('activitiesClassHoursSameEveryDay[]'))}">
-              <th:block th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='activitiesClassHoursSameEveryDay', value='Yes', label=#{activities-class-hourly-schedule.class.hours.same.every.day}, toggleVisibility='#activitiesWeekly')}" />
-              <div id="grouped-days" th:class="${isSameEveryDay ? '' : 'hidden'}">
-                <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName='activitiesClassStartTimeAllDays', endInputName='activitiesClassEndTimeAllDays', label=${fieldData.get('displayWeeklySchedule')})}" />
-              </div>
-              <div id="individual-days" th:class="${isSameEveryDay ? 'hidden' : ''}">
-                <th:block th:each="day: ${fieldData['weeklySchedule[]']}">
-                  <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName='activitiesClassStartTime' + ${day}, endInputName='activitiesClassEndTime' + ${day}, label=#{${'general.week.' + day}})}" />
-                </th:block>
-              </div>
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-class-hourly-schedule ::
+      screen(
+        header=#{activities-class-hourly-schedule.header},
+        subtext=#{activities-class-hourly-schedule.subtext},
+        programName=${fieldData.schoolName},
+        isSameEveryDay=${!#lists.isEmpty(fieldData.get('activitiesClassHoursSameEveryDay[]'))},
+        sameHoursLabel=#{activities-class-hourly-schedule.hours-are-the-same},
+        selectedDays=${fieldData['weeklySchedule[]']},
+        inputName='activitiesClassHoursSameEveryDay',
+        inputNamePrefix='activitiesClass'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-class-weekly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-class-weekly-schedule.html
@@ -1,49 +1,9 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{activities-class-weekly-schedule.title})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.schoolName})}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-class-weekly-schedule.header}, subtext=#{activities-class-weekly-schedule.subtext})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
-                              checkboxFieldset(inputName='weeklySchedule',
-                              ariaLabel='header',
-                              content=~{::checkboxOptions})}">
-                <th:block th:ref="checkboxOptions">
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Monday',  label=#{general.week.Monday})}" />
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Tuesday', label=#{general.week.Tuesday})}"/>
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Wednesday', label=#{general.week.Wednesday})}"/>
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Thursday', label=#{general.week.Thursday})}"/>
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Friday', label=#{general.week.Friday})}"/>
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Saturday', label=#{general.week.Saturday})}"/>
-                  <th:block
-                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='weeklySchedule', value='Sunday', label=#{general.week.Sunday})}"/>
-                </th:block>
-              </th:block>
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-class-weekly-schedule ::
+      screen(
+        header=#{activities-class-weekly-schedule.header},
+        subtext=#{activities-class-weekly-schedule.subtext},
+        programName=${fieldData.schoolName},
+        inputName='weeklySchedule'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-ed-program-dates.html
+++ b/src/main/resources/templates/gcc/activities-ed-program-dates.html
@@ -1,36 +1,9 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{activities-ed-program-dates.title})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.schoolName})}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-ed-program-dates.header}, subtext=#{activities-ed-program-dates.subtext})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/date ::
-                date(inputName='activitiesProgramStart',
-                groupName='activitiesProgramStart',
-                label=#{activities-ed-program-dates.term-start-date})}"/>
-              <th:block th:replace="~{fragments/inputs/date ::
-                date(inputName='activitiesProgramEnd',
-                groupName='activitiesProgramEnd',
-                label=#{activities-ed-program-dates.term-end-date})}"/>
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-dates ::
+      screen(
+        header=#{activities-ed-program-dates.header},
+        programName=${fieldData.schoolName},
+        startDateInputName='activitiesProgramStart',
+        endDateInputName='activitiesProgramEnd'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-ed-program-info.html
+++ b/src/main/resources/templates/gcc/activities-ed-program-info.html
@@ -1,35 +1,12 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{activities-ed-program-info.header})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.schoolName})}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-ed-program-info.header}, subtext=#{activities-ed-program-info.description})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/phone :: phone(inputName='phoneNumber', label=#{activities-ed-program-info.phone-number})}"/>
-               <th:block th:replace="~{fragments/inputs/text :: text(inputName='streetAddress', label=#{general.street-address})}" />
-              <th:block th:replace="~{fragments/inputs/text :: text(inputName='city', label=#{general.city})}" />
-              <th:block th:replace="~{fragments/inputs/state ::
-                  state(inputName='state',
-                  label=#{general.state})}"/>
-              <th:block th:replace="~{fragments/inputs/text :: text(inputName='zipCode', label=#{general.zip-code})}" />
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-info ::
+      screen(
+        subtext=#{activities-ed-program-info.description},
+        programName=${fieldData.schoolName},
+        phoneNumberInputName='phoneNumber',
+        streetAddressInputName='streetAddress',
+        cityInputName='city',
+        stateInputName='state',
+        zipCodeInputName='zipCode'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-ed-program-method.html
+++ b/src/main/resources/templates/gcc/activities-ed-program-method.html
@@ -1,54 +1,11 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{activities-ed-program-method.program.header})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.schoolName})}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-ed-program-method.title}, subtext=#{activities-ed-program-method.description})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/radioFieldset ::
-                              radioFieldset(inputName='programTaught',
-                              label=#{activities-ed-program-method.program.header},
-                              ariaLabel='header',
-                              content=~{::radioOptionsProgramTaught},
-                              )}">
-                <th:block th:ref="radioOptionsProgramTaught">
-                  <th:block
-                          th:replace="~{fragments/inputs/radio :: radio(inputName='programTaught', value='Online',  label=#{activities-ed-program-method.program.online})}" />
-                  <th:block
-                          th:replace="~{fragments/inputs/radio :: radio(inputName='programTaught', value='In-Person', label=#{activities-ed-program-method.program.inperson})}"/>
-                  <th:block
-                          th:replace="~{fragments/inputs/radio :: radio(inputName='programTaught', value='Hybrid (Online and In-Person)', label=#{activities-ed-program-method.program.hybrid})}"/>
-                </th:block>
-              </th:block>
-                <th:block th:replace="~{fragments/inputs/radioFieldset ::
-                              radioFieldset(inputName='programSchedule',
-                              label=#{activities-ed-program-method.schedule.header},
-                              content=~{::radioOptionsProgramSchedule})}">
-                  <th:block th:ref="radioOptionsProgramSchedule">
-                    <th:block
-                            th:replace="~{fragments/inputs/radio :: radio(inputName='programSchedule', value='Yes',  label=#{general.inputs.yes})}" />
-                    <th:block
-                            th:replace="~{fragments/inputs/radio :: radio(inputName='programSchedule', value='No', label=#{general.inputs.no})}"/>
-                  </th:block>
-              </th:block>
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-method ::
+      screen(
+        subtext=#{activities-ed-program-method.description},
+        programName=${fieldData.schoolName},
+        programTaughtLabel=#{activities-ed-program-method.program.header},
+        programScheduleLabel=#{activities-ed-program-method.program.header},
+        programTaughtInputName='programTaught',
+        programScheduleInputName='programSchedule'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-ed-program-method.html
+++ b/src/main/resources/templates/gcc/activities-ed-program-method.html
@@ -1,10 +1,10 @@
 <th:block
-    th:replace="~{fragments/screens/activities-ed-program-method ::
+        th:replace="~{fragments/screens/activities-ed-program-method ::
       screen(
         subtext=#{activities-ed-program-method.description},
         programName=${fieldData.schoolName},
         programTaughtLabel=#{activities-ed-program-method.program.header},
-        programScheduleLabel=#{activities-ed-program-method.program.header},
+        programScheduleLabel=#{activities-ed-program-method.schedule.header},
         programTaughtInputName='programTaught',
         programScheduleInputName='programSchedule'
       )}">

--- a/src/main/resources/templates/gcc/activities-ed-program-type.html
+++ b/src/main/resources/templates/gcc/activities-ed-program-type.html
@@ -1,48 +1,7 @@
 <th:block
-        th:replace="~{fragments/screens/screenWithOneInput ::
-  screenWithOneInput(
-    title=#{activities-ed-program-type.header},
-    iconFragment=~{fragments/gcc-icons :: mortarboard},
-    header=#{activities-ed-program-type.header},
-    buttonLabel=#{general.button.continue},
-    formAction=${formAction},
-    inputContent=~{::inputContent})}">
-    <th:block th:ref="inputContent">
-        <th:block th:replace="~{fragments/inputs/radioFieldset ::
-                              radioFieldset(inputName='educationType',
-                              ariaLabel='header',
-                              content=~{::radioOptions})}">
-            <th:block th:ref="radioOptions">
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='belowPostSecondary',
-                        label=#{activities-ed-program-type.belowPostSecondary},
-                        radioHelpText=#{activities-ed-program-type.belowPostSecondary.secondPart})}"/>
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='highSchool',
-                        label=#{activities-ed-program-type.highSchool})}"/>
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='vocational',
-                        label=#{activities-ed-program-type.vocational})}"/>
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='college',
-                        label=#{activities-ed-program-type.college})}"/>
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='graduateSchool',
-                        label=#{activities-ed-program-type.graduate})}"/>
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='tanf',
-                        label=#{activities-ed-program-type.tanf})}"/>
-                <th:block
-                        th:replace="~{fragments/inputs/radio :: radio(inputName='educationType',
-                        value='other',
-                        label=#{activities-ed-program-type.other})}"/>
-            </th:block>
-        </th:block>
-    </th:block>
+    th:replace="~{fragments/screens/activities-ed-program-type ::
+      screen(
+        header=#{activities-ed-program-type.header},
+        inputName='educationType'
+      )}">
 </th:block>

--- a/src/main/resources/templates/gcc/activities-next-class-schedule.html
+++ b/src/main/resources/templates/gcc/activities-next-class-schedule.html
@@ -1,29 +1,8 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{activities-next-class-schedule.header})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/gcc-icons :: linedDocument}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-next-class-schedule.header})}"/>
-            <div class="notice--warning">
-              <p class="notice-text" th:utext="#{activities-next-class-schedule.description}"></p>
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/continueButton :: continue}"/></br>
-              <a id="skip-coverage-during-classtime" th:href="'/flow/' + ${flow} + '/activities-ed-program-dates'"
-                 th:text="#{activities-next-class-schedule.skip}"></a>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-next-class-schedule ::
+      screen(
+        header=#{activities-next-class-schedule.header},
+        notice=#{activities-next-class-schedule.description},
+        skipLink='/flow/gcc/activities-ed-program-dates'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-add-ed-program.html
+++ b/src/main/resources/templates/gcc/activities-partner-add-ed-program.html
@@ -1,28 +1,7 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+    th:replace="~{fragments/screens/activities-add-ed-program ::
+      screen(
+        header=${#messages.msg('activities-partner-add-ed-program.header', inputData.get('parentPartnerFirstName'))},
+        subtext=#{activities-partner-add-ed-program.subtext}
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-class-hourly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-partner-class-hourly-schedule.html
@@ -1,0 +1,13 @@
+<th:block
+    th:replace="~{fragments/screens/activities-class-hourly-schedule ::
+      screen(
+        header=${#messages.msg('activities-partner-class-hourly-schedule.header', inputData.get('parentPartnerFirstName'))},
+        subtext=${#messages.msg('activities-partner-class-hourly-schedule.subtext', inputData.get('parentPartnerFirstName'))},
+        programName=${fieldData.partnerProgramName},
+        isSameEveryDay=${!#lists.isEmpty(fieldData.get('partnerClassHoursSameEveryDay[]'))},
+        sameHoursLabel=#{activities-partner-class-hourly-schedule.hours-are-the-same},
+        selectedDays=${fieldData['partnerClassWeeklySchedule[]']},
+        inputName='partnerClassHoursSameEveryDay',
+        inputNamePrefix='partnerClass'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-class-weekly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-partner-class-weekly-schedule.html
@@ -1,0 +1,9 @@
+<th:block
+    th:replace="~{fragments/screens/activities-class-weekly-schedule ::
+      screen(
+        header=${#messages.msg('activities-partner-class-weekly-schedule.header', inputData.get('parentPartnerFirstName'))},
+        subtext=${#messages.msg('activities-partner-class-weekly-schedule.subtext', inputData.get('parentPartnerFirstName'))},
+        programName=${fieldData.partnerProgramName},
+        inputName='partnerClassWeeklySchedule'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-ed-program-dates.html
+++ b/src/main/resources/templates/gcc/activities-partner-ed-program-dates.html
@@ -1,0 +1,9 @@
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-dates ::
+      screen(
+        header=${#messages.msg('activities-partner-ed-program-dates.header', inputData.get('parentPartnerFirstName'))},
+        programName=${fieldData.partnerProgramName},
+        startDateInputName='partnerProgramStart',
+        endDateInputName='partnerProgramEnd'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-ed-program-info.html
+++ b/src/main/resources/templates/gcc/activities-partner-ed-program-info.html
@@ -1,0 +1,12 @@
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-info ::
+      screen(
+        subtext=#{activities-partner-ed-program-info.description},
+        programName=${fieldData.partnerProgramName},
+        phoneNumberInputName='partnerEdPhoneNumber',
+        streetAddressInputName='partnerEdStreetAddress',
+        cityInputName='partnerEdCity',
+        stateInputName='partnerEdState',
+        zipCodeInputName='partnerEdZipCode'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-ed-program-method.html
+++ b/src/main/resources/templates/gcc/activities-partner-ed-program-method.html
@@ -1,0 +1,11 @@
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-method ::
+      screen(
+        subtext=${#messages.msg('activities-partner-ed-program-method.description', inputData.get('parentPartnerFirstName'))},
+        programName=${fieldData.partnerProgramName},
+        programTaughtLabel=${#messages.msg('activities-partner-ed-program-method.program.header', inputData.get('parentPartnerFirstName'))},
+        programScheduleLabel=${#messages.msg('activities-partner-ed-program-method.schedule.header', inputData.get('parentPartnerFirstName'))},
+        programTaughtInputName='partnerProgramTaught',
+        programScheduleInputName='partnerProgramSchedule'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-ed-program-name.html
+++ b/src/main/resources/templates/gcc/activities-partner-ed-program-name.html
@@ -1,4 +1,4 @@
 <th:block
     th:replace="~{fragments/screens/activities-ed-program-name ::
-      screen(inputName='schoolName')}">
+      screen(inputName='partnerProgramName')}">
 </th:block>

--- a/src/main/resources/templates/gcc/activities-partner-ed-program-type.html
+++ b/src/main/resources/templates/gcc/activities-partner-ed-program-type.html
@@ -1,0 +1,7 @@
+<th:block
+    th:replace="~{fragments/screens/activities-ed-program-type ::
+      screen(
+        header=${#messages.msg('activities-partner-ed-program-type.header', inputData.get('parentPartnerFirstName'))},
+        inputName='partnerEducationType'
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/activities-partner-next-class-schedule.html
+++ b/src/main/resources/templates/gcc/activities-partner-next-class-schedule.html
@@ -1,0 +1,8 @@
+<th:block
+    th:replace="~{fragments/screens/activities-next-class-schedule ::
+      screen(
+        header=${#messages.msg('activities-partner-next-class-schedule.header', inputData.get('parentPartnerFirstName'))},
+        notice=${#messages.msg('activities-partner-next-class-schedule.description', inputData.get('parentPartnerFirstName'))},
+        skipLink='/flow/gcc/activities-partner-ed-program-dates'
+      )}">
+</th:block>

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -114,8 +114,8 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
     //parent-partner-info-basic
     assertThat(testPage.getHeader()).isEqualTo("Tell us about your partner");
-    testPage.enter("parentPartnerFirstName", "partner");
-    testPage.enter("parentPartnerLastName", "parent");
+    testPage.enter("parentPartnerFirstName", "Pardnur");
+    testPage.enter("parentPartnerLastName", "Parent");
     testPage.enter("parentPartnerBirthMonth", "12");
     testPage.enter("parentPartnerBirthDay", "25");
     testPage.enter("parentPartnerBirthYear", "2018");
@@ -219,10 +219,11 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickElementById("activitiesParentChildcareReason-other");
     testPage.enter("activitiesParentChildcareReason_other", "test");
     testPage.clickElementById("activitiesParentPartnerChildcareReason-TANF_TRAINING");
-    testPage.clickElementById("activitiesParentPartnerChildcareReason-LOOKING_FOR_WORK");
+    testPage.clickElementById("activitiesParentPartnerChildcareReason-WORKING");
+    testPage.clickElementById("activitiesParentPartnerChildcareReason-SCHOOL");
     testPage.clickContinue();
     //activities-add-ed-program (client should be directed to this page if working is not checked)
-    assertThat(testPage.getTitle()).isEqualTo("Tell us about your school or training program.");
+    assertThat(testPage.getTitle()).isEqualTo("School or training program");
     testPage.goBack();
     assertThat(testPage.getTitle()).isEqualTo("Activities Parent Type");
     testPage.clickElementById("activitiesParentChildcareReason-WORKING");
@@ -266,11 +267,10 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 
     //activities-job-weekly-schedule
     assertThat(testPage.getTitle()).isEqualTo("Job hourly schedule");
-    assertThat(testPage.getElementText("activitiesJobHoursSameEveryDay-Yes-label")).isEqualTo("My work hours are the same every day.");
-    testPage.enter("activitiesJobStartTimeMonday", "12:00");
-    testPage.enter("activitiesJobEndTimeMonday", "12:00");
-    testPage.enter("activitiesJobStartTimeSunday", "12:00");
-    testPage.enter("activitiesJobEndTimeSunday", "12:00");
+    testPage.enter("activitiesJobStartTimeMonday", "1200PM");
+    testPage.enter("activitiesJobEndTimeMonday", "0100PM");
+    testPage.enter("activitiesJobStartTimeSunday", "0200PM");
+    testPage.enter("activitiesJobEndTimeSunday", "0300PM");
     testPage.clickContinue();
 
     //activities-work-commute-time
@@ -283,32 +283,32 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickButton("That is all my jobs");
 
     //activities-add-ed-program
-    assertThat(testPage.getTitle()).isEqualTo("Tell us about your school or training program.");
+    assertThat(testPage.getHeader()).isEqualTo("Tell us about your school or training program.");
     testPage.clickContinue();
 
     //activities-ed-program-type
     assertThat(testPage.getElementText("educationType-highSchool-label")).isEqualTo("High School or GED");
     testPage.clickElementById("educationType-highSchool-label");
-    assertThat(testPage.getTitle()).isEqualTo("What type of school or training are you enrolled in?");
+    assertThat(testPage.getHeader()).isEqualTo("What type of school or training are you enrolled in?");
     testPage.clickContinue();
 
     //activities-ed-program-name
     testPage.enter("schoolName", "World");
-    assertThat(testPage.getTitle()).isEqualTo("What is the school or training program name?*");
+    assertThat(testPage.getHeader()).isEqualTo("What is the school or training program name?*");
     testPage.clickContinue();
 
     //activities-ed-program-info
-    assertThat(testPage.getTitle()).isEqualTo("Program information");
+    assertThat(testPage.getTitle()).isEqualTo("School or training program");
     testPage.clickContinue();
 
     //activities-ed-program-method
-    assertThat(testPage.getTitle()).isEqualTo("How is the program taught?");
+    assertThat(testPage.getTitle()).isEqualTo("Learning style");
     testPage.clickElementById("programTaught-Online-label");
     testPage.clickElementById("programSchedule-No-label");
     testPage.clickContinue();
 
     //activities-next-class-schedule
-    assertThat(testPage.getTitle()).isEqualTo("Next, we'll ask about your class schedule.");
+    assertThat(testPage.getHeader()).isEqualTo("Next, we'll ask about your class schedule.");
     testPage.clickContinue();
 
     //activities-class-weekly-schedule
@@ -319,10 +319,40 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 
     //activities-class-hourly-schedule
     assertThat(testPage.getTitle()).isEqualTo("Hourly Class Schedule");
-    assertThat(testPage.getElementText("activitiesClassHoursSameEveryDay-Yes-label")).isEqualTo("My class hours are the same every day.");
+    testPage.clickElementById("activitiesClassHoursSameEveryDay-Yes");
+    testPage.enter("activitiesClassStartTimeAllDays", "0900AM");
+    testPage.enter("activitiesClassEndTimeAllDays", "13:00");
     testPage.clickContinue();
 
     //activities-ed-program-dates
+    assertThat(testPage.getTitle()).isEqualTo("Time of Program");
+    testPage.clickContinue();
+
+    // activities-partner-ed
+    assertThat(testPage.getHeader()).isEqualTo("Now tell us about Pardnur's school or training program.");
+    testPage.clickContinue();
+    testPage.clickElementById("partnerEducationType-college-label");
+    assertThat(testPage.getHeader()).isEqualTo("What type of school or training is Pardnur enrolled in?");
+    testPage.clickContinue();
+    testPage.enter("partnerProgramName", "World University");
+    assertThat(testPage.getHeader()).isEqualTo("What is the school or training program name?*");
+    testPage.clickContinue();
+    assertThat(testPage.getTitle()).isEqualTo("School or training program");
+    testPage.clickContinue();
+    assertThat(testPage.getTitle()).isEqualTo("Learning style");
+    testPage.clickElementById("partnerProgramTaught-In-Person-label");
+    testPage.clickElementById("partnerProgramSchedule-Yes-label");
+    testPage.clickContinue();
+    assertThat(testPage.getTitle()).isEqualTo("Weekly Class Schedule");
+    testPage.clickElementById("partnerClassWeeklySchedule-Monday");
+    testPage.clickElementById("partnerClassWeeklySchedule-Tuesday");
+    testPage.clickContinue();
+    assertThat(testPage.getTitle()).isEqualTo("Hourly Class Schedule");
+    testPage.enter("partnerClassStartTimeMonday", "0900AM");
+    testPage.enter("partnerClassEndTimeMonday", "1100AM");
+    testPage.enter("partnerClassStartTimeTuesday", "14:00");
+    testPage.enter("partnerClassEndTimeTuesday", "15:00");
+    testPage.clickContinue();
     assertThat(testPage.getTitle()).isEqualTo("Time of Program");
     testPage.clickContinue();
 
@@ -349,7 +379,6 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 //    testPage.clickElementById("unearnedIncomePrograms-SNAP");
 
     // Download PDF and verify fields
-    // TODO: Primary Languages is expected to be `58001` but was `English`, update so that it's expected to be `English`
     verifyPDF();
   }
 

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -114,8 +114,8 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
     //parent-partner-info-basic
     assertThat(testPage.getHeader()).isEqualTo("Tell us about your partner");
-    testPage.enter("parentPartnerFirstName", "Pardnur");
-    testPage.enter("parentPartnerLastName", "Parent");
+    testPage.enter("parentPartnerFirstName", "partner");
+    testPage.enter("parentPartnerLastName", "parent");
     testPage.enter("parentPartnerBirthMonth", "12");
     testPage.enter("parentPartnerBirthDay", "25");
     testPage.enter("parentPartnerBirthYear", "2018");
@@ -329,10 +329,10 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
 
     // activities-partner-ed
-    assertThat(testPage.getHeader()).isEqualTo("Now tell us about Pardnur's school or training program.");
+    assertThat(testPage.getHeader()).isEqualTo("Now tell us about partner's school or training program.");
     testPage.clickContinue();
     testPage.clickElementById("partnerEducationType-college-label");
-    assertThat(testPage.getHeader()).isEqualTo("What type of school or training is Pardnur enrolled in?");
+    assertThat(testPage.getHeader()).isEqualTo("What type of school or training is partner enrolled in?");
     testPage.clickContinue();
     testPage.enter("partnerProgramName", "World University");
     assertThat(testPage.getHeader()).isEqualTo("What is the school or training program name?*");

--- a/src/test/java/org/ilgcc/app/submission/actions/SetClassWeeklyScheduleGroupTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SetClassWeeklyScheduleGroupTest.java
@@ -17,21 +17,21 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-class SetWeeklyScheduleGroupTest {
+class SetClassWeeklyScheduleGroupTest {
 
-  private SetWeeklyScheduleGroup action;
+  private SetClassWeeklyScheduleGroup action;
 
   @BeforeEach
   void setup() {
     MessageSource messageSource = Mockito.mock(MessageSource.class);
-    action = new SetWeeklyScheduleGroup(messageSource);
+    action = new SetClassWeeklyScheduleGroup(messageSource);
 
     Stream.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
         .forEach(d -> when(messageSource.getMessage(eq("general.week." + d), any(), any())).thenReturn(d));
   }
 
   @ParameterizedTest
-  @MethodSource("org.ilgcc.app.submission.actions.SetWeeklyScheduleGroupTest#consecutiveDaysArgs")
+  @MethodSource("org.ilgcc.app.submission.actions.SetClassWeeklyScheduleGroupTest#consecutiveDaysArgs")
   void shouldShortenConsecutiveDays(List<String> weeklySchedule, String expected) {
     Submission submission = new SubmissionTestBuilder()
         .with("weeklySchedule[]", weeklySchedule)
@@ -42,7 +42,7 @@ class SetWeeklyScheduleGroupTest {
   }
 
   @ParameterizedTest
-  @MethodSource("org.ilgcc.app.submission.actions.SetWeeklyScheduleGroupTest#dispersedDaysArgs")
+  @MethodSource("org.ilgcc.app.submission.actions.SetClassWeeklyScheduleGroupTest#dispersedDaysArgs")
   void shouldListDispersedDays(List<String> weeklySchedule, String expected) {
     Submission submission = new SubmissionTestBuilder()
         .with("weeklySchedule[]", weeklySchedule)
@@ -53,7 +53,7 @@ class SetWeeklyScheduleGroupTest {
   }
 
   @ParameterizedTest
-  @MethodSource("org.ilgcc.app.submission.actions.SetWeeklyScheduleGroupTest#unsortedDays")
+  @MethodSource("org.ilgcc.app.submission.actions.SetClassWeeklyScheduleGroupTest#unsortedDays")
   void shouldSortWeekdays(List<String> weeklySchedule, String expected) {
     Submission submission = new SubmissionTestBuilder()
         .with("weeklySchedule[]", weeklySchedule)

--- a/src/test/java/org/ilgcc/app/utils/Page.java
+++ b/src/test/java/org/ilgcc/app/utils/Page.java
@@ -1,16 +1,15 @@
 package org.ilgcc.app.utils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import io.percy.selenium.Percy;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import io.percy.selenium.Percy;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.RemoteWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class Page {
 
@@ -45,9 +44,7 @@ public class Page {
   public void goBack() {
     driver.findElement(By.partialLinkText("Go Back")).click();
 
-    await().until(
-        () -> !driver.findElements(By.className("main-footer")).get(0).getAttribute("innerHTML")
-            .isBlank());
+    waitForFooterToLoad();
   }
 
   public void clickLink(String linkText) {
@@ -63,9 +60,7 @@ public class Page {
         .orElseThrow(() -> new RuntimeException("No button found containing text: " + buttonText));
     buttonToClick.click();
 
-    await().until(
-        () -> !driver.findElements(By.className("main-footer")).get(0).getAttribute("innerHTML")
-            .isBlank());
+    waitForFooterToLoad();
   }
 
   public void clickButtonLink(String buttonLinkText) {
@@ -77,16 +72,12 @@ public class Page {
             () -> new RuntimeException("No button link found containing text: " + buttonLinkText));
     buttonToClick.click();
 
-    await().until(
-        () -> !driver.findElements(By.className("main-footer")).get(0).getAttribute("innerHTML")
-            .isBlank());
+    waitForFooterToLoad();
   }
 
   public void clickContinue() {
     clickButton("Continue");
-    await().until(
-        () -> !driver.findElements(By.className("main-footer")).get(0).getAttribute("innerHTML")
-            .isBlank());
+    waitForFooterToLoad();
   }
 
   public void enter(String inputName, String value) {
@@ -131,19 +122,11 @@ public class Page {
   }
 
   private void enterInput(WebElement webElement, String input) {
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    String inputType = webElement.getAttribute("type");
-
-    if (!"radio".equals(inputType)) {
-      if ("time".equals(inputType)) {
-        js.executeScript("arguments[0].value = arguments[1];", webElement, input);
-      } else {
-        webElement.clear();
-        webElement.sendKeys(input);
-      }
+    if (!webElement.getAttribute("type").equals(InputTypeHtmlAttribute.radio.toString())) {
+      webElement.clear();
     }
+    webElement.sendKeys(input);
   }
-
 
   public void enterInputById(String inputId, String value) {
     WebElement we = driver.findElement(By.id(inputId));
@@ -171,6 +154,10 @@ public class Page {
         .orElseThrow();
     buttonToClick.click();
 
+    waitForFooterToLoad();
+  }
+
+  private void waitForFooterToLoad() {
     await().until(
         () -> !driver.findElements(By.className("main-footer")).get(0).getAttribute("innerHTML")
             .isBlank());


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
PT#186822687

#### ✍️ Description
new screens:
- activities-partner-add-ed-program screen
- activities-partner-ed-program-type screen
- activities-partner-ed-program-name screen
- activities-partner-ed-program-info screen
- activities-partner-ed-program-method screen
- activities-partner-next-class-schedule screen
- activities-partner-class-weekly-schedule screen
- activities-partner-class-hourly-schedule screen
- activities-partner-ed-program-dates screen

Refactoring
- extracted duplicate 
- added/updated some validations

#### 📷 Design reference
[Figma link](https://www.figma.com/file/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?type=design&node-id=487-23426&mode=design&t=9iAwAyb6IeEkuqnn-0)

This is the parent education section, the secondary parent is the same except for the copy referring to the partner instead of the primary parent
<img width="600" alt="Screenshot 2024-04-03 at 12 29 24 PM" src="https://github.com/codeforamerica/il-gcc-form-flow/assets/72890349/406bb2a7-74d6-4cfa-accd-8ae01f3489c0">


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria
