### PR TITLE
[CCAP-229] Fixing error messages to use specific first/last name messaging for spouse

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -77,9 +77,9 @@ public class Gcc extends FlowInputs {
     private String parentPartnerIsServing;
     private String parentPartnerInMilitaryReserveOrNationalGuard;
     private String parentPartnerHasDisability;
-    @NotBlank(message = "{general.indicates-required}")
+    @NotBlank(message = "{errors.provide-first-name}")
     private String parentPartnerFirstName;
-    @NotBlank(message = "{general.indicates-required}")
+    @NotBlank(message = "{errors.provide-last-name}")
     private String parentPartnerLastName;
 
     private String parentPartnerSSN;


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-229

#### ✍️ Description
The spouse inputs for first/last name were using the generic error message, instead of the first/last name specific required messages

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [X] Meets acceptance criteria
