### PR TITLE
[CCAP-243] Typo on activities-partner-add-jobs screen

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -476,6 +476,7 @@ activities-ed-program-method.schedule.header=Are your classes taught on a schedu
 activities-partner-add-jobs.title=Activities Partner Add Jobs
 activities-partner-add-jobs.header=Now, let''s add {0}''s jobs.
 activities-partner-add-jobs.subtext=We will ask for their income and work schedule for each jobs.
+activities-partner-add-jobs.this-is-all-their-jobs=That is all their jobs
 #activities-partner-employer-name
 activities-partner-employer-name.title=Activities Partner Employer Name
 activities-partner-employer-name.header=What is the employer or company name?

--- a/src/main/resources/templates/gcc/activities-partner-add-job.html
+++ b/src/main/resources/templates/gcc/activities-partner-add-job.html
@@ -52,7 +52,7 @@
               <div>
                 <a th:if="${addedJobs}"
                    th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'"
-                   th:text="#{activities-add-jobs.this-is-all-my-jobs}"
+                   th:text="#{activities-partner-add-jobs.this-is-all-their-jobs}"
                    class="button spacing-left-0"
                    id="done-adding-jobs"></a>
               </div>

--- a/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
@@ -519,7 +519,7 @@ public class ActivitiesJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
         //activities-partner-add-job
         assertThat(testPage.getHeader()).isEqualTo(getEnMessageWithParams("activities-partner-add-job.header.any-other-jobs", new Object[]{"partner"}));
-        testPage.clickButton(getEnMessage("activities-add-jobs.this-is-all-my-jobs"));
+        testPage.clickButton(getEnMessage("activities-partner-add-jobs.this-is-all-their-jobs"));
         //activities-partner-add-ed-program
         assertThat(testPage.getHeader()).isEqualTo(getEnMessageWithParams("activities-partner-add-ed-program.header", new Object[]{"partner"}));
         testPage.clickContinue();

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -412,7 +412,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 
         //activities-partner-add-job
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("activities-partner-add-jobs.title"));
-        testPage.clickButton(getEnMessage("activities-add-jobs.this-is-all-my-jobs"));
+        testPage.clickButton(getEnMessage("activities-partner-add-jobs.this-is-all-their-jobs"));
         // activities-partner-ed
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("activities-ed-program.title"));
         testPage.clickContinue();


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-243

#### ✍️ Description
Button text on activities-partner-add-jobs screen says “That is all my jobs”, but should read "That is all their jobs"

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
