### PR TITLE
Updated copy and added tracking to No, keep it links

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -470,8 +470,10 @@ activities-ed-program-method.program.online=Online
 activities-ed-program-method.program.inperson=In-Person
 activities-ed-program-method.program.hybrid=Hybrid (Online and In-Person)
 activities-ed-program-method.schedule.header=Are your classes taught on a schedule?*
-#activities-partner-add-jobs
+#activities-partner-add-job
 activities-partner-add-jobs.title=Activities Partner Add Jobs
+activities-partner-add-jobs.header=Now, let''s add {0}''s jobs.
+activities-partner-add-jobs.subtext=We will ask for their income and work schedule for each jobs.
 #activities-partner-employer-name
 activities-partner-employer-name.title=Activities Partner Employer Name
 activities-partner-employer-name.header=What is the employer or company name?

--- a/src/main/resources/templates/gcc/activities-partner-add-job.html
+++ b/src/main/resources/templates/gcc/activities-partner-add-job.html
@@ -11,9 +11,9 @@
             th:with="parentName=${inputData.get('parentPartnerFirstName')},
                addedJobs=${inputData.containsKey('partnerJobs') && inputData.get('partnerJobs').size() > 0}">
         <th:block th:replace="~{fragments/gcc-icons :: income}"></th:block>
-        <th:block th:with="addJobsHeader=|#{activities-add-jobs.header} ${fieldData.get('parentPartnerFirstName')}.|,
+        <th:block th:with="addJobsHeader=#{activities-partner-add-jobs.header(${fieldData.get('parentPartnerFirstName')})},
                            addMoreJobsHeader=#{activities-partner-add-job.header.any-other-jobs(${inputData.get('parentPartnerFirstName')})},
-                           jobsSubtext=#{activities-add-jobs.subtext},
+                           jobsSubtext=#{activities-partner-add-jobs.subtext},
                            addMoreJobsSubtext=#{activities-partner-add-job.subtext.add-jobs-list}">
           <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=${addedJobs ? addMoreJobsHeader : addJobsHeader},
                                                                      subtext=${addedJobs ? addMoreJobsSubtext : jobsSubtext})}"/>

--- a/src/main/resources/templates/gcc/delete-job.html
+++ b/src/main/resources/templates/gcc/delete-job.html
@@ -32,6 +32,7 @@
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton( text=#{delete-job.yes})}"/>
             </form>
             <a class="button spacing-above-35" th:href="'/flow/' + ${flow} + '/activities-add-jobs'"
+               id="keep-job"
                th:text="#{delete-job.no}"></a>
           </div>
         </main>

--- a/src/main/resources/templates/gcc/delete-partner-job.html
+++ b/src/main/resources/templates/gcc/delete-partner-job.html
@@ -32,6 +32,7 @@
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton( text=#{delete-job.yes})}"/>
             </form>
             <a class="button spacing-above-35" th:href="'/flow/' + ${flow} + '/activities-partner-add-job'"
+               id="keep-partner-job"
                th:text="#{delete-job.no}"></a>
           </div>
         </main>

--- a/src/main/resources/templates/gcc/delete-person.html
+++ b/src/main/resources/templates/gcc/delete-person.html
@@ -32,6 +32,7 @@
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton( text=#{delete-confirmation.yes})}"/>
             </form>
             <a class="button spacing-above-35" th:href="'/flow/' + ${flow} + '/parent-add-adults'"
+               id="keep-person"
                th:text="#{delete-confirmation.no}"></a>
           </div>
         </main>

--- a/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
@@ -415,6 +415,8 @@ public class ActivitiesJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
         //activities-partner-add-job
         assertThat(testPage.getTitle()).isEqualTo("Activities Partner Add Jobs");
+        assertThat(testPage.getHeader()).isEqualTo("Now, let's add partner's jobs.");
+        assertThat(testPage.findElementById("header-help-message").getText()).isEqualTo("We will ask for their income and work schedule for each jobs.");
         testPage.clickButton("Add a job");
         //activities-partner-employer-name
         assertThat(testPage.getTitle()).isEqualTo("Activities Partner Employer Name");


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-25

#### ✍️ Description

##### The copy on the `activities-partner-add-job screen` is wrong in the empty state.  Fix:
- [ ] The heading
- [ ] subheading 

##### On the `delete-partner-job` screen
- [ ]  the “No, keep it” button is missing an element id property on the link click event to identify what link the event refers to.

#### 📷 Design reference
[Figma](https://codeforamerica.atlassian.net/browse/CCAP-25)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
