### PR TITLE
CCAP-186 Remove parentPartnerGender field

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -8,6 +8,7 @@ import formflow.library.utils.RegexUtils;
 import jakarta.validation.constraints.*;
 
 import java.util.List;
+
 import org.springframework.web.multipart.MultipartFile;
 
 public class Gcc extends FlowInputs {
@@ -66,7 +67,7 @@ public class Gcc extends FlowInputs {
     private String parentContactPreferredCommunicationMethod;
     private String parentHasPartner;
     private String parentHasQualifyingPartner;
-    @Phone(message="{errors.invalid-phone-number}")
+    @Phone(message = "{errors.invalid-phone-number}")
     private String parentPartnerPhoneNumber;
     @Email(regexp = RegexUtils.EMAIL_REGEX, message = "{errors.invalid-email}")
     private String parentPartnerEmail;
@@ -83,7 +84,6 @@ public class Gcc extends FlowInputs {
     private String parentPartnerBirthDay;
     private String parentPartnerBirthMonth;
     private String parentPartnerBirthYear;
-    private List<String> parentPartnerGender;
     @Phone(message = "{errors.invalid-phone-number}")
     private String phoneNumber;
     private String streetAddress;
@@ -129,7 +129,7 @@ public class Gcc extends FlowInputs {
     @Encrypted
     private String parentSsn;
     private List<String> parentGender;
-    
+
     private String parentConfirmSuggestedAddress;
 
     private String hasAdultDependents;

--- a/src/main/resources/templates/gcc/parent-partner-info-basic.html
+++ b/src/main/resources/templates/gcc/parent-partner-info-basic.html
@@ -3,36 +3,36 @@
 <head th:replace="~{fragments/head :: head(title=#{parent-partner-info-basic.title})}"></head>
 <body>
 <div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/gcc-icons :: person}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-partner-info-basic.header})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent" th:with="genderOptions=${T(org.ilgcc.app.utils.GenderOption).values()}">
-
-            <div class="form-card__content">
-              <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerFirstName', helpText=#{parent-partner-info-basic.first.name.help}, label=#{general.question.their-first-name})}"/>
-              <th:block th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerLastName', helpText=#{parent-partner-info-basic.last.name.help}, label=#{general.question.their-last-name})}"/>
-              <th:block th:replace="~{fragments/inputs/date :: date(inputName='parentPartnerBirth', groupName='parentPartnerBirth', label=|#{general.question.their-date-of-birth}*|)}"/>
-              <th:block th:replace="~{fragments/inputs/ssn :: ssn(inputName='parentPartnerSSN', helpText=#{parent-partner-info-basic.ssn.help}, label=#{parent-partner-info-basic.ssn})}"/>
-              <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
-                  checkboxFieldset(inputName='parentPartnerGender',
-                    label=#{parent-partner-info-basic.gender},
-                    options=${genderOptions},
-                    fieldsetHelpText=#{parent-partner-info-basic.gender.help},
-                    noneOfTheAboveLabel=#{general.inputs.prefer-not-to-answer})}"/>
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/gcc-icons :: person}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-partner-info-basic.header})}"/>
+                <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+                    <th:block th:ref="formContent"
+                              th:with="genderOptions=${T(org.ilgcc.app.utils.GenderOption).values()}">
+                        <div class="form-card__content">
+                            <th:block
+                                    th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerFirstName', helpText=#{parent-partner-info-basic.first.name.help}, label=#{general.question.their-first-name})}"/>
+                            <th:block
+                                    th:replace="~{fragments/inputs/text :: text(inputName='parentPartnerLastName', helpText=#{parent-partner-info-basic.last.name.help}, label=#{general.question.their-last-name})}"/>
+                            <th:block
+                                    th:replace="~{fragments/inputs/date :: date(inputName='parentPartnerBirth', groupName='parentPartnerBirth', label=|#{general.question.their-date-of-birth}*|)}"/>
+                            <th:block
+                                    th:replace="~{fragments/inputs/ssn :: ssn(inputName='parentPartnerSSN', helpText=#{parent-partner-info-basic.ssn.help}, label=#{parent-partner-info-basic.ssn})}"/>
+                        </div>
+                        <div class="form-card__footer">
+                            <th:block
+                                    th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+                        </div>
+                    </th:block>
+                </th:block>
+            </main>
+        </div>
+    </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
 </body>


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-186](https://codeforamerica.atlassian.net/browse/CCAP-186)

#### ✍️ Description
- Remove `parentPartnerGender` field and question
- I decided to NOT remove the now unused translations. I could go either way, but I figured if we need those translations in the future, better to have them there and in Transifex.

![2024-07-22 at 15 52 31@2x](https://github.com/user-attachments/assets/8c138fb6-54b7-4028-9315-f44a82460ea2)


#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria


[CCAP-186]: https://codeforamerica.atlassian.net/browse/CCAP-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ