### PR TITLE
Update onboarding-getting-started eligibility language

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -147,6 +147,9 @@ onboarding-getting-started.accordion.first.label=Session timeout
 onboarding-getting-started.accordion.first.paragraph-1=To protect your information, your session will time out if you leave the application for more than 1 hour.
 onboarding-getting-started.accordion.first.paragraph-2=You can not save your application and return later.
 onboarding-getting-started.accordion.second.label=Check eligibility
+onboarding-getting-started.accordion.second.paragraph-1: To be eligible for Child Care Assistance, parents must be busy or unable to take care of their child.
+onboarding-getting-started.accordion.second.paragraph-2: Qualifying activities include:
+onboarding-getting-started.accordion.second.paragraph-3: Qualifying family incomes include:
 onboarding-getting-started.accordion.third.label=Gather your documents
 onboarding-getting-started.accordion.third.paragraph-1=At the end of this application you will have the option to submit documents from your phone or computer.
 onboarding-getting-started.accordion.third.paragraph-2=The most commonly requested documents verify your income, job, or school.

--- a/src/main/resources/templates/gcc/onboarding-getting-started.html
+++ b/src/main/resources/templates/gcc/onboarding-getting-started.html
@@ -24,7 +24,19 @@
             buttonLabel=#{onboarding-getting-started.accordion.second.label},
             content=~{::second})}">
             <th:block th:ref="second">
-              <p th:text="#{general.eligibility-table.title}"></p>
+              <p th:text="#{onboarding-getting-started.accordion.second.paragraph-1}"></p>
+              <p th:text="#{onboarding-getting-started.accordion.second.paragraph-2}"></p>
+              <ul class="list--bulleted">
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.working}"></li>
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.enrolling}"></li>
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.experiencing-homelessness}"></li>
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.deployed}"></li>
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.participating}"></li>
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.caring}"></li>
+                <li th:text="#{faq.do-i-qualify-for-ccap.activities.li.when-you-are-working}"></li>
+              </ul>
+                <br/>
+              <p th:text="#{onboarding-getting-started.accordion.second.paragraph-3}"></p>
               <table class="eligibility-table">
                 <thead>
                 <tr>


### PR DESCRIPTION
#### 🔗 Jira ticket
This ticket adds eligibility information in the onboarding-getting started page, pet Carl's comment: https://codeforamerica.atlassian.net/browse/CCAP-234?focusedCommentId=11042

#### ✍️ Description
The strings describing eligible activities have been copied over from the FAQ Screen. These differ from Carl's comment in the Jira Ticket and the design but they are matching what is in FAQ because as Karen confirmed: (1) They should match. (2) the FAQ page has language already reviewed by the IDHS partners: https://cfastaff.slack.com/archives/C0648BQM6UX/p1721685187967209?thread_ts=1721682568.423519&cid=C0648BQM6UX


#### 📷 Design reference
![image](https://github.com/user-attachments/assets/3896a2e0-ad34-453c-abe3-6d81bd44ac63)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
