### PR TITLE
Ccap 104 fix home page download pdf link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-#### 🔗 Pivotal Tracker ticket
-<!-- Add link to the issue ex. PT#1234 -->
+#### 🔗 Jira ticket
+<!-- Add link to the issue -->
 
 #### ✍️ Description
 <!-- Brief summary of changes  -->

--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -2,7 +2,5 @@ groups:
   - name: devs # name of the group
     internal_reviewers: 1 # how many reviewers do you want to assign when the PR author belongs to this group?
     usernames: # github usernames of the reviewers
-#      - guiburato
-#      - coltborg
+      - coltborg
       - enyia21
-#      - sree-cfa

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,4 +1,4 @@
-demo.banner-text=<b>EXAMPLE SITE: Do not enter any personal information. </b>(<a href={0}>download PDF</a>)
+demo.banner-text=<b>EXAMPLE SITE: Do not enter any personal information. </b><a href={0}>download PDF</a>
 general.skip-to-content=Skip to content
 general.skip=Skip
 general.indicates-required=* Indicates required fields

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -1,4 +1,4 @@
-demo.banner-text=<b>EXAMPLE SITE: Do not enter any personal information. </b>(<a href={0}>download PDF</a>)
+demo.banner-text=<b>EXAMPLE SITE: Do not enter any personal information. </b><a href={0}>download PDF</a>
 general.skip-to-content=Saltar al contenido
 general.skip=Omitir
 general.indicates-required=* Requerido

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -386,3 +386,7 @@ input[name$="Address2"] {
   background-color: #F7F5F4;
   box-shadow: inset 0px 2px 0px rgba(0, 0, 0, 0.15)
 }
+
+.demo-banner a[href="#"] {
+  display: none;
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-104](https://codeforamerica.atlassian.net/browse/CCAP-104)

#### ✍️ Description
- Hide link to "download PDF" if you can't download a PDF (when `href="#"`)
- Clean up GitHub usernames
- Clean up pull request template to say Jira instead of PT
- Test out Jira integration

[CCAP-104]: https://codeforamerica.atlassian.net/browse/CCAP-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ