### PR TITLE
Remove dashboard being disabled in prod

### DIFF
--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -20,11 +20,3 @@ management:
     web:
       exposure:
         include: '*'
-org:
-  jobrunr:
-    job-scheduler:
-      enabled: true
-    background-job-server:
-      enabled: true
-    dashboard:
-      enabled: false


### PR DESCRIPTION
#### ✍️ Description
We don't need to determine dashboard settings in the production env because the dashboard is disabled by default, and only enabled in a different port in aptible.
