### PR TITLE
[CCAP-254] Using generated security password

### DIFF
--- a/src/main/java/org/ilgcc/app/config/AuthenticationConfiguration.java
+++ b/src/main/java/org/ilgcc/app/config/AuthenticationConfiguration.java
@@ -1,0 +1,20 @@
+package org.ilgcc.app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+/**
+ * This configuration class will allow anonymous auth, since IL CCAP doesn't have logins and
+ * it will remove Spring Boot Security's error about using the default password
+ */
+@Configuration
+public class AuthenticationConfiguration {
+    @Bean
+    public AuthenticationManager noopAuthenticationManager() {
+        return authentication -> {
+            throw new AuthenticationServiceException("Authentication is disabled");
+        };
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-254

#### ✍️ Description
Just turning off the attempt to provide auth that creates an error on startup, since we don't have auth

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
