### PR TITLE
Make submit ccap terms visually required

### DIFF
--- a/src/main/resources/templates/gcc/submit-ccap-terms.html
+++ b/src/main/resources/templates/gcc/submit-ccap-terms.html
@@ -1,74 +1,59 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{submit-ccap-terms.title})}"></head>
-<body>
-<div class="page-wrapper">
-    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-    <section class="slab">
-        <div class="grid">
-            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
-                <th:block th:replace="~{fragments/gcc-icons :: clipboardWithEnvelope}"></th:block>
-                <th:block th:replace="~{fragments/cardHeader :: cardHeader(
-                        header=#{submit-ccap-terms.title},
-                        subtext=#{submit-ccap-terms.subtext})}"/>
-                <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-                    <th:block th:ref="formContent">
-                        <div class="form-card__content">
-                            <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
+<th:block
+  th:replace="~{fragments/screens/screenWithOneInput ::
+  screenWithOneInput(
+    title=#{submit-ccap-terms.title},
+    header=#{submit-ccap-terms.title},
+    subtext=#{submit-ccap-terms.subtext},
+    required='true',
+    iconFragment=~{fragments/gcc-icons :: clipboardWithEnvelope},
+    buttonLabel=#{general.inputs.continue},
+    formAction=${formAction},
+    inputContent=~{::inputContent})}">
+  <th:block th:ref="inputContent">
+      <div class="form-card__content">
+          <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
                                 buttonLabel=#{submit-ccap-terms.accordion-1.title},
                                 content=~{::first})}">
-                                <th:block th:ref="first">
-                                    <th:block th:utext="#{submit-ccap-terms.accordion-1.description}"></th:block>
-                                </th:block>
-                            </th:block>
-                            <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
+              <th:block th:ref="first">
+                  <th:block th:utext="#{submit-ccap-terms.accordion-1.description}"></th:block>
+              </th:block>
+          </th:block>
+          <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
                                 buttonLabel=#{submit-ccap-terms.accordion-2.title},
                                 content=~{::second})}">
-                                <th:block th:ref="second">
-                                    <th:block th:utext="#{submit-ccap-terms.accordion-2.description}"></th:block>
-                                </th:block>
-                            </th:block>
-                            <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
+              <th:block th:ref="second">
+                  <th:block th:utext="#{submit-ccap-terms.accordion-2.description}"></th:block>
+              </th:block>
+          </th:block>
+          <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
                                 buttonLabel=#{submit-ccap-terms.accordion-3.title},
                                 content=~{::third})}">
-                                <th:block th:ref="third">
-                                    <th:block th:utext="#{submit-ccap-terms.accordion-3.description}"></th:block>
-                                </th:block>
-                            </th:block>
-                            <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
+              <th:block th:ref="third">
+                  <th:block th:utext="#{submit-ccap-terms.accordion-3.description}"></th:block>
+              </th:block>
+          </th:block>
+          <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
                                 buttonLabel=#{submit-ccap-terms.accordion-4.title},
                                 content=~{::fourth})}">
-                                <th:block th:ref="fourth">
-                                    <th:block th:utext="#{submit-ccap-terms.accordion-4.description}"></th:block>
-                                </th:block>
-                            </th:block>
-                            <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
+              <th:block th:ref="fourth">
+                  <th:block th:utext="#{submit-ccap-terms.accordion-4.description}"></th:block>
+              </th:block>
+          </th:block>
+          <th:block th:replace="~{fragments/honeycrisp/accordion :: accordion(
                                 buttonLabel=#{submit-ccap-terms.accordion-5.title},
                                 content=~{::fifth})}">
-                                <th:block th:ref="fifth">
-                                    <th:block th:utext="#{submit-ccap-terms.accordion-5.description}"></th:block>
-                                </th:block>
-                            </th:block>
-                            <p class="text--help spacing-above-95"
-                               th:with="downloadUrl=|/download/${flow}/${submission.getId()}|"
-                               th:utext="#{submit-ccap-terms.help(${downloadUrl})}"></p>
-                            <th:block th:replace="~{fragments/inputs/checkboxMod ::
+              <th:block th:ref="fifth">
+                  <th:block th:utext="#{submit-ccap-terms.accordion-5.description}"></th:block>
+              </th:block>
+          </th:block>
+          <p class="text--help spacing-above-95"
+             th:with="downloadUrl=|/download/${flow}/${submission.getId()}|"
+             th:utext="#{submit-ccap-terms.help(${downloadUrl})}"></p>
+          <th:block th:replace="~{fragments/inputs/checkboxMod ::
                                 checkboxMod(inputName='agreesToLegalTerms',
                                 label=#{submit-ccap-terms.checkbox.label},
                                 value='true')}">
-                            </th:block>
-                        </div>
-                        <div class="form-card__footer">
-                            <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
-                                    text=#{general.inputs.continue})}"/>
-                        </div>
-                    </th:block>
-                </th:block>
-            </main>
-        </div>
-    </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+          </th:block>
+      </div>
+  </th:block>
+</th:block>


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP 258>](https://codeforamerica.atlassian.net/browse/CCAP-258)

#### ✍️ Description
- change the page template to use screen with one input, allowing a required tag

#### 📷 Design reference
<img width="480" alt="Screenshot 2024-09-03 at 2 39 22 PM" src="https://github.com/user-attachments/assets/7c6feb82-5bbe-4e55-b80e-0d09ac4ab60d">

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
