### PR TITLE
Collect parent partner activities only if partner qualifies

### DIFF
--- a/src/main/resources/templates/gcc/activities-parent-type.html
+++ b/src/main/resources/templates/gcc/activities-parent-type.html
@@ -18,7 +18,7 @@
               <!--              Display parent name here-->
               <div
                   th:with="childcareReasons=${T(org.ilgcc.app .utils.ChildcareReasonOption).values()},
-                           parentHasPartner=${fieldData.get('parentHasPartner')}">
+                           parentHasPartner=${fieldData.getOrDefault('parentHasQualifyingPartner', 'false')}">
                 <div>
                   <div class="spacing-below-25">
                     <th:block th:utext="${fieldData.get('parentFirstName')}"></th:block>

--- a/src/main/resources/templates/gcc/submit-sign-name.html
+++ b/src/main/resources/templates/gcc/submit-sign-name.html
@@ -19,8 +19,8 @@
                                 text(inputName='signedName',
                                 label=#{submit-sign-name.legal-name.label})}"/>
                             <th:block th:if="
-                                ${inputData.containsKey('parentHasPartner') &&
-                                inputData.get('parentHasPartner')}">
+                                ${inputData.containsKey('parentHasQualifyingPartner') &&
+                                inputData.get('parentHasQualifyingPartner')}">
                                 <th:block th:replace="~{fragments/inputs/text ::
                                     text(inputName='partnerSignedName',
                                     label=#{submit-sign-name.partner-legal-name.label})}"/>

--- a/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
@@ -292,6 +292,47 @@ public class ActivitiesJourneyTest extends AbstractBasePageTest {
     }
 
     @Test
+    void ParentPartnerDoesNotAppearIfIneligible() {
+        // Activities Screen
+        testPage.navigateToFlowScreen("gcc/activities-parent-intro");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .withChild("Second", "Child", "Yes")
+            .with("parentHasPartner", "true")
+            .build());
+
+        //activities-parent-intro
+        assertThat(testPage.getTitle()).isEqualTo("Activities Parent Intro");
+        testPage.clickContinue();
+        //activities-parent-type
+        assertThat(testPage.getTitle()).isEqualTo("Activities Parent Type");
+        assertThat(testPage.findElementById("activitiesParentChildcareReason-WORKING")).isNotNull();
+        assertThat(testPage.elementDoesNotExistById("activitiesParentPartnerChildcareReason-WORKING")).isTrue();
+    }
+
+    @Test
+    void ParentPartnerAppearsIfEligible() {
+        // Activities Screen
+        testPage.navigateToFlowScreen("gcc/activities-parent-intro");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .withChild("Second", "Child", "Yes")
+            .with("parentHasPartner", "true")
+            .with("parentHasQualifyingPartner", "true")
+            .build());
+
+        //activities-parent-intro
+        assertThat(testPage.getTitle()).isEqualTo("Activities Parent Intro");
+        testPage.clickContinue();
+        //activities-parent-type
+        assertThat(testPage.getTitle()).isEqualTo("Activities Parent Type");
+        assertThat(testPage.findElementById("activitiesParentChildcareReason-WORKING")).isNotNull();
+        assertThat(testPage.findElementTextById("activitiesParentPartnerChildcareReason-WORKING")).isNotNull();
+    }
+
+    @Test
     void ParentAndPartnerWithJobAndWorkTest() {
         // Activities Screen
         testPage.navigateToFlowScreen("gcc/activities-parent-intro");

--- a/src/test/java/org/ilgcc/app/journeys/SignatureJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/SignatureJourneyTest.java
@@ -1,0 +1,48 @@
+package org.ilgcc.app.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.Test;
+
+public class SignatureJourneyTest extends AbstractBasePageTest {
+
+    @Test
+    void signatureForPartnerExistsIfEligible() {
+        // CCAP Terms
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withParentPartnerDetails()
+            .withChild("First", "Child", "Yes")
+            .withChild("Second", "Child", "Yes")
+            .build());
+
+        testPage.clickElementById("agreesToLegalTerms-true-label");
+        testPage.clickContinue();
+        //Signature Page
+        assertThat(testPage.getTitle()).isEqualTo("Sign Application");
+        assertThat(testPage.findElementTextById("signedName")).isNotNull();
+        assertThat(testPage.findElementTextById("partnerSignedName")).isNotNull();
+    }
+
+    @Test
+    void signatureForPartnerDoesNotExistIfIneligible() {
+        // CCAP Terms
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withParentPartnerDetails()
+            .withChild("First", "Child", "Yes")
+            .withChild("Second", "Child", "Yes")
+            .with("parentHasQualifyingPartner", "False")
+            .build());
+
+        testPage.clickElementById("agreesToLegalTerms-true-label");
+        testPage.clickContinue();
+        //Signature Page
+        assertThat(testPage.getTitle()).isEqualTo("Sign Application");
+        assertThat(testPage.findElementTextById("signedName")).isNotNull();
+        assertThat(testPage.elementDoesNotExistById("partnerSignedName")).isTrue();
+    }
+}

--- a/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
@@ -66,14 +66,12 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withParentPartnerDetails() {
-        submission.getInputData().put("parentSpouseIsStepParent", "Yes");
-        submission.getInputData().put("parentSpouseShareChildren", "Yes");
-        submission.getInputData().put("parentSpouseLiveTogether", "Yes");
         submission.getInputData().put("parentPartnerFirstName", "partner");
         submission.getInputData().put("parentPartnerLastName", "parent");
         submission.getInputData().put("parentPartnerBirthMonth", "12");
         submission.getInputData().put("parentPartnerBirthDay", "25");
         submission.getInputData().put("parentPartnerBirthYear", "2018");
+        submission.getInputData().put("parentHasQualifyingPartner", "true");
         submission.getInputData().put("parentHasPartner", "true");
         return this;
     }


### PR DESCRIPTION
#### 🔗 Jira ticket
[Link](https://codeforamerica.atlassian.net/browse/CCAP-154)

#### ✍️ Description
- updated activities type logic to only collect activities if the partner is eligible
- updated submission test builder to include "parentHasQualifyingPartner" set to true

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
