### PR TITLE
CCAP-41 Show submittedAt in Central Time

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/FormatSubmittedAtDate.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FormatSubmittedAtDate.java
@@ -4,7 +4,8 @@ import formflow.library.config.submission.Action;
 import formflow.library.data.Submission;
 import org.springframework.stereotype.Component;
 
-import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Component
@@ -15,7 +16,8 @@ public class FormatSubmittedAtDate implements Action {
 
     @Override
     public void run(Submission submission) {
-        OffsetDateTime submittedAt = submission.getSubmittedAt();
+        ZoneId chicagoTimeZone = ZoneId.of("America/Chicago");
+        ZonedDateTime submittedAt = submission.getSubmittedAt().atZoneSameInstant(chicagoTimeZone);
 
         if (submittedAt != null) {
             String formattedSubmittedAtDate = submittedAt.format(DATE_FORMAT);

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -320,7 +320,7 @@ flow:
       - name: doc-upload-add-files
   doc-upload-add-files:
     nextScreens:
-      - name: doc-upload-confirm
+      - name: doc-upload-submit-confirmation
   doc-upload-confirm:
     nextScreens: null
   children-delete:

--- a/src/main/resources/templates/fragments/mixpanelTracking.html
+++ b/src/main/resources/templates/fragments/mixpanelTracking.html
@@ -87,8 +87,6 @@
         }
 
         if (elementDataMixpanel === 'download-pdf') {
-            console.log("Mixpanel!");
-            console.log($(this));
             mixpanel.track('download_application_pdf', {
                 'app_language': htmlLang,
                 'submission_id': submissionId,

--- a/src/test/java/org/ilgcc/app/submission/actions/FormatSubmittedAtDateTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/FormatSubmittedAtDateTest.java
@@ -1,0 +1,35 @@
+package org.ilgcc.app.submission.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import formflow.library.data.Submission;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+
+public class FormatSubmittedAtDateTest {
+    private final FormatSubmittedAtDate action = new FormatSubmittedAtDate();
+
+    @Test
+    public void shouldShowDateTimeInCentralTime() {
+        String testTime = "2024-05-13T22:05:06+00:00";
+        OffsetDateTime parsedTestTime = OffsetDateTime.parse(testTime);
+
+        ZoneId chicagoTimeZone = ZoneId.of("America/Chicago");
+        OffsetDateTime chicagoTime = parsedTestTime.atZoneSameInstant(chicagoTimeZone).toOffsetDateTime();
+        chicagoTime.format(DateTimeFormatter.ofPattern("hh:mm A"));
+
+        Submission submission = Submission.builder()
+                .urlParams(new HashMap<>()).inputData(new HashMap<>()).submittedAt(parsedTestTime).build();
+
+        action.run(submission);
+
+        String expectedDate = "05/13/2024";
+        String expectedTime = "5:05 PM";
+        assertThat(submission.getInputData().get("formattedSubmittedAtDate")).isEqualTo(expectedDate);
+        assertThat(submission.getInputData().get("formattedSubmittedAtTime")).isEqualTo(expectedTime);
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-41](https://codeforamerica.atlassian.net/browse/CCAP-41)

#### ✍️ Description
- Always display submitted at time in the time zone `America/Chicago` (this handles standard and daylight time)
- Add a test to check that GMT shows as CT

[CCAP-41]: https://codeforamerica.atlassian.net/browse/CCAP-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ