### PR TITLE
Revert jackson-databind to the most recent compatible version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'
 
     implementation 'org.jobrunr:jobrunr-spring-boot-3-starter:7.2.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
 
     if (useLocalLibrary == 'true') {
         implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')


### PR DESCRIPTION
#### 🔗 Jira ticket
No Jira ticket, this PR resolves an issue we were seeing with jackson-databind and jackson-core compatibility after a dependabot update.

#### ✍️ Description
Updates jackson-databind to the most recent compatible version 2.16.2
