### PR TITLE
updating the setup.sh script with the change i needed to make to get it to work

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,8 +17,8 @@ else
 fi
 
 echo 'Installing brew packages'
-brew tap homebrew/cask-versions
-brew install temurin17 jenv gradle postgresql@14 node
+brew install --cask temurin@17
+brew install jenv gradle postgresql@14 node
 
 # Install jenv in either the .bashrc or zshrc, whichever is present
 if [ -f ~/.bashrc ]; then
@@ -27,6 +27,7 @@ elif [ -f ~/.zshrc ]; then
   install_jenv "$HOME/.zshrc" "zsh"
 else
   echo 'No shell config file found, cant install jenv'
+  echo 'Please create a .bashrc or .zshrc'
   exit 1
 fi
 


### PR DESCRIPTION
Two little tweaks to the setup script. 

The first was what I had to do manually before re-running the script. This error was happening with the removed line:

```
mperlman@codeforamerica.org@Marcs-MacBook-Pro-2 ~ % brew tap homebrew/cask-versions
Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

The second is just because it appears that new MBPs, or at least mine, didn't come with either a .bashrc or .zshrc file. I had to look at the script to figure out what happened, so this will give future folks a heads up! 