### PR TITLE
CCAP-218

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ form-flow:
   encryption-key: '{"primaryKeyId":2135185311,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.AesGcmKey","value":"GiCRKaXiJ/zlDHAZfRQf1rCIbIY4fFmLqLWYIPLNXpOx4A==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":2135185311,"outputPrefixType":"TINK"}]}"'
   inputs: 'org.ilgcc.app.inputs.'
   uploads:
-    accepted-file-types: '.pdf,.jpg,.png,.avif,.heic,.docx,.pptx,.xlsx'
+    accepted-file-types: '.jpg, .jpeg, .png, .pdf, .bmp, .gif, .doc, .docx, .odt, .ods, .odp'
     thumbnail-width: '64'
     thumbnail-height: '60'
     # 20 files maximum

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,6 @@ form-flow:
           bcc:
   session-continuity-interceptor:
     enabled: true
-  encryption-key: '{"primaryKeyId":2135185311,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.AesGcmKey","value":"GiCRKaXiJ/zlDHAZfRQf1rCIbIY4fFmLqLWYIPLNXpOx4A==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":2135185311,"outputPrefixType":"TINK"}]}"'
   inputs: 'org.ilgcc.app.inputs.'
   uploads:
     accepted-file-types: '.jpg, .jpeg, .png, .pdf, .bmp, .gif, .doc, .docx, .odt, .ods, .odp'


### PR DESCRIPTION
Updates application.yaml to accept correct filetypes

#### 🔗 Jira ticket
CCAP-218

#### ✍️ Description
Update filetypes to include: 
- [ ] .jpg
- [ ] .jpeg
- [ ] .png 
- [ ] .pdf
- [ ] .bmp
- [ ] .gif
- [ ] .doc
- [ ] .docx
- [ ] .odt
- [ ] .ods
- [ ] .odp

#### 📷 Design reference

#### ✅ Completion tasks
To test: 
1. Fill out application until you reach the Doc upload screen 
2.  Upload docs the the corresponding filetypes from QA / UAT testing files
3.  Verify that errors are not thrown 
4. Check s3 to verify that files were uploaded

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
