### PR TITLE
Disable jobrunr dashboard in staging for now to stop the redirect

### DIFF
--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -20,3 +20,7 @@ management:
     web:
       exposure:
         include: '*'
+org:
+  jobrunr:
+    dashboard:
+      enabled: false


### PR DESCRIPTION
Fix staging redirect by simply turning off the jobrunr dashboard.