### PR TITLE
CCAP-262 Make header and footer link hovers contrast accessible

### DIFF
--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -78,6 +78,11 @@ html, body {
   color: var(--white);
 }
 
+.main-header a:not([role="menuitem"]):hover,
+.main-footer a:hover {
+  color: var(--idhs-highlight-green);
+}
+
 main.slab {
   padding-top: 0;
   padding-bottom: 0;


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-262](https://codeforamerica.atlassian.net/browse/CCAP-262)

#### ✍️ Description
- Make link hover color have more contrast in the `.main-header` and `.main-footer`
- Ignore the links in the language dropdown as the background is `white`.

![2024-08-20 at 16 50 21@2x](https://github.com/user-attachments/assets/afe4e63e-dce9-4ca1-8ded-dc3432d1ee3b)


[CCAP-262]: https://codeforamerica.atlassian.net/browse/CCAP-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ