### PR TITLE
Implement lock app after submit

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ form-flow:
   encryption-key: ${ENCRYPTION_KEY}
   lock-after-submitted:
     - flow: gcc
-      redirect: submit-sign-name
+      redirect: submit-complete
   design-system:
     name: honeycrisp
   languages: en, es

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ form-flow:
   encryption-key: ${ENCRYPTION_KEY}
   lock-after-submitted:
     - flow: gcc
-      redirect: submit-confirmation
+      redirect: submit-sign-name
   design-system:
     name: honeycrisp
   languages: en, es

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -345,6 +345,7 @@ flow:
     nextScreens:
       - name: submit-sign-name
   submit-sign-name:
+    onPostAction: UploadSubmissionToS3
     nextScreens:
       - name: submit-complete
   submit-complete:
@@ -374,7 +375,6 @@ flow:
   delete-partner-job:
     nextScreens: null
   doc-upload-submit-confirmation:
-    onPostAction: UploadSubmissionToS3
     nextScreens:
       - name: submit-next-steps
 subflows:
@@ -401,6 +401,8 @@ subflows:
 landmarks:
   firstScreen: onboarding-getting-started
   afterSubmitPages:
+    - submit-complete
+    - submit-next-steps
     - submit-confirmation
     - doc-upload-recommended-docs
     - doc-upload-add-files

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -349,13 +349,13 @@ flow:
     nextScreens:
       - name: submit-complete
   submit-complete:
+    beforeDisplayAction: FormatSubmittedAtDate
     nextScreens:
       - name: submit-next-steps
   submit-next-steps:
     nextScreens:
       - name: submit-confirmation
   submit-confirmation:
-    beforeDisplayAction: FormatSubmittedAtDate
     nextScreens:
       - name: submit-confirmation
   doc-upload-recommended-docs:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -621,6 +621,7 @@ submit-sign-name.title=Sign Application
 submit-sign-name.subtext=By signing this application you agree that you want to apply for benefits, that you have been honest on this application, and that you have read and agreed to the terms on the previous page.
 submit-sign-name.legal-name.label=Your Full Legal Name
 submit-sign-name.partner-legal-name.label=Partner's Full Legal Name
+submit-sign-name.submit-application=Submit application
 submit-complete.title=Your application has been submitted!
 submit-complete.header=<p>Your application has been submitted!</p><p>You have the option to submit verification documents now.</p>
 submit-complete.info-box=<p>Verification documents are due within 10 business days of application submission.</p><p>We will share document recommendations on the next page. If you don't have your documents now, it's okay. You will get a Request for Information form in the mail.</p>

--- a/src/main/resources/templates/gcc/submit-complete.html
+++ b/src/main/resources/templates/gcc/submit-complete.html
@@ -10,6 +10,9 @@
             <div th:replace="~{fragments/goBack :: goBackLink}"></div>
             <main id="content" role="main" class="form-card spacing-above-35">
                 <th:block th:replace="~{fragments/gcc-icons :: greenCheck}"></th:block>
+                <div th:if="${lockedSubmissionMessage}" class="notice--warning">
+                    <p th:text="${lockedSubmissionMessage}"></p>
+                </div>
                 <header class="form-card__header">
                     <h1 id="header" class="h2" th:utext="#{submit-complete.header}"></h1>
                 </header>

--- a/src/main/resources/templates/gcc/submit-confirmation.html
+++ b/src/main/resources/templates/gcc/submit-confirmation.html
@@ -15,9 +15,6 @@
         <div class="grid">
             <div th:replace="~{fragments/goBack :: goBackLink}"></div>
             <main id="content" role="main" class="form-card spacing-above-35">
-                <div th:if="${lockedSubmissionMessage}" class="notice--warning">
-                    <p th:text="${lockedSubmissionMessage}"></p>
-                </div>
                 <th:block th:replace="~{fragments/gcc-icons :: documentsSent}"></th:block>
                 <th:block th:replace="~{fragments/cardHeader :: cardHeader(
                     header=#{submit-confirmation.title(${provider.getDisplayName()})},

--- a/src/main/resources/templates/gcc/submit-next-steps.html
+++ b/src/main/resources/templates/gcc/submit-next-steps.html
@@ -24,7 +24,7 @@
                         </div>
                         <div class="form-card__footer">
                             <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
-                                text=#{submit-next-steps.button})}"/>
+                                text=#{general.button.continue})}"/>
                         </div>
                     </th:block>
                 </th:block>

--- a/src/main/resources/templates/gcc/submit-next-steps.html
+++ b/src/main/resources/templates/gcc/submit-next-steps.html
@@ -14,8 +14,7 @@
                     <p id="header-help-message"
                        th:utext="#{submit-next-steps.subtext}"></p>
                 </header>
-                <th:block
-                        th:replace="~{fragments/form :: form(action=|/flow/${flow}/${screen}/submit|, content=~{::formContent})}">
+                <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
                     <th:block th:ref="formContent">
                         <div class="form-card__content">
                             <div class="notice--success">

--- a/src/main/resources/templates/gcc/submit-sign-name.html
+++ b/src/main/resources/templates/gcc/submit-sign-name.html
@@ -12,8 +12,8 @@
                 <th:block th:replace="~{fragments/cardHeader :: cardHeader(
                         header=#{submit-sign-name.title},
                         subtext=#{submit-sign-name.subtext})}"/>
-                <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-                    <th:block th:ref="formContent">
+                <th:block
+                    th:replace="~{fragments/form :: form(action=|/flow/${flow}/${screen}/submit|, content=~{::formContent})}">                    <th:block th:ref="formContent">
                         <div class="form-card__content">
                             <th:block th:replace="~{fragments/inputs/text ::
                                 text(inputName='signedName',

--- a/src/main/resources/templates/gcc/submit-sign-name.html
+++ b/src/main/resources/templates/gcc/submit-sign-name.html
@@ -28,7 +28,7 @@
                         </div>
                         <div class="form-card__footer">
                             <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
-                                text=#{general.inputs.continue})}"/>
+                                text=#{submit-sign-name.submit-application})}"/>
                         </div>
                     </th:block>
                 </th:block>

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -483,7 +483,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-sign-name.title"));
         testPage.enter("signedName", "parent first parent last");
         testPage.enter("partnerSignedName", "partner parent");
-        testPage.clickContinue();
+        testPage.clickButton(getEnMessage("submit-sign-name.submit-application"));
 
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
@@ -511,7 +511,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 
         // submit-next-steps
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-next-steps.title"));
-        testPage.clickButton(getEnMessage("submit-next-steps.button"));
+        testPage.clickContinue();
 
         // submit-confirmation
         assertThat(testPage.getTitle()).isEqualTo(getEnMessageWithParams("submit-confirmation.title", new Object[]{"Open Sesame"}));


### PR DESCRIPTION
#### 🔗 Jira ticket
[Link](https://codeforamerica.atlassian.net/browse/CCAP-191)

#### ✍️ Description
- Moves application submission to sign-name page
- Changes the lock application configuration to after sign-name

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
