### PR TITLE
CCAP-63 Add new PDF custom preparers

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ApplicationPreparer.java
@@ -8,6 +8,9 @@ import formflow.library.pdf.SingleField;
 import formflow.library.pdf.SubmissionField;
 import formflow.library.pdf.SubmissionFieldPreparer;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -20,16 +23,29 @@ public class ApplicationPreparer implements SubmissionFieldPreparer {
     @Override
     public Map<String, SubmissionField> prepareSubmissionFields(Submission submission, PdfMap pdfMap) {
         var results = new HashMap<String, SubmissionField>();
-
         var inputData = submission.getInputData();
+        var receivedTimestampFormat = DateTimeFormatter.ofPattern("MMMM d, yyyy, h:mm a zzz");
+        ZoneId chicagoTimeZone = ZoneId.of("America/Chicago");
+
+        Optional<OffsetDateTime> submittedAt = Optional.ofNullable(submission.getSubmittedAt());
+        submittedAt.ifPresent(offsetDateTime -> {
+            offsetDateTime.atZoneSameInstant(chicagoTimeZone);
+            String formattedSubmittedAtDate = offsetDateTime.atZoneSameInstant(chicagoTimeZone).format(receivedTimestampFormat);
+            results.put("receivedTimestamp", new SingleField("receivedTimestamp", formattedSubmittedAtDate, null));
+        });
 
         var partnerSignature = inputData.getOrDefault("partnerSignedName", "");
 
         if (!partnerSignature.equals("")) {
             Optional<LocalDate> partnerSignatureDate = Optional.of(LocalDate.from(submission.getSubmittedAt()));
             results.put("partnerSignedAt",
-                new SingleField("partnerSignedAt", formatToStringFromLocalDate(partnerSignatureDate), null));
+                    new SingleField("partnerSignedAt", formatToStringFromLocalDate(partnerSignatureDate), null));
         }
+
+        var parentFirstName = inputData.getOrDefault("parentFirstName", "");
+        var parentLastName = inputData.getOrDefault("parentLastName", "");
+        results.put("parentFullName",
+                new SingleField("parentFullName", String.format("%s, %s", parentLastName, parentFirstName), null));
 
         String rentalIncome = inputData.getOrDefault("unearnedIncomeRental", "").toString();
         String dividendIncome = inputData.getOrDefault("unearnedIncomeDividends", "").toString();
@@ -38,10 +54,12 @@ public class ApplicationPreparer implements SubmissionFieldPreparer {
         String pensionIncome = inputData.getOrDefault("unearnedIncomePension", "0").toString();
         String workersIncome = inputData.getOrDefault("unearnedIncomeWorkers", "0").toString();
 
-        var totalExpenses = PreparerUtilities.numberValueOf(rentalIncome) + PreparerUtilities.numberValueOf(dividendIncome) + PreparerUtilities.numberValueOf(unemploymentIncome) + PreparerUtilities.numberValueOf(royaltiesIncome) + PreparerUtilities.numberValueOf(pensionIncome) + PreparerUtilities.numberValueOf(workersIncome);
+        var totalExpenses = PreparerUtilities.numberValueOf(rentalIncome) + PreparerUtilities.numberValueOf(dividendIncome)
+                + PreparerUtilities.numberValueOf(unemploymentIncome) + PreparerUtilities.numberValueOf(royaltiesIncome)
+                + PreparerUtilities.numberValueOf(pensionIncome) + PreparerUtilities.numberValueOf(workersIncome);
 
         results.put("otherMonthlyIncomeApplicant",
-            new SingleField("otherMonthlyIncomeApplicant", String.format("%.0f", Math.floor(totalExpenses)), null));
+                new SingleField("otherMonthlyIncomeApplicant", String.format("%.0f", Math.floor(totalExpenses)), null));
 
         return results;
     }

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -349,13 +349,13 @@ flow:
     nextScreens:
       - name: submit-complete
   submit-complete:
-    beforeDisplayAction: FormatSubmittedAtDate
     nextScreens:
       - name: submit-next-steps
   submit-next-steps:
     nextScreens:
       - name: submit-confirmation
   submit-confirmation:
+    beforeDisplayAction: FormatSubmittedAtDate
     nextScreens:
       - name: submit-confirmation
   doc-upload-recommended-docs:

--- a/src/main/resources/pdf-map.yaml
+++ b/src/main/resources/pdf-map.yaml
@@ -3,6 +3,7 @@ pdf: /pdfs/IL-CCAP-Form.pdf
 inputFields:
   parentFirstName: APPLICANT_NAME_FIRST
   parentLastName: APPLICANT_NAME_LAST
+  parentFullName: APPLICANT_NAME_FULL
   parentHomeStreetAddress1: APPLICANT_ADDRESS_HOME_STREET
   parentHomeStreetAddress2: APPLICANT_ADDRESS_HOME_APT
   parentHomeCity: APPLICANT_ADDRESS_HOME_CITY
@@ -122,6 +123,7 @@ inputFields:
   signedName: APPLICANT_SIGNATURE
   partnerSignedName: PARTNER_SIGNATURE
   partnerSignedAt: PARTNER_SIGNATURE_DATE
+  receivedTimestamp: RECEIVED_TIMESTAMP
 dbFields:
   submittedAt: APPLICANT_SIGNATURE_DATE
 

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -578,7 +578,11 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
     private static List<String> getMissMatches(AcroFields expectedAcroFields, AcroFields actualAcroFields) {
         List<String> missMatches = new ArrayList<>();
 //        These fields are dynamic and untestable with the current PDF approach
-        List<String> UNTESTABLE_FIELDS = List.of("PARTNER_SIGNATURE_DATE", "APPLICANT_SIGNATURE_DATE");
+        List<String> UNTESTABLE_FIELDS = List.of(
+                "PARTNER_SIGNATURE_DATE",
+                "APPLICANT_SIGNATURE_DATE",
+                "APPLICANT_NAME_FULL",
+                "RECEIVED_TIMESTAMP");
         for (String expectedField : expectedAcroFields.getAllFields().keySet()) {
             if(!UNTESTABLE_FIELDS.contains(expectedField)){
                 var actual = actualAcroFields.getField(expectedField);

--- a/src/test/java/org/ilgcc/app/pdf/ApplicationPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ApplicationPreparerTest.java
@@ -13,87 +13,114 @@ import org.junit.jupiter.api.Test;
 
 public class ApplicationPreparerTest {
 
-  private final ApplicationPreparer preparer = new ApplicationPreparer();
+    private final ApplicationPreparer preparer = new ApplicationPreparer();
 
-  private Submission submission;
+    private Submission submission;
 
-  @Test
-  public void addsPartnerSignatureDateIfPartnerSignatureExists() {
-    submission = new SubmissionTestBuilder()
-        .with("partnerSignedName", "PartnerSignature")
-        .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
-        .build();
+    @Test
+    public void addsPartnerSignatureDateIfPartnerSignatureExists() {
+        submission = new SubmissionTestBuilder().with("partnerSignedName", "PartnerSignature")
+                .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0))).build();
 
-    Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
 
-    assertThat(result.get("partnerSignedAt")).isEqualTo(new SingleField("partnerSignedAt", "10/11/2022", null));
-  }
+        assertThat(result.get("partnerSignedAt")).isEqualTo(new SingleField("partnerSignedAt", "10/11/2022", null));
+    }
 
-  @Test
-  public void doesNotAddPartnerSignatureDateIfPartnerSignatureBlank() {
-    submission = new SubmissionTestBuilder()
-        .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
-        .build();
+    @Test
+    public void doesNotAddPartnerSignatureDateIfPartnerSignatureBlank() {
+        submission = new SubmissionTestBuilder().withSubmittedAtDate(
+                OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0))).build();
 
-    Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
 
-    assertThat(result.get("partnerSignedAt")).isEqualTo(null);
-  }
+        assertThat(result.get("partnerSignedAt")).isEqualTo(null);
+    }
 
-  @Test
-  public void setsOtherMonthlyIncomeToZeroWhenNoUnearnedIncome(){
-    submission = new SubmissionTestBuilder().build();
+    @Test
+    public void setsOtherMonthlyIncomeToZeroWhenNoUnearnedIncome() {
+        submission = new SubmissionTestBuilder().build();
 
-    Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
 
-    assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(new SingleField("otherMonthlyIncomeApplicant", "0", null));
-  }
+        assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(
+                new SingleField("otherMonthlyIncomeApplicant", "0", null));
+    }
 
-  @Test
-  public void setsOtherMonthlyIncomeByAddingUnearnedIncome(){
-    submission = new SubmissionTestBuilder()
-        .with("unearnedIncomeRental", "123")
-        .with("unearnedIncomeDividends", "127")
-        .with("unearnedIncomeUnemployment", "124")
-        .with("unearnedIncomeRoyalties", "126")
-        .with("unearnedIncomePension", "122")
-        .with("unearnedIncomeWorkers", "128")
-        .build();
+    @Test
+    public void setsOtherMonthlyIncomeByAddingUnearnedIncome() {
+        submission = new SubmissionTestBuilder().with("unearnedIncomeRental", "123").with("unearnedIncomeDividends", "127")
+                .with("unearnedIncomeUnemployment", "124").with("unearnedIncomeRoyalties", "126")
+                .with("unearnedIncomePension", "122").with("unearnedIncomeWorkers", "128").build();
 
-    Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
 
-    assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(new SingleField("otherMonthlyIncomeApplicant", "750", null));
-  }
+        assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(
+                new SingleField("otherMonthlyIncomeApplicant", "750", null));
+    }
 
-  @Test
-  public void setsOtherMonthlyIncomeWithEmptyStringValue(){
-    submission = new SubmissionTestBuilder()
-        .with("unearnedIncomeRental", "")
-        .with("unearnedIncomeDividends", "")
-        .with("unearnedIncomeUnemployment", "124")
-        .with("unearnedIncomeRoyalties", "126")
-        .with("unearnedIncomePension", "")
-        .with("unearnedIncomeWorkers", "")
-        .build();
+    @Test
+    public void setsOtherMonthlyIncomeWithEmptyStringValue() {
+        submission = new SubmissionTestBuilder().with("unearnedIncomeRental", "").with("unearnedIncomeDividends", "")
+                .with("unearnedIncomeUnemployment", "124").with("unearnedIncomeRoyalties", "126")
+                .with("unearnedIncomePension", "").with("unearnedIncomeWorkers", "").build();
 
-    Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
 
-    assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(new SingleField("otherMonthlyIncomeApplicant", "250", null));
-  }
+        assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(
+                new SingleField("otherMonthlyIncomeApplicant", "250", null));
+    }
 
-  @Test
-  public void roundsDownOtherMonthlyIncome(){
-    submission = new SubmissionTestBuilder()
-        .with("unearnedIncomeRental", "")
-        .with("unearnedIncomeDividends", "")
-        .with("unearnedIncomeUnemployment", "124.33")
-        .with("unearnedIncomeRoyalties", "126.66")
-        .with("unearnedIncomePension", "")
-        .with("unearnedIncomeWorkers", "")
-        .build();
+    @Test
+    public void roundsDownOtherMonthlyIncome() {
+        submission = new SubmissionTestBuilder().with("unearnedIncomeRental", "").with("unearnedIncomeDividends", "")
+                .with("unearnedIncomeUnemployment", "124.33").with("unearnedIncomeRoyalties", "126.66")
+                .with("unearnedIncomePension", "").with("unearnedIncomeWorkers", "").build();
 
-    Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
 
-    assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(new SingleField("otherMonthlyIncomeApplicant", "250", null));
-  }
+        assertThat(result.get("otherMonthlyIncomeApplicant")).isEqualTo(
+                new SingleField("otherMonthlyIncomeApplicant", "250", null));
+    }
+
+    @Test
+    public void doesNotAddReceivedTimestampIfSubmittedAtBlank() {
+        submission = new SubmissionTestBuilder().build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+
+        assertThat(result.get("receivedTimestamp")).isEqualTo(null);
+    }
+
+
+    @Test
+    public void receivedTimestampIsFormattedCorrectlyInDaylightTime() {
+        submission = new SubmissionTestBuilder().withSubmittedAtDate(
+                OffsetDateTime.of(2024, 6, 6, 23, 47, 0, 0, ZoneOffset.of("+00:00"))).build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+
+        assertThat(result.get("receivedTimestamp")).isEqualTo(
+                new SingleField("receivedTimestamp", "June 6, 2024, 6:47 PM CDT", null));
+    }
+
+    @Test
+    public void receivedTimestampIsFormattedCorrectlyInStandardTime() {
+        submission = new SubmissionTestBuilder().withSubmittedAtDate(
+                OffsetDateTime.of(2024, 12, 6, 23, 47, 0, 0, ZoneOffset.of("+00:00"))).build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+
+        assertThat(result.get("receivedTimestamp")).isEqualTo(
+                new SingleField("receivedTimestamp", "December 6, 2024, 5:47 PM CST", null));
+    }
+
+    @Test
+    public void addsParentFullName() {
+        submission = new SubmissionTestBuilder().with("parentFirstName", "Lily-Mae").with("parentLastName", "Stone").build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);
+
+        assertThat(result.get("parentFullName")).isEqualTo(new SingleField("parentFullName", "Stone, Lily-Mae", null));
+    }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-63](https://codeforamerica.atlassian.net/browse/CCAP-63)

#### ✍️ Description
- Add unit test for `parentFullName`
- Add unit test for `receivedTimestamp`
- Ignore these fields in `verifyPDF` because fields from custom preparers aren't in the db and that's a limitation of our pdf testing.
- I moved the call to the action `FormatSubmittedAtDate` to happen on the `submit-confirmation` screen so that it was triggering after the `submittedAt` is filled, [so that the confirmation screen correctly displays the formatted date time](https://cfastaff.slack.com/archives/C0648BQM6UX/p1721834799327459) (this was not apart of the ticket but it was simple and closely releated).

![2024-07-23 at 12 49 47@2x](https://github.com/user-attachments/assets/33b488f6-219d-4d4d-92f3-39eca84cbd4e)


#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria


[CCAP-63]: https://codeforamerica.atlassian.net/browse/CCAP-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ