### PR TITLE
Clear SPRING_PROFILES_ACTIVE in sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -21,7 +21,7 @@
 # Values are `dev` and unset. Leaving this unset implies we are operating in a cloud / docker
 # environment, where we will pull the form-flow library jar in it's publish version.
 # If set to `dev` we will use the locally compiled form-flow library as specified in the build.gradle file.
-SPRING_PROFILES_ACTIVE=dev
+SPRING_PROFILES_ACTIVE=
 
 #######################################################################################
 # Cloud repository configuration


### PR DESCRIPTION
#### 🔗 Jira ticket
N/A

#### ✍️ Description
Clear `SPRING_PROFILES_ACTIVE` env variable in sample.env. This means that Form Flow will be pulled from Maven instead of being built locally.

#### 📷 Design reference
N/A

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [N/A] Added relevant tests
- [N/A] Meets acceptance criteria
