### PR TITLE
CCAP-27-add-secondary-parents-work-schedule-to-an-application

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/PartnerSetJobWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/PartnerSetJobWeeklyScheduleGroup.java
@@ -1,0 +1,68 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PartnerSetJobWeeklyScheduleGroup implements Action {
+
+  private final MessageSource messageSource;
+
+  public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+
+  public static final String DISPLAY_LABEL = "displayWeeklySchedule";
+
+  public PartnerSetJobWeeklyScheduleGroup(MessageSource messageSource) {
+    this.messageSource = messageSource;
+  }
+
+  @Override
+  public void run(Submission submission, String id) {
+
+    Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("partnerJobs", id);
+    if (!subflowEntry.containsKey("activitiesJobWeeklySchedule[]")) {
+      return;
+    }
+
+    var weeklySchedule = new ArrayList<>((List<String>) subflowEntry.get("activitiesJobWeeklySchedule[]"));
+    var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
+    String firstDay = null, lastDay = null;
+    Locale locale = LocaleContextHolder.getLocale();
+
+    Iterator<String> iter = WEEKDAYS.iterator();
+    while (iter.hasNext() && !weeklySchedule.isEmpty()) {
+      String day = iter.next();
+      if (weeklySchedule.remove(day)) {
+        if (firstDay == null) {
+          firstDay = messageSource.getMessage("general.week." + day, null, locale);
+        } else {
+          lastDay = messageSource.getMessage("general.week." + day, null, locale);
+        }
+      } else if (firstDay != null) {
+        var displayDays = formatWeekdaysSeparated(sortedDays, locale);
+        subflowEntry.put(DISPLAY_LABEL, displayDays);
+        return;
+      }
+    }
+
+    subflowEntry.put(DISPLAY_LABEL, lastDay == null ? firstDay : "%s-%s".formatted(firstDay, lastDay));
+
+  }
+
+  private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
+    return sortedDays.stream()
+        .map(d -> messageSource.getMessage("general.week." + d, null, locale))
+        .collect(Collectors.joining(", "));
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/PartnersWorkDaysOrHoursVaryDoNotVary.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/PartnersWorkDaysOrHoursVaryDoNotVary.java
@@ -1,0 +1,25 @@
+package org.ilgcc.app.submission.conditions;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartnersWorkDaysOrHoursVaryDoNotVary implements Condition {
+
+  @Override
+  public Boolean run(Submission submission, String uuid) {
+    var jobs = (List<Map<String, Object>>) submission.getInputData().getOrDefault("partnerJobs", emptyList());
+    for (var job : jobs) {
+      if (job.get("uuid").equals(uuid)) {
+        var activitiesWorkVary = job.getOrDefault("activitiesWorkVary", "false");
+        return activitiesWorkVary.equals("false");
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -257,6 +257,25 @@ flow:
   activities-partner-self-employment:
     subflow: partnerJobs
     nextScreens:
+      - name: activities-partner-work-schedule-vary
+  activities-partner-work-schedule-vary:
+    subflow: partnerJobs
+    nextScreens:
+      - name: activities-partner-job-weekly-schedule
+        condition: PartnersWorkDaysOrHoursVaryDoNotVary
+      - name: activities-partner-next-work-schedule
+  activities-partner-next-work-schedule:
+    subflow: partnerJobs
+    nextScreens:
+      - name: activities-partner-job-weekly-schedule
+  activities-partner-job-weekly-schedule:
+    subflow: partnerJobs
+    nextScreens:
+      - name: activities-partner-job-hourly-schedule
+  activities-partner-job-hourly-schedule:
+    beforeDisplayAction: PartnerSetJobWeeklyScheduleGroup
+    subflow: partnerJobs
+    nextScreens:
       - name: activities-partner-commute-time
   activities-partner-commute-time:
     subflow: partnerJobs

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -472,18 +472,40 @@ activities-ed-program-method.program.hybrid=Hybrid (Online and In-Person)
 activities-ed-program-method.schedule.header=Are your classes taught on a schedule?*
 #activities-partner-add-jobs
 activities-partner-add-jobs.title=Activities Partner Add Jobs
+#activities-partner-employer-name
 activities-partner-employer-name.title=Activities Partner Employer Name
 activities-partner-employer-name.header=What is the employer or company name?
 activities-partner-employer-name.subtext=If {0} is self-employed, then enter {0}''s name or profession. For example: barber, dog walker, etc.
+#activities-partner-employer-address
 activities-partner-employer-address.title=Activities Partner Employer Address
 activities-partner-employer-address.subtext=You can skip questions that are not relevant to this job.
+#activities-partner-self-employment
 activities-partner-self-employment.title=Activities Partner Self Employment
 activities-partner-self-employment.header=Is {0}''s job here considered freelance, contracting or self-employment?
+#activities-partner-work-schedule-vary
+activities-partner-work-schedule-vary.title=Partner Work Schedule Varies
+activities-partner-work-schedule-vary.header=Do {0}''s work days or hours vary at this job?
+#activities-partner-next-work-schedule
+activities-partner-next-work-schedule.title=Notice Partner Work Schedule Varies
+activities-partner-next-work-schedule.header=Next, we''ll ask about {0}''s work schedule
+activities-partner-next-work-schedule.notice=<b>Since {0}''s work schedule varies</b>, please select the days and times {0} plans to work while your child is in daycare.
+#activities-partner-job-weekly-schedule
+activities-partner-job-weekly-schedule.title=Partner Weekly Schedule
+activities-partner-job-weekly-schedule.header=What days does {0} work at this job?
+activities-partner-job-weekly-schedule.subtext=If {0}''s work days vary, choose the days {0} typically works that you need child care coverage for.
+#activities-partner-job-hourly-schedule
+activities-partner-job-hourly-schedule.title=Partner Hourly Schedule
+activities-partner-job-hourly-schedule.header=What are {0}''s typical work hours?
+activities-partner-job-hourly-schedule.subtext=If their work hours vary, choose the hours they typically work that you need child care coverage for.
+activities-partner-job-hourly-schedule.job.hours.same.every.day={0}''s work hours are the same every day.
+#activities-partner-commute-time
 activities-partner-commute-time.title=Activities Partner Commute Time
 activities-partner-commute-time.header=How long does it typically take {0} to commute to work?
 activities-partner-commute-time.subtext=Their travel time will be added to their work hours to make sure you get child care coverage.
+#activities-partner-add-job
 activities-partner-add-job.header.any-other-jobs=Does {0} have any other jobs?
 activities-partner-add-job.subtext.add-jobs-list=We will ask for their income and work schedule for each job.
+
 activities-partner-ed-program-method.description=This information helps us better understand {0}''s schedule.
 activities-partner-ed-program-method.program.header=How are {0}''s classes taught?
 activities-partner-ed-program-method.schedule.header=Are {0}''s classes taught on a schedule?*

--- a/src/main/resources/templates/gcc/activities-partner-job-hourly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-partner-job-hourly-schedule.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{activities-partner-job-hourly-schedule.title})}"></head>
+<script th:inline="javascript">
+  $(document).ready(function () {
+    const $everyDayCheckbox = $('#activitiesJobHoursSameEveryDay-Yes')
+
+    function toggleFields() {
+        $('#grouped-days').toggleClass('hidden');
+        $('#individual-days').toggleClass('hidden');
+        disableFields()
+      }
+
+      function disableFields(){
+        if ($('#grouped-days').hasClass('hidden')) {
+          $('#grouped-days :input').prop('disabled', true);
+          $('#individual-days :input').prop('disabled', false);
+        } else {
+          $('#grouped-days :input').prop('disabled', false);
+          $('#individual-days :input').prop('disabled', true);
+        }
+      }
+
+      // on load
+      disableFields()
+
+      // On checkbox change
+      $everyDayCheckbox.change(function () {
+        toggleFields();
+      });
+  });
+</script>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.companyName})}"></th:block>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-partner-job-hourly-schedule.header(${inputData.get('parentPartnerFirstName')})}, subtext=#{activities-partner-job-hourly-schedule.subtext})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <input type="hidden" th:name="current_uuid" th:value="${fieldData.get('uuid')}">
+            <div class="form-card__content" th:with="isSameEveryDay=${!#lists.isEmpty(fieldData.get('activitiesJobHoursSameEveryDay[]'))}">
+              <th:block th:replace="~{fragments/inputs/checkbox :: checkbox(inputName='activitiesJobHoursSameEveryDay', value='Yes', label=#{activities-partner-job-hourly-schedule.job.hours.same.every.day(${inputData.get('parentPartnerFirstName')})}, toggleVisibility='#activitiesWeekly')}" />
+              <div id="grouped-days" th:class="${isSameEveryDay ? '' : 'hidden'}">
+                <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName='activitiesJobStartTimeAllDays', endInputName='activitiesJobEndTimeAllDays', label=${fieldData.get('displayWeeklySchedule')})}" />
+              </div>
+              <div id="individual-days" th:class="${isSameEveryDay ? 'hidden' : ''}">
+                <th:block th:each="day: ${fieldData['activitiesJobWeeklySchedule[]']}">
+                  <th:block th:replace="~{fragments/inputs/timeRange :: timeRange(startInputName='activitiesJobStartTime' + ${day}, endInputName='activitiesJobEndTime' + ${day}, label=#{${'general.week.' + day}})}" />
+                </th:block>
+              </div>
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/activities-partner-job-weekly-schedule.html
+++ b/src/main/resources/templates/gcc/activities-partner-job-weekly-schedule.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{activities-partner-job-weekly-schedule.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.companyName})}"></th:block>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-partner-job-weekly-schedule.header(${inputData.get('parentPartnerFirstName')})}, subtext=#{activities-partner-job-weekly-schedule.subtext(${inputData.get('parentPartnerFirstName')})})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+              <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
+                              checkboxFieldset(inputName='activitiesJobWeeklySchedule',
+                              ariaLabel='header',
+                              content=~{::checkboxOptions})}">
+                <th:block th:ref="checkboxOptions">
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Monday',  label=#{general.week.Monday})}" />
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Tuesday', label=#{general.week.Tuesday})}"/>
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Wednesday', label=#{general.week.Wednesday})}"/>
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Thursday', label=#{general.week.Thursday})}"/>
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Friday', label=#{general.week.Friday})}"/>
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Saturday', label=#{general.week.Saturday})}"/>
+                  <th:block
+                          th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='activitiesJobWeeklySchedule', value='Sunday', label=#{general.week.Sunday})}"/>
+                </th:block>
+              </th:block>
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/activities-partner-next-work-schedule.html
+++ b/src/main/resources/templates/gcc/activities-partner-next-work-schedule.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{activities-partner-next-work-schedule.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-partner-next-work-schedule.header(${inputData.get('parentPartnerFirstName')})})}"/>
+        <div class="notice--warning spacing-below-60" th:utext="#{activities-partner-next-work-schedule.notice(${inputData.get('parentPartnerFirstName')})}"></div>
+        <div class="form-card__footer">
+          <th:block th:replace="~{fragments/continueButton :: continue}"/>
+        </div>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/activities-partner-work-schedule-vary.html
+++ b/src/main/resources/templates/gcc/activities-partner-work-schedule-vary.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{activities-partner-work-schedule-vary.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${fieldData.companyName})}"></th:block>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-partner-work-schedule-vary.header(${inputData.get('parentPartnerFirstName')})})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <th:block th:replace="~{fragments/inputs/overrides/yesOrNo :: yesOrNo(
+              inputName='activitiesWorkVary',
+              ariaDescribe='header')}"/>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
@@ -435,6 +435,41 @@ public class ActivitiesJourneyTest extends AbstractBasePageTest {
         //activities-partner-self-employment
         assertThat(testPage.getTitle()).isEqualTo("Activities Partner Self Employment");
         testPage.clickButton("No");
+
+        //check that selecting yes on activities-partner-work-schedule-vary screen send you to ...next-work-schedule
+        // and no sends you to the ...job-weekly-schedule screen
+
+        //activities-partner-work-schedule-vary
+        assertThat(testPage.getTitle()).isEqualTo("Partner Work Schedule Varies");
+        assertThat(testPage.getHeader()).isEqualTo("Do partner's work days or hours vary at this job?");
+        testPage.clickButton("No");
+
+        //activities-partner-job-weekly-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Partner Weekly Schedule");
+        testPage.goBack();
+
+        //activities-partner-work-schedule-vary
+        assertThat(testPage.getTitle()).isEqualTo("Partner Work Schedule Varies");
+        testPage.clickButton("Yes");
+
+        //activities-partner-next-work-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Notice Partner Work Schedule Varies");
+        assertThat(testPage.getHeader()).isEqualTo("Next, we'll ask about partner's work schedule");
+        testPage.clickContinue();
+        //activities-partner-job-weekly-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Partner Weekly Schedule");
+        testPage.clickElementById("activitiesJobWeeklySchedule-Monday");
+        testPage.clickElementById("activitiesJobWeeklySchedule-Sunday");
+        testPage.clickContinue();
+
+        //activities-partner-job-hourly-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Partner Hourly Schedule");
+        testPage.enter("activitiesJobStartTimeMonday", "1200PM");
+        testPage.enter("activitiesJobEndTimeMonday", "0100PM");
+        testPage.enter("activitiesJobStartTimeSunday", "0200PM");
+        testPage.enter("activitiesJobEndTimeSunday", "0300PM");
+        testPage.clickContinue();
+
         //activities-partner-commute-time
         assertThat(testPage.getTitle()).isEqualTo("Activities Partner Commute Time");
         testPage.selectFromDropdown("activitiesJobCommuteTime", "1.5 hours");

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -267,7 +267,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo("Work schedule vary");
         testPage.clickButton("Yes");
 
-        //activities-partner-next-work-schedule
+        //activities-next-work-schedule
         assertThat(testPage.getTitle()).isEqualTo("Work Schedule");
         testPage.clickContinue();
 
@@ -277,7 +277,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickElementById("activitiesJobWeeklySchedule-Sunday");
         testPage.clickContinue();
 
-        //activities-job-weekly-schedule
+        //activities-job-hourly-schedule
         assertThat(testPage.getTitle()).isEqualTo("Job hourly schedule");
         testPage.enter("activitiesJobStartTimeMonday", "1200PM");
         testPage.enter("activitiesJobEndTimeMonday", "0100PM");
@@ -373,10 +373,42 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
         //activities-partner-self-employment
         assertThat(testPage.getTitle()).isEqualTo("Activities Partner Self Employment");
         testPage.clickButton("No");
+        //activities-partner-work-schedule-vary
+        assertThat(testPage.getTitle()).isEqualTo("Partner Work Schedule Varies");
+        assertThat(testPage.getHeader()).isEqualTo("Do partner's work days or hours vary at this job?");
+        testPage.clickButton("No");
+
+        //activities-partner-job-weekly-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Partner Weekly Schedule");
+        testPage.goBack();
+
+        //activities-partner-work-schedule-vary
+        assertThat(testPage.getTitle()).isEqualTo("Partner Work Schedule Varies");
+        testPage.clickButton("Yes");
+
+        //activities-partner-next-work-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Notice Partner Work Schedule Varies");
+        assertThat(testPage.getHeader()).isEqualTo("Next, we'll ask about partner's work schedule");
+        testPage.clickContinue();
+        //activities-partner-job-weekly-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Partner Weekly Schedule");
+        testPage.clickElementById("activitiesJobWeeklySchedule-Monday");
+        testPage.clickElementById("activitiesJobWeeklySchedule-Sunday");
+        testPage.clickContinue();
+
+        //activities-partner-job-hourly-schedule
+        assertThat(testPage.getTitle()).isEqualTo("Partner Hourly Schedule");
+        testPage.enter("activitiesJobStartTimeMonday", "1200PM");
+        testPage.enter("activitiesJobEndTimeMonday", "0100PM");
+        testPage.enter("activitiesJobStartTimeSunday", "0200PM");
+        testPage.enter("activitiesJobEndTimeSunday", "0300PM");
+        testPage.clickContinue();
+
         //activities-partner-commute-time
         assertThat(testPage.getTitle()).isEqualTo("Activities Partner Commute Time");
         testPage.selectFromDropdown("activitiesJobCommuteTime", "1.5 hours");
         testPage.clickContinue();
+
         //activities-partner-add-job
         assertThat(testPage.getHeader()).isEqualTo("Does partner have any other jobs?");
         testPage.clickButton("That is all my jobs");


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-27

#### ✍️ Description
- [ ] Implement `activities-partner-work-schedule-vary` screen
- [ ] Implement `activities-partner-next-work-schedule` screen 
- [ ] Implement `activities-partner-job-weekly-schedule` screen 
- [ ] Implement `activities-partner-job-hourly-schedule` screen 
- [x] Implement `activities-partner-work-commute-time` screen (Implemented in CCAP-25)
- [x] Implement `activities-partner-add-jobs-list` screen (Implemented in CCAP-25)

#### 📷 Design reference
[Figma](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?node-id=1322-7833&t=y5u0LwKgTY7D993C-4)

#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
