### PR TITLE
Add the ability to use a SSL for localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ node_modules/
 
 ### Mac OS ###
 .DS_Store
+
+### Local cert ###
+*.p12

--- a/README.md
+++ b/README.md
@@ -316,7 +316,19 @@ This script will ensure that all dependencies are installed (using `Homebrew`):
 - The right `Java` version
 - `PostgreSQL`
 
+It will also create a localhost cert so that local develop can happen over `https`.
+
 Next, it will create the database needed for running tests, and then run the tests.
+
+### generate_localhost_cert.sh
+
+This script will install dependencies to create an SSL certification so that you can use `https` with `localhost`.
+
+To run this script, from the root of this project:
+
+```bash
+sh ./scripts/generate_localhost_cert.sh
+```
 
 ### generate_migration.sh
 

--- a/sample.env
+++ b/sample.env
@@ -60,3 +60,9 @@ MAILGUN_KEY=
 # Location of the clammit virus scanning service used to verify that uploaded files do not 
 # have a virus.
 CLAMAV_URL=
+
+#######################################################################################
+# Localhost SSL cert password
+#######################################################################################
+# This password is in our shared LastPast folder, ask a team member if you don't have access
+KEY_STORE_PASSWORD=

--- a/scripts/generate_localhost_cert.sh
+++ b/scripts/generate_localhost_cert.sh
@@ -1,0 +1,29 @@
+set -e
+
+# Make sure homebrew is installed
+if ! brew --version; then
+  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+else
+  brew update
+fi
+
+# Install mkcert dependencies
+brew install mkcert nss
+
+# Start mkcert and create a new cert
+mkcert -install
+mkcert -pkcs12 localhost 127.0.0.1 ::1
+
+# Check if password is in .env file
+if [ -f ".env" ]; then
+    # Search for the key in the .env file
+    if grep -q "^KEY_STORE_PASSWORD=[^[:space:]]\+" ".env"; then
+        echo "🟢 localhost cert is ready for development"
+    else
+        echo "🟡 Look for KEY_STORE_PASSWORD in our LastPass folder and add it to your .env file."
+    fi
+else
+    echo "🔴 The .env file does not exist. Please create one, you can reference sample.env"
+fi
+
+echo "✅ localhost cert now installed"

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -9,3 +9,9 @@ management:
     web:
       exposure:
         include: '*'
+server:
+  ssl:
+    enabled: true
+    key-store: ./localhost+2.p12
+    key-store-type: PKCS12
+    key-store-password: ${KEY_STORE_PASSWORD}


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-189](https://codeforamerica.atlassian.net/browse/CCAP-189)

#### ✍️ Description
This branch allows us to us `https` when developing on `localhost`.

#### Steps

If you already have this repo set up, here he how you'd add https:

* Pull down this PR
* Go to the root of the repo in a terminal
* Run `sh ./scripts/generate_localhost_cert.sh`
* Go into your `.env` file and add the key `KEY_STORE_PASSWORD`
* The value of `KEY_STORE_PASSWORD` is in our shared lastpass folder called `Localhost cert password`
* Start the app locally
* In the browser go to `https://localhost:8080`
    * Once you visit `https` at least once in a browser, it should force `http` to `https` moving forward using the header [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
* Success! 🎉 


[CCAP-189]: https://codeforamerica.atlassian.net/browse/CCAP-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ