### PR TITLE
CCAP-252 Handle illegal arguments

### DIFF
--- a/src/main/java/org/ilgcc/app/GlobalControllerExceptionHandler.java
+++ b/src/main/java/org/ilgcc/app/GlobalControllerExceptionHandler.java
@@ -10,8 +10,8 @@ import org.springframework.web.servlet.view.RedirectView;
 public class GlobalControllerExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public RedirectView handleIllegalArgumentException() {
-        log.info("IllegalArgumentException handled");
+    public RedirectView handleIllegalArgumentException(IllegalArgumentException e) {
+        log.info(String.format("IllegalArgumentException handled: %s", e.getMessage()));
         return new RedirectView("/error");
     }
 }

--- a/src/main/java/org/ilgcc/app/GlobalControllerExceptionHandler.java
+++ b/src/main/java/org/ilgcc/app/GlobalControllerExceptionHandler.java
@@ -1,0 +1,17 @@
+package org.ilgcc.app;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.view.RedirectView;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalControllerExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public RedirectView handleIllegalArgumentException() {
+        log.info("IllegalArgumentException handled");
+        return new RedirectView("/error");
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-252](https://codeforamerica.atlassian.net/browse/CCAP-252)

#### ✍️ Description
- Handle `IllegalArgumentException`

With this global adviser, when an illegal character is passed to an argument, in this case `lang=../..`, it is handled by redirecting to the `/error` screen, thus handling the exception.

![As seen in the Heroku environment, the error is handled.](https://github.com/user-attachments/assets/5915ffbb-d33d-44c0-a09d-83dcdf829c0e)


[CCAP-252]: https://codeforamerica.atlassian.net/browse/CCAP-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ