### PR TITLE
[CCAP-119] Tweaking the secondary parent string to match the primary

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -502,7 +502,7 @@ activities-partner-job-hourly-schedule.subtext=If their work hours vary, choose 
 activities-partner-job-hourly-schedule.job.hours.same.every.day={0}''s work hours are the same every day.
 #activities-partner-commute-time
 activities-partner-commute-time.title=Activities Partner Commute Time
-activities-partner-commute-time.header=How long does it typically take {0} to commute to work?
+activities-partner-commute-time.header=How long does it typically take {0} to commute from work to child care?
 activities-partner-commute-time.subtext=Their travel time will be added to their work hours to make sure you get child care coverage.
 #activities-partner-add-job
 activities-partner-add-job.header.any-other-jobs=Does {0} have any other jobs?


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-119

#### ✍️ Description
@MThorpester noticed that the secondary parent string, which was not noted in the original ticket, used the old phrasing. Confirmed with Carl that we want the secondary string to match the primary string.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
