### PR TITLE
CCAP-41 Hide email notification text if there is no email

### DIFF
--- a/src/main/resources/templates/gcc/submit-complete.html
+++ b/src/main/resources/templates/gcc/submit-complete.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org"
+      th:with="email = ${inputData.getOrDefault('parentContactEmail', null)}">
 <head th:replace="~{fragments/head :: head(title=#{submit-complete.title})}"></head>
 <body>
 <div class="page-wrapper">
@@ -24,8 +25,8 @@
                        th:text="#{submit-complete.button.skip}"
                        class="button"
                        id="skip-link"></a>
-                    <ul class="list--checkmark list--material-checkmark"
-                    th:with="email = ${inputData.getOrDefault('parentContactEmail', '<no email>')}">
+                    <ul th:if="${!#strings.isEmpty(email)}" class="list--checkmark list--material-checkmark"
+                    >
                         <li th:text="#{submit-complete.email-notice(${email})}"></li>
                     </ul>
                 </div>


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-41](https://codeforamerica.atlassian.net/browse/CCAP-41?focusedCommentId=10367)

#### ✍️ Description
On `submit-complete`, hide the email notification text if an email was not given to us.

#### If there's an email
![2024-05-20 at 17 17 07@2x](https://github.com/codeforamerica/il-gcc-form-flow/assets/9101728/ac76453a-8292-4bfa-b616-74320f4578d7)


#### If there isn't an email
![2024-05-20 at 17 18 18@2x](https://github.com/codeforamerica/il-gcc-form-flow/assets/9101728/e50bcc8e-9f75-4b31-954d-5a2cbe7d9235)


[CCAP-41]: https://codeforamerica.atlassian.net/browse/CCAP-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ