### PR TITLE
Ccap 34 document upload conditional logic

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/conditions/HasRecommendedDocumentsToUpload.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/HasRecommendedDocumentsToUpload.java
@@ -1,0 +1,16 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.ilgcc.app.utils.RecommendedDocumentsUtilities;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HasRecommendedDocumentsToUpload implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    return RecommendedDocumentsUtilities.shouldDisplayRecommendedDocumentScreens(submission);
+  }
+
+}

--- a/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
@@ -75,7 +75,7 @@ public class RecommendedDocumentsUtilities {
     List<Map> jobs = (List<Map>) submission.getInputData().getOrDefault("jobs", emptyList());
     if (!jobs.isEmpty()) {
       for (var job : jobs) {
-        if (job.getOrDefault("isSelfEmployed", "no").equals("yes")) {
+        if (job.getOrDefault("isSelfEmployed", "false").equals("true")) {
           return true;
         }
       }
@@ -83,7 +83,7 @@ public class RecommendedDocumentsUtilities {
     List<Map> partnerJobs = (List<Map>) submission.getInputData().getOrDefault("partnerJobs", emptyList());
     if (!partnerJobs.isEmpty()) {
       for (var job : partnerJobs) {
-        if (job.getOrDefault("isSelfEmployed", "no").equals("yes")) {
+        if (job.getOrDefault("isSelfEmployed", "false").equals("true")) {
           return true;
         }
       }

--- a/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
@@ -96,7 +96,6 @@ public class RecommendedDocumentsUtilities {
         showTANFDocumentation(submission) ||
         showWorkingDocumentation(submission) ||
         showSelfEmploymentDocumentation(submission) ||
-        showSelfEmploymentDocumentation(submission)) ||
-        showRequiredHomelessnessDocuments(submission);
+        showRequiredHomelessnessDocuments(submission));
   }
 }

--- a/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
@@ -1,0 +1,102 @@
+package org.ilgcc.app.utils;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+
+public class RecommendedDocumentsUtilities {
+
+  //create a function that checks homelessness
+  public static boolean showRequiredHomelessnessDocuments(Submission submission) {
+    return submission.getInputData().getOrDefault("parentHomeExperiencingHomelessness[]", List.of("no")).equals(List.of("yes"));
+  }
+
+  public static boolean showTANFDocumentation(Submission submission) {
+    Map<String, Object> inputData = submission.getInputData();
+    List<String> parentNeedForChildcareReasons = (List<String>) inputData.getOrDefault("activitiesParentChildcareReason[]",
+        List.of());
+    boolean tanfISReasonForParentChildcareNeed = parentNeedForChildcareReasons.stream().anyMatch(
+        reason -> reason.equals(ChildcareReasonOption.TANF_TRAINING.toString())
+    );
+    boolean parentHasAPartner = inputData.getOrDefault("parentHasPartner", "false").equals("true");
+    if (parentHasAPartner) {
+      List<String> partnerNeedForChildcareReasons = (List<String>) inputData.getOrDefault(
+          "activitiesParentPartnerChildcareReason[]", List.of());
+      boolean tanfISReasonForPartnerChildcareNeed = partnerNeedForChildcareReasons.stream().anyMatch(
+          reason -> reason.equals(ChildcareReasonOption.TANF_TRAINING.toString())
+      );
+      return (tanfISReasonForPartnerChildcareNeed || tanfISReasonForParentChildcareNeed);
+    }
+    return tanfISReasonForParentChildcareNeed;
+  }
+
+  public static boolean showWorkingDocumentation(Submission submission) {
+    Map<String, Object> inputData = submission.getInputData();
+    List<String> parentNeedForChildcareReasons = (List<String>) inputData.getOrDefault("activitiesParentChildcareReason[]",
+        List.of());
+    boolean workingISReasonForParentChildcareNeed = parentNeedForChildcareReasons.stream().anyMatch(
+        reason -> reason.equals(ChildcareReasonOption.WORKING.toString())
+    );
+    boolean parentHasAPartner = inputData.getOrDefault("parentHasPartner", "false").equals("true");
+    if (parentHasAPartner) {
+      List<String> partnerNeedForChildcareReasons = (List<String>) inputData.getOrDefault(
+          "activitiesParentPartnerChildcareReason[]", List.of());
+      boolean workingISReasonForPartnerChildcareNeed = partnerNeedForChildcareReasons.stream().anyMatch(
+          reason -> reason.equals(ChildcareReasonOption.WORKING.toString())
+      );
+      return (workingISReasonForPartnerChildcareNeed || workingISReasonForParentChildcareNeed);
+    }
+    return workingISReasonForParentChildcareNeed;
+  }
+
+  public static boolean showSchoolOrTrainingDocumentation(Submission submission) {
+    Map<String, Object> inputData = submission.getInputData();
+    List<String> parentNeedForChildcareReasons = (List<String>) inputData.getOrDefault("activitiesParentChildcareReason[]",
+        List.of());
+    boolean schoolISReasonForParentChildcareNeed = parentNeedForChildcareReasons.stream().anyMatch(
+        reason -> reason.equals(ChildcareReasonOption.SCHOOL.toString())
+    );
+    boolean parentHasAPartner = inputData.getOrDefault("parentHasPartner", "false").equals("true");
+    if (parentHasAPartner) {
+      List<String> partnerNeedForChildcareReasons = (List<String>) inputData.getOrDefault(
+          "activitiesParentPartnerChildcareReason[]", List.of());
+      boolean schoolISReasonForPartnerChildcareNeed = partnerNeedForChildcareReasons.stream().anyMatch(
+          reason -> reason.equals(ChildcareReasonOption.SCHOOL.toString())
+      );
+      return (schoolISReasonForPartnerChildcareNeed || schoolISReasonForParentChildcareNeed);
+    }
+    return schoolISReasonForParentChildcareNeed;
+  }
+
+  public static boolean showSelfEmploymentDocumentation(Submission submission) {
+    //get jobs for parent if parent has a job
+    List<Map> jobs = (List<Map>) submission.getInputData().getOrDefault("jobs", emptyList());
+    if (!jobs.isEmpty()) {
+      for (var job : jobs) {
+        if (job.getOrDefault("isSelfEmployed", "no").equals("yes")) {
+          return true;
+        }
+      }
+    }
+    List<Map> partnerJobs = (List<Map>) submission.getInputData().getOrDefault("partnerJobs", emptyList());
+    if (!partnerJobs.isEmpty()) {
+      for (var job : partnerJobs) {
+        if (job.getOrDefault("isSelfEmployed", "no").equals("yes")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public static boolean shouldDisplayRecommendedDocumentScreens(Submission submission){
+    return (showSchoolOrTrainingDocumentation(submission) ||
+        showTANFDocumentation(submission) ||
+        showWorkingDocumentation(submission) ||
+        showSelfEmploymentDocumentation(submission) ||
+        showSelfEmploymentDocumentation(submission)) ||
+        showRequiredHomelessnessDocuments(submission);
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -359,6 +359,7 @@ flow:
     nextScreens:
       - name: submit-confirmation
   doc-upload-recommended-docs:
+    condition: HasRecommendedDocumentsToUpload
     nextScreens:
       - name: doc-upload-add-files
   doc-upload-add-files:

--- a/src/main/resources/templates/gcc/doc-upload-add-files.html
+++ b/src/main/resources/templates/gcc/doc-upload-add-files.html
@@ -13,7 +13,12 @@
         <th:block
             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::documentUpload})}">
           <th:block th:ref="documentUpload">
-            <div class="form-card__content">
+            <div class="form-card__content"
+                 th:with="showWorkingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showWorkingDocumentation(submission)},
+                          showSchoolOrTrainingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSchoolOrTrainingDocumentation(submission)},
+                          showTANFDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showTANFDocumentation(submission)},
+                          showSelfEmploymentDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSelfEmploymentDocumentation(submission)},
+                          showHomelessDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showRequiredHomelessnessDocuments(submission)}">
               <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
                 controlId='r1',
                 linkLabel=~{::revealLabel1},
@@ -25,11 +30,11 @@
                 </th:block>
                 <th:block th:ref="revealContent1">
                   <p th:text="#{doc-upload-add-files.accordion-1.p1}"></p>
-                  <p th:utext="#{doc-upload-add-files.accordion-1.body1}"></p>
-                  <p th:utext="#{doc-upload-add-files.accordion-1.body2}"></p>
-                  <p th:utext="#{doc-upload-add-files.accordion-1.body3}"></p>
-                  <p th:utext="#{doc-upload-add-files.accordion-1.body4}"></p>
-                  <p th:utext="#{doc-upload-add-files.accordion-1.body5}"></p>
+                  <p th:if="${showWorkingDocumentation}" th:id="job-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body1}"></p>
+                  <p th:if="${showSelfEmploymentDocumentation}" th:id="self-employment-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body2}"></p>
+                  <p th:if="${showSchoolOrTrainingDocumentation}" th:id="school-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body3}"></p>
+                  <p th:if="${showTANFDocumentation}" th:id="tanf-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body4}"></p>
+                  <p th:if="${showHomelessDocumentation}" th:id="homelessness-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body5}"></p>
                 </th:block>
               </th:block>
               <th:block

--- a/src/main/resources/templates/gcc/doc-upload-add-files.html
+++ b/src/main/resources/templates/gcc/doc-upload-add-files.html
@@ -14,29 +14,32 @@
             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::documentUpload})}">
           <th:block th:ref="documentUpload">
             <div class="form-card__content"
-                 th:with="showWorkingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showWorkingDocumentation(submission)},
+                 th:with="shouldDisplayRecommendedDocumentScreens=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).shouldDisplayRecommendedDocumentScreens(submission)},
+                          showWorkingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showWorkingDocumentation(submission)},
                           showSchoolOrTrainingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSchoolOrTrainingDocumentation(submission)},
                           showTANFDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showTANFDocumentation(submission)},
                           showSelfEmploymentDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSelfEmploymentDocumentation(submission)},
                           showHomelessDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showRequiredHomelessnessDocuments(submission)}">
-              <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
+              <div th:if="${shouldDisplayRecommendedDocumentScreens}">
+                <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
                 controlId='r1',
                 linkLabel=~{::revealLabel1},
                 content=~{::revealContent1},
                 forceShowContent='true')}">
-                <th:block th:ref="revealLabel1">
-                  <i class="icon-">&#xE862;</i>
-                  <th:span th:text="#{doc-upload-add-files.accordion-1.title}"></th:span>
+                  <th:block th:ref="revealLabel1">
+                    <i class="icon-">&#xE862;</i>
+                    <th:span th:text="#{doc-upload-add-files.accordion-1.title}"></th:span>
+                  </th:block>
+                  <th:block th:ref="revealContent1">
+                    <p th:text="#{doc-upload-add-files.accordion-1.p1}"></p>
+                    <p th:if="${showWorkingDocumentation}" th:id="job-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body1}"></p>
+                    <p th:if="${showSelfEmploymentDocumentation}" th:id="self-employment-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body2}"></p>
+                    <p th:if="${showSchoolOrTrainingDocumentation}" th:id="school-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body3}"></p>
+                    <p th:if="${showTANFDocumentation}" th:id="tanf-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body4}"></p>
+                    <p th:if="${showHomelessDocumentation}" th:id="homelessness-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body5}"></p>
+                  </th:block>
                 </th:block>
-                <th:block th:ref="revealContent1">
-                  <p th:text="#{doc-upload-add-files.accordion-1.p1}"></p>
-                  <p th:if="${showWorkingDocumentation}" th:id="job-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body1}"></p>
-                  <p th:if="${showSelfEmploymentDocumentation}" th:id="self-employment-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body2}"></p>
-                  <p th:if="${showSchoolOrTrainingDocumentation}" th:id="school-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body3}"></p>
-                  <p th:if="${showTANFDocumentation}" th:id="tanf-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body4}"></p>
-                  <p th:if="${showHomelessDocumentation}" th:id="homelessness-upload-instruction" th:utext="#{doc-upload-add-files.accordion-1.body5}"></p>
-                </th:block>
-              </th:block>
+              </div>
               <th:block
                   th:replace="~{fragments/inputs/overrides/fileUploader :: fileUploader(inputName='uploadDocuments')}"></th:block>
 

--- a/src/main/resources/templates/gcc/doc-upload-recommended-docs.html
+++ b/src/main/resources/templates/gcc/doc-upload-recommended-docs.html
@@ -11,28 +11,33 @@
         <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{doc-upload-recommended-docs.header}, subtext=#{doc-upload-recommended-docs.subheader})}"/>
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
-            <div class="form-card__content">
-              <div class="spacing-below-60">
+            <div class="form-card__content"
+                 th:with="showWorkingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showWorkingDocumentation(submission)},
+                          showSchoolOrTrainingDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSchoolOrTrainingDocumentation(submission)},
+                          showTANFDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showTANFDocumentation(submission)},
+                          showSelfEmploymentDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSelfEmploymentDocumentation(submission)},
+                          showHomelessDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showRequiredHomelessnessDocuments(submission)}">
+              <div class="spacing-below-60" th:id="job-recommendation" th:if="showWorkingDocumentation">
                 <th:block th:replace="~{fragments/gcc-icons :: incomeFamily}"></th:block>
                 <h2 class="h3 spacing-below-0 spacing-above-0" th:text="#{doc-upload-recommended-docs.jobs.header}"></h2>
                 <p th:text="#{doc-upload-recommended-docs.jobs.body}"></p>
               </div>
-              <div class="spacing-below-60">
+              <div class="spacing-below-60" th:id="self-employment-documentation" th:if="${showSelfEmploymentDocumentation}">
                 <th:block th:replace="~{fragments/gcc-icons :: income}"></th:block>
                 <h2 class="h3 spacing-below-0 spacing-above-0" th:text="#{doc-upload-recommended-docs.self-employment.header}"></h2>
                 <p th:text="#{doc-upload-recommended-docs.self-employment.body}"></p>
               </div>
-              <div class="spacing-below-60">
+              <div class="spacing-below-60" th:id="education-documentation" th:if="${showSchoolOrTrainingDocumentation}">
                 <th:block th:replace="~{fragments/gcc-icons :: education}"></th:block>
                 <h2 class="h3 spacing-below-0 spacing-above-0" th:text="#{doc-upload-recommended-docs.school.header}"></h2>
                 <p th:text="#{doc-upload-recommended-docs.school.body}"></p>
               </div>
-              <div class="spacing-below-60">
+              <div class="spacing-below-60" th:id="tanf-training-recommendation" th:if="${showTANFDocumentation}">
                 <th:block th:replace="~{fragments/gcc-icons :: job}"></th:block>
                 <h2 class="h3 spacing-below-0 spacing-above-0" th:text="#{doc-upload-recommended-docs.training.header}"></h2>
                 <p th:text="#{doc-upload-recommended-docs.training.body}"></p>
               </div>
-              <div class="spacing-below-60">
+              <div class="spacing-below-60" th:id="homeless-documentation" th:if="${showHomelessDocumentation}">
                 <th:block th:replace="~{fragments/gcc-icons :: homelessness}"></th:block>
                 <h2 class="h3 spacing-below-0 spacing-above-0" th:text="#{doc-upload-recommended-docs.homelessness.header}"></h2>
                 <p th:text="#{doc-upload-recommended-docs.homelessness.body}"></p>

--- a/src/main/resources/templates/gcc/doc-upload-recommended-docs.html
+++ b/src/main/resources/templates/gcc/doc-upload-recommended-docs.html
@@ -17,7 +17,7 @@
                           showTANFDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showTANFDocumentation(submission)},
                           showSelfEmploymentDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showSelfEmploymentDocumentation(submission)},
                           showHomelessDocumentation=${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).showRequiredHomelessnessDocuments(submission)}">
-              <div class="spacing-below-60" th:id="job-recommendation" th:if="showWorkingDocumentation">
+              <div class="spacing-below-60" th:if="${showWorkingDocumentation}" th:id="job-recommendation">
                 <th:block th:replace="~{fragments/gcc-icons :: incomeFamily}"></th:block>
                 <h2 class="h3 spacing-below-0 spacing-above-0" th:text="#{doc-upload-recommended-docs.jobs.header}"></h2>
                 <p th:text="#{doc-upload-recommended-docs.jobs.body}"></p>

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -1,0 +1,23 @@
+package org.ilgcc.app.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.Test;
+
+public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
+    @Test
+    void skipDocUploadRecommendedDocsScreenIfNoDocumentsAreRequiredForParentandNoSpouse(){
+    testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
+    saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+        .withParentDetails()
+        .withChild("First", "Child", "Yes")
+        .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+        .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+        .with("parentHomeExperiencingHomelessness[]", List.of())
+        .with("activitiesParentChildcareReason", List.of())
+        .build());
+    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-ccap-terms.title"));
+//    testPage.clickElementById();
+    }
+}

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.ilgcc.app.utils.AbstractBasePageTest;
 import org.junit.jupiter.api.Test;
-
+import org.ilgcc.app.utils.ChildcareReasonOption;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
     @Test
     void skipDocUploadRecommendedDocsScreenIfNoDocumentsAreRequiredForParentandNoSpouse(){
@@ -15,9 +15,47 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
         .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
         .with("parentHomeExperiencingHomelessness[]", List.of())
-        .with("activitiesParentChildcareReason", List.of())
+        .with("activitiesParentChildcareReason[]", List.of())
         .build());
     assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-ccap-terms.title"));
-//    testPage.clickElementById();
+    testPage.clickElementById("agreesToLegalTerms-true");
+    testPage.clickContinue();
+
+    // submit-sign-name
+    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-sign-name.title"));
+    testPage.enter("signedName", "parent first parent last");
+    testPage.clickButton(getEnMessage("submit-sign-name.submit-application"));
+
+    // submit-complete
+    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+    testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    }
+    @Test
+    void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredForParent(){
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .build());
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-ccap-terms.title"));
+        testPage.clickElementById("agreesToLegalTerms-true");
+        testPage.clickContinue();
+
+        // submit-sign-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-sign-name.title"));
+        testPage.enter("signedName", "parent first parent last");
+        testPage.clickButton(getEnMessage("submit-sign-name.submit-application"));
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
     }
 }

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -22,6 +22,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
 
     assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    assertThat(testPage.elementDoesNotExistById("controlId")).isTrue();
     }
     @Test
     void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredForParent(){

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -8,7 +8,7 @@ import org.ilgcc.app.utils.ChildcareReasonOption;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
     @Test
     void skipDocUploadRecommendedDocsScreenIfNoDocumentsAreRequiredForParentandNoSpouse(){
-    testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
+    testPage.navigateToFlowScreen("gcc/submit-complete");
     saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
         .withParentDetails()
         .withChild("First", "Child", "Yes")
@@ -17,14 +17,6 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         .with("parentHomeExperiencingHomelessness[]", List.of())
         .with("activitiesParentChildcareReason[]", List.of())
         .build());
-    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-ccap-terms.title"));
-    testPage.clickElementById("agreesToLegalTerms-true");
-    testPage.clickContinue();
-
-    // submit-sign-name
-    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-sign-name.title"));
-    testPage.enter("signedName", "parent first parent last");
-    testPage.clickButton(getEnMessage("submit-sign-name.submit-application"));
 
     // submit-complete
     assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
@@ -34,7 +26,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredForParent(){
-        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
+        testPage.navigateToFlowScreen("gcc/submit-complete");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -43,19 +35,197 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
             .build());
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-ccap-terms.title"));
-        testPage.clickElementById("agreesToLegalTerms-true");
-        testPage.clickContinue();
 
-        // submit-sign-name
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-sign-name.title"));
-        testPage.enter("signedName", "parent first parent last");
-        testPage.clickButton(getEnMessage("submit-sign-name.submit-application"));
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+    }
+
+    @Test
+    void shouldNotDisplayHomelessnessInstructionsForDocumentUploadIfHomelessnessNotSelected(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .build());
 
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
 
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("tanf-training-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.training.body"));
+        assertThat(testPage.elementDoesNotExistById("homeless-documentation")).isTrue();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+//        assertThat(testPage.getElementText("tanf-upload-instruction")).contains(getEnMessage("doc-upload-add-files.accordion-1.body4"));
+//        assertThat(testPage.elementDoesNotExistById("homelessness-upload-instruction")).isTrue();
+    }
+    @Test
+    void shouldNotDisplayJobInstructionsForDocumentUploadIfJobIsNotSelected(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("tanf-training-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.training.body"));
+        assertThat(testPage.elementDoesNotExistById("homeless-documentation")).isTrue();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    }
+    @Test
+    void shouldNotDisplaySelfEmploymentInstructionsForDocumentUploadIfSelfEmploymentIsNotSelected(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("WORKING"))
+            .withJob("jobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("job-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.jobs.body"));
+        assertThat(testPage.elementDoesNotExistById("self-employment-documentation")).isTrue();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    }
+    @Test
+    void shouldNotDisplayTanfInstructionsForDocumentUploadIfTanfIsNotSelected(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("WORKING"))
+            .withJob("jobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("job-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.jobs.body"));
+        assertThat(testPage.elementDoesNotExistById("tanf-training-recommendation")).isTrue();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    }
+    @Test
+    void shouldDisplayJobsInstructionsIfPartnerSelectsJobsAndParentDoesNot(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withParentPartnerDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("tanf-training-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.training.body"));
+        assertThat(testPage.elementDoesNotExistById("job-recommendation")).isFalse();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    }
+    @Test
+    void shouldDisplaySelfEmploymentInstructionsIfPartnerSelectsSelfEmploymentAndParentDoesNot(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withParentPartnerDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "true")
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("tanf-training-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.training.body"));
+        assertThat(testPage.elementDoesNotExistById("self-employment-documentation")).isFalse();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    }
+
+    @Test
+    void shouldDisplayTanfInstructionsIfPartnerSelectsTanfAndParentDoesNot(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withParentPartnerDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentPartnerChildcareReason[]", List.of("TANF_TRAINING"))
+            .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "true")
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("tanf-training-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.training.body"));
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
     }
 }

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.ilgcc.app.utils.AbstractBasePageTest;
 import org.junit.jupiter.api.Test;
-import org.ilgcc.app.utils.ChildcareReasonOption;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
     @Test
     void skipDocUploadRecommendedDocsScreenIfNoDocumentsAreRequiredForParentandNoSpouse(){
@@ -67,8 +66,36 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         // doc-upload-add-files
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
-//        assertThat(testPage.getElementText("tanf-upload-instruction")).contains(getEnMessage("doc-upload-add-files.accordion-1.body4"));
-//        assertThat(testPage.elementDoesNotExistById("homelessness-upload-instruction")).isTrue();
+        assertThat(testPage.elementDoesNotExistById("tanf-upload-instruction")).isFalse();
+        assertThat(testPage.elementDoesNotExistById("homelessness-upload-instruction")).isTrue();
+    }
+
+    @Test
+    void shouldNotDisplaySchoolInstructionsForDocumentUploadIfSchoolNotSelected(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("tanf-training-recommendation")).contains(getEnMessage("doc-upload-recommended-docs.training.body"));
+        assertThat(testPage.elementDoesNotExistById("education-documentation")).isTrue();
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("tanf-upload-instruction")).isFalse();
+        assertThat(testPage.elementDoesNotExistById("school-upload-instruction")).isTrue();
     }
     @Test
     void shouldNotDisplayJobInstructionsForDocumentUploadIfJobIsNotSelected(){
@@ -94,6 +121,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         // doc-upload-add-files
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("homeless-documentation")).isTrue();
     }
     @Test
     void shouldNotDisplaySelfEmploymentInstructionsForDocumentUploadIfSelfEmploymentIsNotSelected(){
@@ -120,6 +148,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         // doc-upload-add-files
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("self-employment-documentation")).isTrue();
     }
     @Test
     void shouldNotDisplayTanfInstructionsForDocumentUploadIfTanfIsNotSelected(){
@@ -146,18 +175,20 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         // doc-upload-add-files
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("tanf-training-recommendation")).isTrue();
     }
     @Test
     void shouldDisplayJobsInstructionsIfPartnerSelectsJobsAndParentDoesNot(){
         testPage.navigateToFlowScreen("gcc/submit-complete");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
+            .with("parentHasPartner", "true")
             .withParentPartnerDetails()
             .withChild("First", "Child", "Yes")
-            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
             .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
+            .with("activitiesParentPartnerChildcareReason[]", List.of("TANF_TRAINING", "WORKING"))
             .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
             .build());
 
@@ -173,6 +204,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         // doc-upload-add-files
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("job-upload-instruction")).isFalse();
     }
     @Test
     void shouldDisplaySelfEmploymentInstructionsIfPartnerSelectsSelfEmploymentAndParentDoesNot(){
@@ -207,6 +239,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         testPage.navigateToFlowScreen("gcc/submit-complete");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
+            .with("parentHasPartner", "true")
             .withParentPartnerDetails()
             .withChild("First", "Child", "Yes")
             .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
@@ -227,5 +260,33 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         // doc-upload-add-files
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("tanf-upload-instruction")).isFalse();
+    }
+    @Test
+    void shouldDisplaySchoolInstructionsIfPartnerSelectsSchoolAndParentDoesNot(){
+        testPage.navigateToFlowScreen("gcc/submit-complete");
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+            .withParentDetails()
+            .with("parentHasPartner", "true")
+            .withParentPartnerDetails()
+            .withChild("First", "Child", "Yes")
+            .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
+            .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
+            .with("parentHomeExperiencingHomelessness[]", List.of())
+            .with("activitiesParentPartnerChildcareReason[]", List.of("TANF_TRAINING", "SCHOOL"))
+            .build());
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        // doc-upload-recommended-docs
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        assertThat(testPage.getElementText("education-documentation")).contains(getEnMessage("doc-upload-recommended-docs.school.body"));
+
+        // doc-upload-add-files
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("school-upload-instruction")).isFalse();
     }
 }

--- a/src/test/java/org/ilgcc/app/pdf/ParentPartnerPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ParentPartnerPreparerTest.java
@@ -81,8 +81,8 @@ public class ParentPartnerPreparerTest {
   @Test
   public void partnerJobsProperlyMapped(){
     submission = new SubmissionTestBuilder()
-        .withPartnerJob("partnerJobs", "Partner Company One", "123 Partner First Job St", "Chicago", "IL", "60302", "(555) 123-1234")
-        .withPartnerJob("partnerJobs", "Partner Company Two", "456 Partner Second Job St", "Chicago", "IL", "60302", "(555) 343-1235")
+        .withPartnerJob("partnerJobs", "Partner Company One", "123 Partner First Job St", "Chicago", "IL", "60302", "(555) 123-1234", "false")
+        .withPartnerJob("partnerJobs", "Partner Company Two", "456 Partner Second Job St", "Chicago", "IL", "60302", "(555) 343-1235","false")
         .build();
 
     Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);

--- a/src/test/java/org/ilgcc/app/pdf/ParentPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ParentPreparerTest.java
@@ -82,7 +82,7 @@ public class ParentPreparerTest {
   @Test
   public void singleJobsIsProperlyMapped(){
     submission = new SubmissionTestBuilder()
-        .withJob("jobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234")
+        .withJob("jobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
         .build();
 
     Map<String, SubmissionField> result = preparer.prepareSubmissionFields(submission, null);

--- a/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
@@ -163,7 +163,7 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withJob(String subflow, String companyName, String employerStreetAddress, String employerCity,
-        String employerState, String employerZipCode, String employerPhoneNumber) {
+        String employerState, String employerZipCode, String employerPhoneNumber, String isSelfEmployed) {
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) submission.getInputData().get(subflow);
         if (jobs == null) {
             jobs = new ArrayList<>();
@@ -178,6 +178,7 @@ public class SubmissionTestBuilder {
         job.put("employerState", employerState);
         job.put("employerZipCode", employerZipCode);
         job.put("employerPhoneNumber", employerPhoneNumber);
+        job.put("isSelfEmployed", isSelfEmployed);
         job.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
         jobs.add(job);
         submission.getInputData().put(subflow, jobs);
@@ -185,7 +186,7 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withPartnerJob(String subflow, String companyName, String employerStreetAddress,
-        String employerCity, String employerState, String employerZipCode, String employerPhoneNumber) {
+        String employerCity, String employerState, String employerZipCode, String employerPhoneNumber, String isSelfEmployed) {
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) submission.getInputData().get(subflow);
         if (jobs == null) {
             jobs = new ArrayList<>();
@@ -200,6 +201,7 @@ public class SubmissionTestBuilder {
         job.put("partnerEmployerState", employerState);
         job.put("partnerEmployerZipCode", employerZipCode);
         job.put("partnerEmployerPhoneNumber", employerPhoneNumber);
+        job.put("isSelfEmployed", isSelfEmployed);
         job.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
         jobs.add(job);
         submission.getInputData().put(subflow, jobs);
@@ -297,7 +299,7 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withRegularWorkSchedule(List days, String startTime, String endTime) {
-        withJob("jobs", "Regular Schedule Job", "123 Main Str", "", "", "", "");
+        withJob("jobs", "Regular Schedule Job", "123 Main Str", "", "", "", "", "false");
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) submission.getInputData().get("jobs");
         if (jobs == null) {
             return this;
@@ -314,7 +316,7 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withWorkScheduleByDay(String day, String startTime, String endTime) {
-        withJob("jobs", "Regular Mixed Schedule Job", "123 Main Str", "", "", "", "");
+        withJob("jobs", "Regular Mixed Schedule Job", "123 Main Str", "", "", "", "", "false");
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) submission.getInputData().get("jobs");
         if (jobs == null) {
             return this;
@@ -337,7 +339,7 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withPartnerRegularWorkSchedule(List days, String startTime, String endTime) {
-        withJob("partnerJobs", "Regular Schedule Job", "123 Main Str", "", "", "", "");
+        withJob("partnerJobs", "Regular Schedule Job", "123 Main Str", "", "", "", "", "false");
         List<Map<String, Object>> jobs = (List<Map<String, Object>>) submission.getInputData().get("partnerJobs");
         if (jobs == null) {
             return this;
@@ -355,7 +357,7 @@ public class SubmissionTestBuilder {
 
     public SubmissionTestBuilder withPartnerWorkScheduleByDay(String day, String startTime, String endTime) {
         withParentPartnerDetails();
-        withJob("partnerJobs", "Regular Mixed Schedule Job", "123 Main Str", "", "", "", "");
+        withJob("partnerJobs", "Regular Mixed Schedule Job", "123 Main Str", "", "", "", "", "false");
         List<Map<String, Object>> partnerJobs = (List<Map<String, Object>>) submission.getInputData().get("partnerJobs");
         if (partnerJobs == null) {
             return this;


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-34

#### ✍️ Description
## doc-upload-recommended-docs

  - [ ] If no documents are required, then skip this screen and go directly to the doc-upload-add-files screen
  - [ ] Only show the Parent jobs and income required documents information if one parent indicated "Working" as a reason for childcare on the activities-parent-type screen 
  - [ ] Only show the Self-Employment information if one parent answered "Yes" to say that they were self-employed on either the activities-self-employment screen or the activities-partner-self-employment 
  - [ ] Only show the School or training required documents information if one parent indicated "Going to school or training" as a reason for childcare on the activities-parent-type screen 
  - [ ] Only show the "TANF Work Training" required documents information if one parent indicated "TANF Training" as a reason for childcare on the activities-parent-type screen 
  - [ ] Only show the "Experiencing homelessness" required documents info if the client checked the "I am currently experiencing homelessness" box on the `parent-home-address` screen doc-upload-add-files 
## doc-upload-add-files
- [ ] Accordion condition logic
  - [ ] If no documents are required, then hide the accordion entirely 
  - [ ] Only show the Parent jobs and income required documents information if one parent indicated "Working" as a reason for childcare on the activities-parent-type screen 
  - [ ] Only show the Self-Employment information if one parent answered "Yes" to say that they were self-employed on either the activities-self-employment screen or the activities-partner-self-employment 
  - [ ] Only show the School or training required documents information if one parent indicated "Going to school or training" as a reason for childcare on the activities-parent-type screen 
  - [ ] Only show the "TANF Work Training" required documents information if one parent indicated "TANF Training" as a reason for childcare on the activities-parent-type screen 
  - [ ] Only show the "Experiencing homelessness" required documents info if the client checked the "I am currently experiencing homelessness" box on the `parent-home-address` screen

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
