### PR TITLE
Use correct file extension in uploaded document transfer background job

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/SendUploadedFileToDocumentTransferService.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendUploadedFileToDocumentTransferService.java
@@ -1,5 +1,6 @@
 package org.ilgcc.app.submission.actions;
 
+import com.google.common.io.Files;
 import formflow.library.config.submission.Action;
 import formflow.library.data.Submission;
 import formflow.library.data.UserFile;
@@ -42,7 +43,8 @@ public class SendUploadedFileToDocumentTransferService implements Action {
             if (!userFiles.isEmpty()) {
                 for (int i = 0; i < userFiles.size(); i++) {
                     UserFile userFile = userFiles.get(i);
-                    String fileName = FileNameUtility.getFileNameForUploadedDocument(submission, i + 1, userFiles.size());
+                    String fileExtension = Files.getFileExtension(userFile.getOriginalName());
+                    String fileName = FileNameUtility.getFileNameForUploadedDocument(submission, i + 1, userFiles.size(), fileExtension);
                     CompletableFuture<Boolean> scannedAndCleanFuture = s3PresignService.isObjectScannedAndClean(userFile.getRepositoryPath());
                     int currentFileIndex = i;
                     scannedAndCleanFuture.thenAccept(scannedAndClean -> {

--- a/src/main/java/org/ilgcc/app/utils/enums/FileNameUtility.java
+++ b/src/main/java/org/ilgcc/app/utils/enums/FileNameUtility.java
@@ -21,12 +21,12 @@ public class FileNameUtility {
         return String.format("%s-%s-CCAP-Application-Form.pdf", formattedApplicantName, dashFormattedSubmittedAtDate);
     }
 
-    public static String getFileNameForUploadedDocument(Submission submission, int fileNumber, int totalFiles) {
+    public static String getFileNameForUploadedDocument(Submission submission, int fileNumber, int totalFiles, String fileExtension) {
         String applicantNameLastToFirst = SubmissionUtilities.getApplicantNameLastToFirst(submission);
         String formattedApplicantName = formatApplicantNameForFileName(applicantNameLastToFirst);
         String dashFormattedSubmittedAtDate = SubmissionUtilities.getDashFormattedSubmittedAtDate(submission);
-        return String.format("%s-%s-CCAP-Application-Form-Supporting-Document-%d-of-%d.pdf",
-                formattedApplicantName, dashFormattedSubmittedAtDate, fileNumber, totalFiles);
+        return String.format("%s-%s-CCAP-Application-Form-Supporting-Document-%d-of-%d.%s",
+                formattedApplicantName, dashFormattedSubmittedAtDate, fileNumber, totalFiles, fileExtension);
     }
 
     public static String formatApplicantNameForFileName(String fullNameLastToFirst) {


### PR DESCRIPTION
Fixes an issue where uploaded documents were being incorrectly given a .pdf extension when transferred to the document transfer service. 