### PR TITLE
CCAP-120 Fix phone number validation for parent and parent partner

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -44,7 +44,7 @@ public class Gcc extends FlowInputs {
     private String parentHomeState;
     @NotBlank(message = "{errors.provide-zip}")
     private String parentHomeZipCode;
-    @Length(min = 9, message = "{errors.invalid-phone-number}")
+    @Phone(message = "{errors.invalid-phone-number}")
     private String parentContactPhoneNumber;
     @Email(regexp = RegexUtils.EMAIL_REGEX, message = "{errors.invalid-email}")
     private String parentContactEmail;
@@ -67,7 +67,7 @@ public class Gcc extends FlowInputs {
     private String parentSpouseShareChildren;
     @NotBlank(message = "{errors.require-yes-no}")
     private String parentSpouseLiveTogether;
-    @Length(min = 9, message = "{errors.invalid-phone-number}")
+    @Phone(message="{errors.invalid-phone-number}")
     private String parentPartnerPhoneNumber;
     @Email(regexp = RegexUtils.EMAIL_REGEX, message = "{errors.invalid-email}")
     private String parentPartnerEmail;


### PR DESCRIPTION
#### 🔗 Jira ticket
[<!-- Add link to the issue -->](https://codeforamerica.atlassian.net/browse/CCAP-120)

#### ✍️ Description
Parent and Parent Partner phone number validation was based on having a minimum of 9 digits. Now it's based on the Phone number annotation.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
Start an application
on page "flow/gcc/parent-contact" 
- leave it blank, confirm you can move forward
- add an incomplete number and confirm you can't move forward
- add 10 digits and confirm you can move forward

Add a partner
on page gcc/parent-partner-contact
- leave it blank, confirm you can move forward
- add an incomplete number and confirm you can't move forward
- add 10 digits and confirm you can move forward


- [ ] Added relevant tests
- [ ] Meets acceptance criteria
