### PR TITLE
[CCAP-267] Remove periods from the end of H1 titles

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -306,7 +306,7 @@ children-info-intro.box.two=Which children need care
 children-info-intro.box.three=Child care schedules
 #
 children-add.title=Children add
-children-add.header=Add your children.
+children-add.header=Add your children
 children-add.subtext=Include all biological or adopted children under the age of 18 that live with you.
 children-add.add-button=Add child
 children-add.thats-all=That is all my children
@@ -369,7 +369,7 @@ activities-parent-intro.box.two=Work info
 activities-parent-intro.box.three=School info
 #activities-parent-type
 activities-parent-type.title=Activities Parent Type
-activities-parent-type.header=Tell us why you need child care.
+activities-parent-type.header=Tell us why you need child care
 activities-parent-type.doing-while-in-care=What are you doing while your child is in care?
 activities-parent-type.working=Working
 activities-parent-type.going-to-school=Going to school or training
@@ -440,9 +440,9 @@ activities-work-commute-time.default.option=Select commute time
 #activities-add-jobs-list
 #activities-add-ed-program
 activities-ed-program.title=School or training program
-activities-add-ed-program.header=Tell us about your school or training program.
+activities-add-ed-program.header=Tell us about your school or training program
 activities-add-ed-program.subtext=We will ask for program info and class schedule. You may be asked to submit your GPA at the end of the semester.
-activities-partner-add-ed-program.header=Now tell us about {0}''s school or training program.
+activities-partner-add-ed-program.header=Now tell us about {0}''s school or training program
 activities-partner-add-ed-program.subtext=We will ask for program info and class schedule. You may be asked to submit their GPA at the end of the semester.
 #activities-ed-program-type
 activities-ed-program-type.header=What type of school or training are you enrolled in?
@@ -474,7 +474,7 @@ activities-ed-program-method.program.hybrid=Hybrid (Online and In-Person)
 activities-ed-program-method.schedule.header=Are your classes taught on a schedule?
 #activities-partner-add-job
 activities-partner-add-jobs.title=Activities Partner Add Jobs
-activities-partner-add-jobs.header=Now, let''s add {0}''s jobs.
+activities-partner-add-jobs.header=Now, let''s add {0}''s jobs
 activities-partner-add-jobs.subtext=We will ask for their income and work schedule for each jobs.
 #activities-partner-employer-name
 activities-partner-employer-name.title=Activities Partner Employer Name
@@ -515,7 +515,7 @@ activities-partner-ed-program-method.program.header=How are {0}''s classes taugh
 activities-partner-ed-program-method.schedule.header=Are {0}''s classes taught on a schedule?
 
 #activities-next-class-schedule
-activities-next-class-schedule.header=Next, we'll ask about your class schedule.
+activities-next-class-schedule.header=Next, we'll ask about your class schedule
 activities-next-class-schedule.description=<b>Since your class schedule is flexible</b>, please select the days and times you plan to take classes or study while your child is in daycare.
 activities-next-class-schedule.skip=Skip because I don't need child care coverage during class time.
 activities-partner-next-class-schedule.skip=Skip because they don't need child care coverage during class time.

--- a/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ActivitiesJourneyTest.java
@@ -573,7 +573,7 @@ public class ActivitiesJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
 
         // Note that currently, we are skipping the parent partner job questions
-        assertThat(testPage.getHeader()).isEqualTo("Now tell us about partner's school or training program.");
+        assertThat(testPage.getHeader()).isEqualTo(getEnMessageWithParams("activities-partner-add-ed-program.header", new Object[]{"partner"}));
         testPage.clickContinue();
         testPage.clickElementById("partnerEducationType-fourYearCollege-label");
         assertThat(testPage.getHeader()).isEqualTo(getRequiredEnMessageWithParams("activities-partner-ed-program-type.header", new Object[]{"partner"}));


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-267

#### ✍️ Description
inconsistent punctuation in card titles - throughout the application, some titles have no punctuation while others have a period at the end

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
