### PR TITLE
Ccap 35 implement file upload functionality

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ form-flow:
   encryption-key: '{"primaryKeyId":2135185311,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.AesGcmKey","value":"GiCRKaXiJ/zlDHAZfRQf1rCIbIY4fFmLqLWYIPLNXpOx4A==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":2135185311,"outputPrefixType":"TINK"}]}"'
   inputs: 'org.ilgcc.app.inputs.'
   uploads:
-    accepted-file-types: '.jpeg,.jpg,.png,.pdf,.bmp,.gif,.doc,.docx,.odt,.ods,.odp'
+    accepted-file-types: '.pdf, .jpg, .png, .avif, .heic, .docx, .pptx, .xlsx'
     thumbnail-width: '64'
     thumbnail-height: '60'
     # 20 files maximum
@@ -24,7 +24,7 @@ form-flow:
     # 20 MB file size limit
     # If this is not set then the server values below for servlet max-file-size and tomcat max POST size will not be set
     # which will cause the server to use the default values of 1MB preventing uploads larger than that.
-    max-file-size: '20'
+    max-file-size: '10'
     virus-scanning:
       enabled: false
       service-url: ${CLAMAV_URL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ form-flow:
   encryption-key: '{"primaryKeyId":2135185311,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.AesGcmKey","value":"GiCRKaXiJ/zlDHAZfRQf1rCIbIY4fFmLqLWYIPLNXpOx4A==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":2135185311,"outputPrefixType":"TINK"}]}"'
   inputs: 'org.ilgcc.app.inputs.'
   uploads:
-    accepted-file-types: '.pdf, .jpg, .png, .avif, .heic, .docx, .pptx, .xlsx'
+    accepted-file-types: '.pdf,.jpg,.png,.avif,.heic,.docx,.pptx,.xlsx'
     thumbnail-width: '64'
     thumbnail-height: '60'
     # 20 files maximum

--- a/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
@@ -205,6 +205,11 @@
       filesToDelete.forEach(fTD => {
         if (fTD.name === file.name) {
           removeFileFromDropzone(file, id);
+          mixpanel.track('delete_file_when_cancel_is_clicked', {
+            'page_name': window.location.pathname,
+            'file_size': file.size,
+            'file_format': file.type
+          });
           sendDeleteXhrRequest(id);
           window['cancelledFiles' + [[${inputName}]]] =
               window['cancelledFiles' + [[${inputName}]]]
@@ -290,6 +295,11 @@
               + fileNameComponents[0] + "</span>" +
               "<span class='filename-text-ext' aria-hidden='true'>" + fileNameComponents[1]
               + "</span>";
+          mixpanel.track('initiate_file_upload', {
+            'page_name': window.location.pathname,
+            'file_format': file.type,
+            'file_size': file.size
+          });
 
           removeLink.onclick = destroyerCreator(file);
           removeLink.innerText = [[#{general.cancel}]].toLowerCase();
@@ -353,12 +363,23 @@
           window['userFileIds' + [[${inputName}]]].push(id);
           updateFileInputValue();
 
+          mixpanel.track('file_upload_success', {
+            'page_name': window.location.pathname,
+            'file_size': file.size,
+            'file_format': file.type
+          });
+
           removeLink.onclick = function () {
             let confirmation = confirm(
                 [[#{general.files.confirm-delete}]] + fileName + '. '
                 + [[#{general.files.confirm-delete-ok}]])
             if (confirmation) {
               sendDeleteXhrRequest(id, [[${flow}]]);
+              mixpanel.track('delete_file_when_delete_clicked', {
+                'page_name': window.location.pathname,
+                'file_size': file.size,
+                'file_format': file.type
+              });
               removeFileFromDropzone(file, id);
             }
           }
@@ -423,7 +444,12 @@
         }
 
         showNumberOfAddedFiles();
-
+        mixpanel.track('file_upload_fail', {
+          'page_name': window.location.pathname,
+          'file_size': file.size,
+          'file_format': file.type,
+          'reason': errorMessage
+        });
         file.previewElement.classList.add("form-group--error");
 
         var removeLink = file.previewElement.getElementsByClassName("dz-remove")[0];

--- a/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
@@ -1,0 +1,445 @@
+<th:block
+    th:fragment="fileUploader"
+    th:assert="${!#strings.isEmpty(inputName)}">
+  <div th:id="${'dropzone-' + inputName}">
+    <div class="dropzone needsclick" th:id="${'document-upload-' + inputName}">
+      <div th:id="${'max-files-reached-' + inputName}">
+        <div class='max-files spacing-below-35 display-none' id="max-files"
+             th:text='#{upload-documents.error-maximum-number-of-files}'></div>
+      </div>
+      <div th:id="${'drag-and-drop-box-' + inputName}"
+           class="drag-and-drop-box spacing-below-35 spacing-above-35 grid"
+           ondragenter="addDragBorder()" ondrop="removeDragBorder()"
+           ondragleave="removeDragBorder()">
+        <h2 th:id="${'vertical-header-desktop-' + inputName}"
+            class="blue-label text--centered hide-on-mobile narrow-centered-text"
+            th:text="#{general.files.add-your-files}"></h2>
+        <h2 th:id="${'vertical-header-mobile-' + inputName}"
+            class="blue-label text--centered hide-on-desktop"
+            th:text="#{general.files.add-your-files}"></h2>
+        <div th:id="${'upload-button-' + inputName}" class="dz-message text--centered">
+          <button th:aria-label="#{general.files.add-your-files}" type="button"
+                  th:id="${'upload-button-inner-' + inputName}"
+                  class="button dz-button upload-button-inner">
+            <svg xmlns="http://www.w3.org/2000/svg" height="60px" viewBox="0 0 24 24"
+                 width="60px" fill="#FFFFFF">
+              <path d="M0 0h24v24H0V0z" fill="none"/>
+              <path stroke="white" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+            </svg>
+          </button>
+        </div>
+        <div class="grid--item width-two-thirds">
+          <h2 th:id="${'horizontal-header-desktop-' + inputName}"
+              class="blue-label hide-on-mobile hidden spacing-below-5"
+              th:text="#{general.files.add-your-files}"></h2>
+          <h2 th:id="${'horizontal-header-mobile-' + inputName}"
+              class="blue-label hide-on-desktop hidden spacing-below-5 spacing-above-15"
+              th:text="#{general.files.add-your-files}"></h2>
+          <div th:id="${'number-of-uploaded-files-' + inputName}" class="body-gray">
+          </div>
+        </div>
+      </div>
+      <div th:id="${'upload-doc-div-' + inputName}" class="spacing-below-25 hidden">
+        <p th:id="${'upload-doc-text-' + inputName}" class="upload-doc-text"
+           th:text="#{general.files.uploaded-documents}"></p>
+      </div>
+      <div th:id="${'file-preview-template-' + inputName}" class="file-preview-template">
+        <div class="preview-container"></div>
+      </div>
+    </div>
+  </div>
+  <input type="hidden" th:name="${inputName}">
+  <script src="/webjars/dropzone/5.9.3/dist/min/dropzone.min.js"></script>
+  <script th:inline="javascript">
+    Dropzone.autoDiscover = false;
+    window.dropzonePrefix = 'myDropZone';
+    window['documentIcon'
+    + [[${inputName}]]] = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABGCAYAAACE0Gk0AAAFK0lEQVR4Xu2caVcTSRSG314SyEJQPIAsMucoihDmzJE1BBhnEZ35xzPjmU9ABAR/AThnFBBQQciedLrn3Epaw6Z9OxsTqr7kQ25XVz31VtWt5baSTiYsyOSIgCJhOeIkjCQs56wkLAYrCasusFKpFF5vbmJ/7x1My4KmqZz3VmRr5A3oHh3DI6Po6e2tKC/Ow67GrJOTE7xaX8PB/gG8Xi8URYFl1XNStZDNZtF+4yamIzO42dHBqbNrWzasbDaDtZUV7GxvIxgMNgAUTUsALCCRSKCzsxMzc3Pw+wOuITh9kA3r9dYmNtZforW1FaqiflEUVaDWqUy8pGbTMpGIx3Fn4DtEorPQdb2mJWDDii0t4mB/Dx6Pt85dj8RkQRGyKiYCZhQMpJJJDN5/gPHJKahq7cZONqznf/6BZCLxuRXtAmfS6RK8WknMgq57hKLLk6KqyGbSSKfTGJuYxPBIuGbqqggWtbRlWtB0HT6fT7RqoVCAUgNeiqLCMPLIZDJFVdkKUyDeSw1Ik8zM7JzolrVIbFh/P/8L8ZMTMXWbBRPpdAq9fX2YikTR0tKCXC5X1lGqV2RN17C3t4dX6y9Fg2iq9iVzhbqkKsrl8/sQnZ1HZ1dX9V5ud3vu2vAsrFQqKVoyOjcvxpBapg8f3mM1FoNhGNC0Mlil8YuUTgN+e/sNROfnxW81U0XKskwTyWRRWSR/j8dTzbKdy+vd7i421tdQMArnYJX6JqhMx8fH6OnpxeyPj8+NcZUUsCqw+vr7EIleAVglheXzOcTjcTwYeojpmWglfE5PJpV0Q1tZVwmWGPxphsxmQDP0D4/GEB79virAmk5ZdncUM2QyiVw2i8npiFBZpak5YRV9C+FSHH/6JFyK+cc/487AQEW8mhdWGbCjw0PhB/70yxN03LrlGlhzwyqNX+TRHH78KECRwtra2lwBa3pYREXViisL6pL9dwYQmYmi1edjA7sWsGxg+XweiXgC94eG8GhsnO0XXhtYtkuRz+VAftjDkTBGwqMXO7eXaO5awRLAFEXAorXkcDjMcimuHSzbDyP/K9TejidPf3M8dv2vYO3u7mBjbRXGZWvDr1T77KYgLcYDwQAWnv3enLBo33/1xTILFjmk1PW8Xg9UVfu8u0uw2kIh/LrwtDlhHR0d4p+tLZimKdZ/ThJt5ZDb8P5gX6wVaaOSNg6bHlY5HKdHb+JgwyxgeXFRnEgFAn4Bms4em1pZTpR0kQ2paCW2jO23b8SRGTmpEtYlNMkZXYktYWd7RyrrW4qTsL5FqOx/CUvCYhBgmEplSVgMAgxTqSwJi0GAYSqVJWExCDBMpbIkLAYBhqlUloTFIMAwlcqSsBgEGKZSWRIWgwDDVCpLwmIQYJhKZUlYDAIMU6ksCYtBgGF6pZRVrwgLBp9TpgTrxfISdncaeMhKgU71jN1xC4vuRVCc5Ns3/zbu+L6eUWFuQFHgK8VwUzz12kpMKMvn89fvrkN5cGY94w1dwbIg7ozSFSUK3iwYBhSVLhwVrxwFgkEsPKvhzb/GRbK6wUXPFC+z0VVuXdNPXWarOaxGxki7xXX2OfsSblf3bREn6TSx75Q2NPreaa0usitF7ttR+xQ+PD4xibv3Bh3nyoZ1Jb7r4Lh6pw3tj3XQ9yD6+vsxFYmgpeV0gPrXsmbDoswa/8UQPi0bFMVwd3V3YWxiCqFQiJWRK1j0hkZ+i4ZVw5JxoWBCVRR03+7B3cFB+P1+djauYbHf1AQPSFiMRpSwJCwGAYbpf7oLq5uJEmkZAAAAAElFTkSuQmCC";
+    window['isUploadComplete' + [[${inputName}]]] = true;
+    window['fileTooBigMsg' + [[${inputName}]]] = [[#{upload-documents.this-file-is-too-large(20)}]];
+    window['myDropZone' + [[${inputName}]]] = null;
+    window['userFileIds' + [[${inputName}]]] = [];
+    window['cancelledFiles' + [[${inputName}]]] = [];
+    var userFiles = [[${session.userFiles}]] != null ? JSON.parse([[${session.userFiles}]]) : null;
+    var thumbnailWidthFromAppYml = [[${@environment.getProperty('form-flow.uploads.thumbnail-width')}]];
+    var thumbnailHeightFromAppYml = [[${@environment.getProperty('form-flow.uploads.thumbnail-height')}]];
+    var thumbnailWidth = thumbnailWidthFromAppYml ? thumbnailWidthFromAppYml : '64';
+    var thumbnailHeight = thumbnailHeightFromAppYml ? thumbnailHeightFromAppYml : '60';
+    var maxFilesFromAppYaml = [[${@environment.getProperty('form-flow.uploads.max-files')}]];
+    var maxFiles = maxFilesFromAppYaml ? maxFilesFromAppYaml : 20;
+    var maxFileSize = Number(
+        [[${@environment.getProperty('form-flow.uploads.max-file-size')}]]);
+
+    function addDragBorder() {
+      var dragAndDropBox = document.getElementById("drag-and-drop-box-" + [[${inputName}]]);
+      dragAndDropBox.classList.add("drag-over");
+    }
+
+    function removeDragBorder() {
+      var dragAndDropBox = document.getElementById("drag-and-drop-box-" + [[${inputName}]]);
+      dragAndDropBox.classList.remove("drag-over");
+    }
+
+    function getFilenameComponents(element) {
+      var name = element.innerText;
+      var extIdx = name.lastIndexOf('.');
+      if (extIdx === -1) {
+        return [name, ""];
+      }
+
+      var extStr = name.slice(extIdx, name.length);
+      return [name.slice(0, extIdx), extStr];
+    }
+
+    function onSubmit() {
+      if (!window['isUploadComplete' + [[${inputName}]]]) {
+        $('.form-group').addClass('form-group--error');
+        $('.text--error').show();
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    function toggleMaxFileMessage(state) {
+      if (state === 'on') {
+        $(document.getElementById("max-files")).addClass("display-flex").removeClass(
+            "display-none");
+      } else {
+        $(document.getElementById("max-files")).addClass("display-none").removeClass(
+            "display-flex");
+      }
+    }
+
+    $('.text--error').hide();
+
+    function destroyerCreator(file) {
+      return function () {
+        window[dropzonePrefix + [[${inputName}]]].emit('addFileToBeDestroyed', file);
+      }
+    }
+
+    function removeCreator(file) {
+      return function () {
+        removeFileFromDropzone(file);
+      }
+    }
+
+    function processDZQueueAfterThumbnailGeneration() {
+      var allUploadsHaveThumbnails = window[dropzonePrefix + [[${inputName}]]]
+      .getQueuedFiles()
+      .every(f => f.dataURL && f.dataURL.length > 0);
+      if (allUploadsHaveThumbnails) {
+        window[dropzonePrefix + [[${inputName}]]].processQueue();
+      }
+    }
+
+    function showNumberOfAddedFiles() {
+      var numberOfAddedFiles = window[dropzonePrefix + [[${inputName}]]].files.length;
+      var numberOfAddedFilesDiv = document.getElementById(
+          "number-of-uploaded-files-" + [[${inputName}]]);
+      var numberOfUploadsString = numberOfAddedFiles === 1 ? [[#{general.files.file-added.one}]]
+          : `${numberOfAddedFiles} ` + [[#{general.files.file-added.other}]];
+      numberOfAddedFilesDiv.innerHTML = numberOfUploadsString;
+    }
+
+    function setDefaultThumbnail(file) {
+      file.dataURL = window['documentIcon' + [[${inputName}]]];
+      window[dropzonePrefix + [[${inputName}]]].emit("thumbnail", file,
+          window['documentIcon' + [[${inputName}]]]);
+    }
+
+    function prependAddedFile() {
+      var $previewsContainer = $(
+          [[${'#document-upload-' + inputName}]] + ' .preview-container')[0];
+      var $previews = $([[${'#document-upload-' + inputName}]] + ' .dz-preview');
+      var $lastPreviewInList = $previews[$previews.length - 1];
+      $previewsContainer.prepend($lastPreviewInList);
+    }
+
+    function updateUploadBoxLayout() {
+      var $dragAndDropBox = $('#drag-and-drop-box-' + [[${inputName}]]);
+      var $horizontalHeaderDesktop = $('#horizontal-header-desktop-' + [[${inputName}]]);
+      var $horizontalHeaderMobile = $('#horizontal-header-mobile-' + [[${inputName}]]);
+      var $verticalHeaderDesktop = $('#vertical-header-desktop-' + [[${inputName}]]);
+      var $verticalHeaderMobile = $('#vertical-header-mobile-' + [[${inputName}]]);
+      var $uploadButton = $('#upload-button-' + [[${inputName}]]);
+
+      $horizontalHeaderDesktop.removeClass('hidden');
+      $horizontalHeaderMobile.removeClass('hidden');
+      $verticalHeaderDesktop.addClass('hidden');
+      $verticalHeaderMobile.addClass('hidden');
+      $uploadButton.addClass('grid--item width-one-third');
+      $dragAndDropBox.addClass('drag-and-drop-box-compact');
+    }
+
+    function showUploadListHeaderOnUpload() {
+      var $uploadDocHeaderDiv = $('#upload-doc-div-' + [[${inputName}]]);
+      $uploadDocHeaderDiv.removeClass("hidden");
+    }
+
+    function updateFileInputValue() {
+      var inputEl = document.querySelector('input[name=' + [[${inputName}]] + ']');
+      inputEl.value = JSON.stringify(window['userFileIds' + [[${inputName}]]]);
+    }
+
+    function removeFileFromDropzone(file, id) {
+      window[dropzonePrefix + [[${inputName}]]].removeFile(file);
+      if (id) {
+        let toDeleteIdx = window['userFileIds' + [[${inputName}]]].indexOf(id);
+        if (toDeleteIdx !== -1) {
+          window['userFileIds' + [[${inputName}]]].splice(toDeleteIdx, 1)
+        }
+      }
+      updateFileInputValue();
+      showNumberOfAddedFiles();
+
+      if (window['myDropZone' + [[${inputName}]]].files.length <= window['myDropZone'
+      + [[${inputName}]]].options.maxFiles) {
+        toggleMaxFileMessage('off');
+      }
+    }
+
+    function deleteCancelledFiles(file, id) {
+      let filesToDelete = window['cancelledFiles' + [[${inputName}]]];
+      filesToDelete.forEach(fTD => {
+        if (fTD.name === file.name) {
+          removeFileFromDropzone(file, id);
+          sendDeleteXhrRequest(id);
+          window['cancelledFiles' + [[${inputName}]]] =
+              window['cancelledFiles' + [[${inputName}]]]
+              .filter(cancelledFile => cancelledFile.name !== file.name);
+        }
+      });
+    }
+
+    function sendDeleteXhrRequest(id, flow) {
+      var xhrRequest = new XMLHttpRequest();
+      xhrRequest.open('POST',
+          '/file-delete?' + id + '&returnPath=' + window.location.pathname + '&inputName='
+          + [[${inputName}]] + '&flow=' + flow, true);
+      xhrRequest.withCredentials = false;
+      xhrRequest.setRequestHeader("Accept", "*/*");
+      xhrRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+      var csrfToken = [[${_csrf.token}]];
+      var formData = new FormData();
+      formData.append("_csrf", csrfToken);
+      formData.append("id", id);
+      xhrRequest.send(formData);
+    }
+
+    $("#document-upload-" + [[${inputName}]]).dropzone({
+      url: "/file-upload",
+      uploadMultiple: false,
+      previewsContainer: [[${'#document-upload-' + inputName}]] + " .preview-container",
+      autoProcessQueue: false,
+      thumbnailMethod: "crop",
+      thumbnailWidth: thumbnailWidth,
+      thumbnailHeight: thumbnailHeight,
+      maxFiles: maxFiles,
+      parallelUploads: 1,
+      timeout: 30000,
+      maxFilesize: maxFileSize,
+      dictFileTooBig: [[#{upload-documents.this-file-is-too-large(0)}]].toString().replace("0",
+          maxFileSize),
+      dictMaxFilesExceeded: [[#{upload-documents.error-maximum-number-of-files}]],
+      dictInvalidFileType: [[#{upload-documents.error-invalid-file-type}]]
+          + ' '
+          + [[${acceptedFileTypes}]],
+      acceptedFiles: [[${acceptedFileTypes}]],
+      clickable: ".drag-and-drop-box",
+      previewTemplate: `
+            <div class="dz-preview dz-file-preview spacing-below-15">
+              <div class="dz-details display-flex">
+                <div class="thumbnail" style="width: ${thumbnailWidth}px; height: ${thumbnailHeight}px;">
+                    <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
+                    <img class="dz-thumb" data-dz-thumbnail aria-hidden="true" />
+                </div>
+                <div class="file">
+                    <div class="dz-filename"><div class="filename-text" data-dz-name></div></div>
+                    <div class="display-flex body-gray file-details">
+                        <div class="dz-size" data-dz-size></div>
+                        <span class="file-details-delimiter" aria-hidden="true">•</span>
+                        <a class="dz-remove" href="javascript:undefined;" ></a>
+                    </div>
+                </div>
+              </div>
+              <p class='text--error spacing-above-0' aria-live="assertive" aria-atomic="true"></p>
+            </div>`,
+      init: function () {
+        window[dropzonePrefix + [[${inputName}]]] = this;
+        var dzInstance = [[${inputName}]]
+        var flow = [[${flow}]]
+        var documents = userFiles?.userFileMap?.[flow]?.[dzInstance] || [];
+
+        if (documents != null && Object.entries(documents).length > this.options.maxFiles) {
+          toggleMaxFileMessage('on');
+        }
+
+        this.on('addedfile', function (file) {
+          if (window[dropzonePrefix + [[${inputName}]]].files.length
+              >= window[dropzonePrefix + [[${inputName}]]].options.maxFiles) {
+            toggleMaxFileMessage('on');
+          }
+          var fileNameSpan = file.previewElement.getElementsByClassName('filename-text')[0];
+          var fileNameComponents = getFilenameComponents(fileNameSpan);
+          var removeLink = file.previewElement.getElementsByClassName("dz-remove")[0];
+          var thumbnail = file.previewElement.getElementsByClassName("dz-thumb")[0];
+          fileNameSpan.setAttribute('aria-label', fileNameSpan.innerText);
+          fileNameSpan.innerHTML = "<span class='filename-text-name' aria-hidden='true'>"
+              + fileNameComponents[0] + "</span>" +
+              "<span class='filename-text-ext' aria-hidden='true'>" + fileNameComponents[1]
+              + "</span>";
+
+          removeLink.onclick = destroyerCreator(file);
+          removeLink.innerText = [[#{general.cancel}]].toLowerCase();
+          thumbnail.classList.add("hidden");
+          window['isUploadComplete' + [[${inputName}]]] = false;
+          if (file.type.includes('heic')) {
+            window[dropzonePrefix + [[${inputName}]]].emit("error", file,
+                [[#{upload-documents.error-heic}]]);
+          }
+          if (file.type.includes('tif') || file.type.includes('tiff')) {
+            window[dropzonePrefix + [[${inputName}]]].emit("error", file,
+                [[#{upload-documents.error-tiff}]]);
+          }
+          if (!file.type.includes("image")) {
+            setDefaultThumbnail(file);
+          }
+          if (file.type.includes("image") && file.size / 1024 / 1024 >= 10) {
+            setDefaultThumbnail(file)
+          }
+
+          $('#submit-my-documents-' + [[${inputName}]]).removeClass('hidden');
+          showNumberOfAddedFiles();
+          prependAddedFile();
+          updateUploadBoxLayout();
+          showUploadListHeaderOnUpload();
+        });
+
+        this.on("thumbnail", function (file, dataUrl) {
+          file.dataURL = dataUrl;
+          setTimeout(function () {
+            processDZQueueAfterThumbnailGeneration()
+          }, 1);
+        });
+
+        this.on("sending", function (file, xhr, formData) {
+          var csrfToken = [[${_csrf.token}]];
+          formData.append("_csrf", csrfToken);
+          formData.append("type", file.type);
+          formData.append("flow", [[${flow}]]);
+          formData.append("screen", [[${screen}]]);
+          formData.append("inputName", [[${inputName}]]);
+          formData.append("thumbDataURL", file.dataURL);
+        })
+
+        this.on('queuecomplete', function () {
+          window['isUploadComplete' + [[${inputName}]]] = true;
+          if (documents != null && Object.entries(documents).length > this.options.maxFiles) {
+            toggleMaxFileMessage('on');
+          }
+        });
+
+        this.on('maxfilesexceeded', function () {
+          toggleMaxFileMessage('on');
+        });
+
+        this.on('success', function (file, id, e) {
+          var removeLink = file.previewElement.getElementsByClassName("dz-remove")[0];
+          var thumbnail = file.previewElement.getElementsByClassName("dz-thumb")[0];
+          var progressBar = file.previewElement.getElementsByClassName("dz-progress")[0];
+          var fileName = file.name;
+          window['userFileIds' + [[${inputName}]]].push(id);
+          updateFileInputValue();
+
+          removeLink.onclick = function () {
+            let confirmation = confirm(
+                [[#{general.files.confirm-delete}]] + fileName + '. '
+                + [[#{general.files.confirm-delete-ok}]])
+            if (confirmation) {
+              sendDeleteXhrRequest(id, [[${flow}]]);
+              removeFileFromDropzone(file, id);
+            }
+          }
+          removeLink.innerText = [[#{general.delete}]].toLowerCase();
+          thumbnail.classList.remove("hidden");
+          progressBar.classList.add("hidden");
+          $('#submit-my-documents-' + [[${inputName}]]).removeClass("disabled");
+          deleteCancelledFiles(file, id);
+        });
+
+        // This lets dropzone know to process the queue after each file has completed
+        // Important for uploading multiple files at once
+        this.on("complete", function () {
+          processDZQueueAfterThumbnailGeneration();
+        })
+
+        // `addFileToBeDestroyed` is a custom event that we have defined, not something built into dropzone.
+        // This event is emitted when the client clicks cancel on a file that has not finished uploading.
+        this.on('addFileToBeDestroyed', function (file) {
+          window['cancelledFiles' + [[${inputName}]]].push(file);
+        });
+
+        this.on('processing', function (file) {
+          $('#submit-my-documents-' + [[${inputName}]]).addClass("disabled");
+        });
+
+        if (documents) {
+          $.each(Object.entries(documents), function (key, uploadedDocWithThumbnail) {
+            var doc = uploadedDocWithThumbnail[1];
+            var mockFile = {
+              name: doc.originalFilename,
+              size: doc.filesize,
+              type: doc.type,
+              id: uploadedDocWithThumbnail[0],
+              accepted: true
+            };
+            window[dropzonePrefix + [[${inputName}]]].files.push(mockFile);
+            window[dropzonePrefix + [[${inputName}]]].emit("addedfile", mockFile);
+            window[dropzonePrefix + [[${inputName}]]].emit("thumbnail", mockFile,
+                doc.thumbnailUrl);
+            window[dropzonePrefix + [[${inputName}]]].emit("success", mockFile, mockFile.id);
+            window[dropzonePrefix + [[${inputName}]]].emit("complete", mockFile);
+          });
+        }
+      },
+      error: function (file, errorMessage, xhr) {
+        if (xhr && xhr.response) {
+          file.previewElement.getElementsByClassName("text--error")[0].innerText = xhr.response;
+        } else {
+          var message = errorMessage.error ? errorMessage.error : errorMessage;
+          file.previewElement.getElementsByClassName("text--error")[0].innerText = message;
+        }
+
+        for (var i = 0; i < window[dropzonePrefix + [[${inputName}]]].files.length; i++) {
+          if (window[dropzonePrefix + [[${inputName}]]].files[i] === file) {
+            window[dropzonePrefix + [[${inputName}]]].files.splice(i, 1);
+          }
+        }
+
+        if (window[dropzonePrefix + [[${inputName}]]].files.length === 0) {
+          $('#submit-my-documents-' + [[${inputName}]]).addClass('hidden');
+        }
+
+        showNumberOfAddedFiles();
+
+        file.previewElement.classList.add("form-group--error");
+
+        var removeLink = file.previewElement.getElementsByClassName("dz-remove")[0];
+        removeLink.onclick = removeCreator(file);
+        removeLink.innerText = [[#{general.remove}]].toLowerCase();
+        removeLink.classList.add("text--red");
+
+        var filePreview = file.previewElement.getElementsByClassName("thumbnail")[0]
+        filePreview.innerHTML = `<svg class=\"margin-auto\" style=\"width: ${thumbnailWidth}px; height: ${thumbnailHeight}px;\" width=\"40\" height=\"47\" viewBox=\"0 0 40 47\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n`
+            +
+            "<path d=\"M6.625 40.125H20.375L13.5 28.25L6.625 40.125ZM14.125 38.25H12.875V37H14.125V38.25ZM14.125 35.75H12.875V33.25H14.125V35.75Z\" fill=\"#D13F00\"/>\n"
+            +
+            "<path d=\"M26.6667 0H4.44444C3.2657 0 2.13524 0.550197 1.30175 1.52955C0.468252 2.50891 0 3.8372 0 5.22222V41.7778C0 43.1628 0.468252 44.4911 1.30175 45.4704C2.13524 46.4498 3.2657 47 4.44444 47H35.5556C36.7343 47 37.8648 46.4498 38.6983 45.4704C39.5317 44.4911 40 43.1628 40 41.7778V15.6667L26.6667 0ZM35.5556 41.7778H4.44444V5.22222H24.4444V18.2778H35.5556V41.7778Z\" fill=\"#D13F00\" fill-opacity=\"0.5\"/>\n"
+            +
+            "</svg>";
+      }
+    });
+  </script>
+</th:block>

--- a/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
@@ -205,7 +205,7 @@
       filesToDelete.forEach(fTD => {
         if (fTD.name === file.name) {
           removeFileFromDropzone(file, id);
-          mixpanel.track('delete_file_when_cancel_is_clicked', {
+          mixpanel.track('file_upload_cancel', {
             'page_name': window.location.pathname,
             'file_size': file.size,
             'file_format': file.type
@@ -375,7 +375,7 @@
                 + [[#{general.files.confirm-delete-ok}]])
             if (confirmation) {
               sendDeleteXhrRequest(id, [[${flow}]]);
-              mixpanel.track('delete_file_when_delete_clicked', {
+              mixpanel.track('delete_file', {
                 'page_name': window.location.pathname,
                 'file_size': file.size,
                 'file_format': file.type

--- a/src/main/resources/templates/gcc/doc-upload-add-files.html
+++ b/src/main/resources/templates/gcc/doc-upload-add-files.html
@@ -33,7 +33,7 @@
                 </th:block>
               </th:block>
               <th:block
-                  th:replace="~{fragments/fileUploader :: fileUploader(inputName='uploadDocuments')}"></th:block>
+                  th:replace="~{fragments/inputs/overrides/fileUploader :: fileUploader(inputName='uploadDocuments')}"></th:block>
 
             </div>
             <div class="form-card__footer">


### PR DESCRIPTION
#### 🔗 Jira ticket
[Jira Ticket](https://codeforamerica.atlassian.net/browse/CCAP-35?atlOrigin=eyJpIjoiMDBjMmIxZDVjN2JkNDU5MjhjYmUxNDVjZTFjM2Y0M2IiLCJwIjoiaiJ9)

#### ✍️ Description

Added `fileUploader` fragment to `doc-upload-add-files` screen. We also added Mixpanel tracking to select events 

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks

##### doc-upload-add-files
- [ ] Users can upload an image from the camera roll on iOS or Android
- [ ] Users can upload a file from the file picker on Android or iOS 
- [ ] Users can take a photo using the camera on Android or iOS 
- [ ] Users can drag and drop a file to upload it on a desktop browser  
- [ ] Users can choose a file from the file picker to upload it on a desktop browser 
- [ ] Accepted file types are, pdf, jpg, png, avif, heic, docx, pptx, xlsx. If an invalid file is uploaded then an error is returned. 
        - [ ] avif, heic,pptx, xlsx are not supported by file uploader
        - [ ] docx, png, jpg, pdf are supported by file uploader
- [ ] Files can be accepted up to 10MB. If a client attempts to upload a file larger than 10MB, then an error is returned. 
- [ ] Up to 20 documents can be added.

##### Mixpanel Tracking
- [ ] When a client attempts to upload a file on the 'doc-upload-list' screen, an `initiate_file_upload` event should fire
- [ ] If a client's attempt to upload a file on the  'doc-upload-list'  is successful, then a `file_upload_success` event fires
- [ ] If a client's attempt to upload a file on the `doc-upload-list` screen results in failure, then a `file_upload_fail` event should fire
- [ ] If a client deletes a file using the delete link on the doc-upload-list` screen, then a `delete_file` event should fire
track cancel clicks with the event name file_upload_cancel and the file_size, file_type, and page_name as properties on that event.

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
