### PR TITLE
Added conditional logic to only navigate to add jobs if client select…

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -1,6 +1,7 @@
 package org.ilgcc.app.inputs;
 
 import formflow.library.data.FlowInputs;
+import formflow.library.data.annotations.Phone;
 import formflow.library.utils.RegexUtils;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -212,12 +213,12 @@ public class Gcc extends FlowInputs {
     private String activitiesParentPartnerChildcareReason_other;
     @NotBlank(message = "{errors.require-company-name}")
     private String companyName;
-
+    @Phone(message = "{errors.invalid-phone-number}")
     private String employerPhoneNumber;
     private String employerStreetAddress;
     private String employerCity;
     private String employerState;
-    @Pattern(regexp = "^\\d{5,}$", message = "{activities-ed-program-info.validationMessage}")
+    @Pattern(regexp = "^\\d{5,}$", message = "{errors.invalid-zipcode}")
     private String employerZipCode;
 
     private String isSelfEmployed;

--- a/src/main/java/org/ilgcc/app/submission/conditions/WorkingIsOneReasonForChildcareNeed.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/WorkingIsOneReasonForChildcareNeed.java
@@ -1,0 +1,21 @@
+package org.ilgcc.app.submission.conditions;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkingIsOneReasonForChildcareNeed implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    List<String> reasonsForChildcareNeed = (List<String>) submission.getInputData()
+        .getOrDefault("activitiesParentChildcareReason[]", emptyList());
+    return reasonsForChildcareNeed.contains("WORKING");
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -148,6 +148,8 @@ flow:
   activities-parent-type:
     nextScreens:
       - name: activities-add-jobs
+        condition: WorkingIsOneReasonForChildcareNeed
+      - name: activities-add-ed-program
   activities-add-jobs:
     subflow: jobs
     nextScreens:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -86,6 +86,7 @@ errors.invalid-phone-number=Make sure the phone number you entered includes 9 di
 errors.invalid-email=Make sure the email you entered follows the right format.
 errors.require-email=Please provide an email address.
 errors.require-company-name=Please provide an employer name or a profession.
+errors.invalid-zipcode=Make sure the zip code you entered follows the right format.
 #
 index.title=Get help paying for child care.
 index.notice-html=Our new online application is currently available to families using child care centers in DeKalb County, Illinois. <a rel="noopener nofollow" target="_blank" href="https://www.illinoiscaresforkids.org/toddler-en/early-care-and-education/child-care-assistance-program">Check with your local resource agency or daycare</a> for more information.

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -216,11 +216,16 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
     //activities-parent-type
     assertThat(testPage.getTitle()).isEqualTo("Activities Parent Type");
-    testPage.clickElementById("activitiesParentChildcareReason-WORKING");
     testPage.clickElementById("activitiesParentChildcareReason-other");
     testPage.enter("activitiesParentChildcareReason_other", "test");
     testPage.clickElementById("activitiesParentPartnerChildcareReason-TANF_TRAINING");
     testPage.clickElementById("activitiesParentPartnerChildcareReason-LOOKING_FOR_WORK");
+    testPage.clickContinue();
+    //activities-add-ed-program (client should be directed to this page if working is not checked)
+    assertThat(testPage.getTitle()).isEqualTo("Tell us about your school or training program.");
+    testPage.goBack();
+    assertThat(testPage.getTitle()).isEqualTo("Activities Parent Type");
+    testPage.clickElementById("activitiesParentChildcareReason-WORKING");
     testPage.clickContinue();
     //activities-add-jobs
     assertThat(testPage.getTitle()).isEqualTo("Activities Add Jobs");
@@ -231,9 +236,16 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
     //activities-employer-address
     assertThat(testPage.getTitle()).isEqualTo("Activities Employer Address");
-    testPage.enter("employerPhoneNumber", "333333333");
+    testPage.enter("employerPhoneNumber", "3333333");
+    testPage.clickContinue();
+    //activities-employer-address page should have an error for invalid phone number
+    assertThat(testPage.getFirstInputError()).isEqualTo("Make sure the phone number you entered includes 9 digits.");
+    testPage.enter("employerPhoneNumber", "3333333333");
     testPage.enter("employerCity", "Chicago");
     testPage.enter("employerStreetAddress", "123 Test Me");
+    testPage.enter("employerZipCode", "6042");
+    testPage.clickContinue();
+    assertThat(testPage.getFirstInputError()).isEqualTo("Make sure the zip code you entered follows the right format.");//
     testPage.enter("employerZipCode", "60423");
     testPage.clickContinue();
     //activities-self-employment

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -237,15 +237,13 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     //activities-employer-address
     assertThat(testPage.getTitle()).isEqualTo("Activities Employer Address");
     testPage.enter("employerPhoneNumber", "3333333");
-    testPage.clickContinue();
-    //activities-employer-address page should have an error for invalid phone number
-    assertThat(testPage.getFirstInputError()).isEqualTo("Make sure the phone number you entered includes 9 digits.");
-    testPage.enter("employerPhoneNumber", "3333333333");
     testPage.enter("employerCity", "Chicago");
     testPage.enter("employerStreetAddress", "123 Test Me");
     testPage.enter("employerZipCode", "6042");
     testPage.clickContinue();
-    assertThat(testPage.getFirstInputError()).isEqualTo("Make sure the zip code you entered follows the right format.");//
+    assertThat(testPage.hasErrorText("Make sure the phone number you entered includes 9 digits.")).isTrue();
+    assertThat(testPage.hasErrorText("Make sure the zip code you entered follows the right format.")).isTrue();
+    testPage.enter("employerPhoneNumber", "3333333333");
     testPage.enter("employerZipCode", "60423");
     testPage.clickContinue();
     //activities-self-employment


### PR DESCRIPTION
#### 🔗 Pivotal Tracker ticket
[#186714156](https://www.pivotaltracker.com/story/show/186714156)

#### ✍️ Description
1.  The jobs subflow and all screens within it are only shown to clients if the client indicates that one reason they need care is that the primary parent is "Working" on the activities-parent-type screen
2.  Added phone and zipcode validations to match figma

#### 📷 Design reference

![image](https://github.com/codeforamerica/il-gcc-form-flow/assets/46062709/d4f54ed3-1261-4559-bec6-c86f6ca906e6)


#### ✅ Completion tasks


- [ x ] Added relevant tests
- [ ] Meets acceptance criteria
