### PR TITLE
CCAP-42 Remove doc upload form submit-complete.html if no documents t…

### DIFF
--- a/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/RecommendedDocumentsUtilities.java
@@ -20,7 +20,7 @@ public class RecommendedDocumentsUtilities {
     boolean tanfISReasonForParentChildcareNeed = parentNeedForChildcareReasons.stream().anyMatch(
         reason -> reason.equals(ChildcareReasonOption.TANF_TRAINING.toString())
     );
-    boolean parentHasAPartner = inputData.getOrDefault("parentHasPartner", "false").equals("true");
+    boolean parentHasAPartner = inputData.getOrDefault("parentHasQualifyingPartner", "false").equals("true");
     if (parentHasAPartner) {
       List<String> partnerNeedForChildcareReasons = (List<String>) inputData.getOrDefault(
           "activitiesParentPartnerChildcareReason[]", List.of());
@@ -39,7 +39,7 @@ public class RecommendedDocumentsUtilities {
     boolean workingISReasonForParentChildcareNeed = parentNeedForChildcareReasons.stream().anyMatch(
         reason -> reason.equals(ChildcareReasonOption.WORKING.toString())
     );
-    boolean parentHasAPartner = inputData.getOrDefault("parentHasPartner", "false").equals("true");
+    boolean parentHasAPartner = inputData.getOrDefault("parentHasQualifyingPartner", "false").equals("true");
     if (parentHasAPartner) {
       List<String> partnerNeedForChildcareReasons = (List<String>) inputData.getOrDefault(
           "activitiesParentPartnerChildcareReason[]", List.of());
@@ -58,7 +58,7 @@ public class RecommendedDocumentsUtilities {
     boolean schoolISReasonForParentChildcareNeed = parentNeedForChildcareReasons.stream().anyMatch(
         reason -> reason.equals(ChildcareReasonOption.SCHOOL.toString())
     );
-    boolean parentHasAPartner = inputData.getOrDefault("parentHasPartner", "false").equals("true");
+    boolean parentHasAPartner = inputData.getOrDefault("parentHasQualifyingPartner", "false").equals("true");
     if (parentHasAPartner) {
       List<String> partnerNeedForChildcareReasons = (List<String>) inputData.getOrDefault(
           "activitiesParentPartnerChildcareReason[]", List.of());

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -78,7 +78,7 @@ general.language.polish=Polski
 general.other=Other
 
 general.hour=Hour
-general.minute=Minute 
+general.minute=Minute
 general.amOrPM=AM or PM
 
 general.locked-submission=You've already submitted this application. To protect your data, we can't let you go back at this time.
@@ -666,6 +666,9 @@ submit-sign-name.partner-legal-name.label=Partner's Full Legal Name
 submit-sign-name.submit-application=Submit application
 submit-complete.title=Your application has been submitted!
 submit-complete.header=<p>Your application has been submitted!</p><p>You have the option to submit verification documents now.</p>
+submit-complete-no-documents-to-upload.header=Your application has been submitted!
+submit-complete-no-documents-to-upload.subtext=Please review your next steps:
+submit-complete-no-documents-to-upload.finish-application=Finish application
 submit-complete.info-box=<p>Verification documents are due within 10 business days of application submission.</p><p>We will share document recommendations on the next page. If you don't have your documents now, it's okay. You will get a Request for Information form in the mail.</p>
 submit-complete.button.submit-docs=Submit documents now
 submit-complete.button.skip=Skip and finish

--- a/src/main/resources/templates/gcc/submit-complete.html
+++ b/src/main/resources/templates/gcc/submit-complete.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org"
-      th:with="email = ${inputData.getOrDefault('parentContactEmail', null)}">
+      th:with="showDocumentUploadInfo = ${T(org.ilgcc.app.utils.RecommendedDocumentsUtilities).shouldDisplayRecommendedDocumentScreens(submission)}">
 <head th:replace="~{fragments/head :: head(title=#{submit-complete.title})}"></head>
 <body>
 <div class="page-wrapper">
@@ -13,21 +13,42 @@
                 <div th:if="${lockedSubmissionMessage}" class="notice--warning">
                     <p th:text="${lockedSubmissionMessage}"></p>
                 </div>
-                <header class="form-card__header">
-                    <h1 id="header" class="h2" th:utext="#{submit-complete.header}"></h1>
-                </header>
-                <div class="form-card__content">
-                    <div class="notice notice--gray" th:utext="#{submit-complete.info-box}"></div>
+                <!-- Display document verification information and Document Upload Links-->
+                <div th:if="${showDocumentUploadInfo}">
+                    <header class="form-card__header">
+                        <h1 id="header-doc-upload" class="h2" th:utext="#{submit-complete.header}"></h1>
+                    </header>
+                    <div class="form-card__content">
+                        <div class="notice notice--gray" th:utext="#{submit-complete.info-box}"></div>
+                    </div>
+                    <div class="form-card__footer">
+                        <a href="/flow/gcc/doc-upload-recommended-docs"
+                           th:text="#{submit-complete.button.submit-docs}"
+                           class="button button--primary"
+                           id="continue-link"></a>
+                        <a href="/flow/gcc/submit-next-steps"
+                           th:text="#{submit-complete.button.skip}"
+                           class="button"
+                           id="skip-link"></a>
+                    </div>
                 </div>
-                <div class="form-card__footer">
-                    <a href="/flow/gcc/doc-upload-recommended-docs"
-                       th:text="#{submit-complete.button.submit-docs}"
-                       class="button button--primary"
-                       id="continue-link"></a>
-                    <a href="/flow/gcc/submit-next-steps"
-                       th:text="#{submit-complete.button.skip}"
-                       class="button"
-                       id="skip-link"></a>
+                <!-- Show information about next steps -->
+                <div th:if="${!showDocumentUploadInfo}">
+                    <header class="form-card__header">
+                        <h1 id="header-next-steps" class="h2" th:text="#{submit-complete-no-documents-to-upload.header}"></h1>
+                        <p id="header-help-message" th:text="#{submit-complete-no-documents-to-upload.subtext}"></p>
+                    </header>
+                    <div class="form-card__content">
+                        <div class="notice--success">
+                            <th:block th:utext="#{submit-next-steps.notice}"></th:block>
+                        </div>
+                    </div>
+                    <div class="form-card__footer">
+                        <a href="/flow/gcc/submit-confirmation"
+                           th:text="#{submit-complete-no-documents-to-upload.finish-application}"
+                           class="button button--primary"
+                           id="finish-application-link"></a>
+                    </div>
                 </div>
             </main>
         </div>

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -3,11 +3,13 @@ package org.ilgcc.app.journeys;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.ilgcc.app.utils.ChildCareProvider;
 import org.junit.jupiter.api.Test;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
+    boolean hasPartner = false;
     @Test
-    void skipDocUploadRecommendedDocsScreenIfNoDocumentsAreRequiredForParentandNoSpouse(){
-    testPage.navigateToFlowScreen("gcc/submit-complete");
+    void shouldSkipDocUploadPromptIfNoDocumentsAreRequiredForParentOrSpouse(){
+    testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
     saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
         .withParentDetails()
         .withChild("First", "Child", "Yes")
@@ -15,18 +17,21 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
         .with("parentHomeExperiencingHomelessness[]", List.of())
         .with("activitiesParentChildcareReason[]", List.of())
+        .with("activitiesParentPartnerChildcareReason[]", List.of())
+        .withParentPartnerDetails()
         .build());
-
+    hasPartner = true;
+    navigatePassedSignedName(hasPartner);
     // submit-complete
     assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-    testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+    testPage.clickButton(getEnMessage("submit-complete-no-documents-to-upload.finish-application"));
 
-    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
-    assertThat(testPage.elementDoesNotExistById("controlId")).isTrue();
+    assertThat(testPage.getTitle()).isEqualTo(getEnMessageWithParams("submit-confirmation.title", List.of(ChildCareProvider.OPEN_SESAME.getDisplayName()).toArray()));
+
     }
     @Test
     void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredForParent(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -35,6 +40,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
             .build());
+        hasPartner = false;
+        navigatePassedSignedName(hasPartner);
 
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
@@ -45,7 +52,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
 
     @Test
     void shouldNotDisplayHomelessnessInstructionsForDocumentUploadIfHomelessnessNotSelected(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -54,7 +61,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
             .build());
-
+        hasPartner = false;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -73,7 +81,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
 
     @Test
     void shouldNotDisplaySchoolInstructionsForDocumentUploadIfSchoolNotSelected(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -82,7 +90,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
             .build());
-
+        hasPartner = false;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -100,7 +109,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void shouldNotDisplayJobInstructionsForDocumentUploadIfJobIsNotSelected(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -109,7 +118,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
             .build());
-
+        hasPartner = false;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -126,7 +136,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void shouldNotDisplaySelfEmploymentInstructionsForDocumentUploadIfSelfEmploymentIsNotSelected(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -136,10 +146,11 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("activitiesParentChildcareReason[]", List.of("WORKING"))
             .withJob("jobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
             .build());
-
+        hasPartner = false;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.button.submit-docs"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -153,7 +164,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void shouldNotDisplayTanfInstructionsForDocumentUploadIfTanfIsNotSelected(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withChild("First", "Child", "Yes")
@@ -163,7 +174,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("activitiesParentChildcareReason[]", List.of("WORKING"))
             .withJob("jobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
             .build());
-
+        hasPartner = false;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -180,10 +192,9 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void shouldDisplayJobsInstructionsIfPartnerSelectsJobsAndParentDoesNot(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
-            .with("parentHasPartner", "true")
             .withParentPartnerDetails()
             .withChild("First", "Child", "Yes")
             .withMailingAddress("972 Mission St", "5", "San Francisco", "CA", "94103")
@@ -192,7 +203,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("activitiesParentPartnerChildcareReason[]", List.of("TANF_TRAINING", "WORKING"))
             .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "false")
             .build());
-
+        hasPartner = true;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -209,7 +221,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void shouldDisplaySelfEmploymentInstructionsIfPartnerSelectsSelfEmploymentAndParentDoesNot(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
             .withParentPartnerDetails()
@@ -220,7 +232,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("activitiesParentChildcareReason[]", List.of("TANF_TRAINING"))
             .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "true")
             .build());
-
+        hasPartner = true;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -237,10 +250,9 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
 
     @Test
     void shouldDisplayTanfInstructionsIfPartnerSelectsTanfAndParentDoesNot(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
-            .with("parentHasPartner", "true")
             .withParentPartnerDetails()
             .withChild("First", "Child", "Yes")
             .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
@@ -249,7 +261,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("activitiesParentPartnerChildcareReason[]", List.of("TANF_TRAINING"))
             .withPartnerJob("partnerJobs", "Company Name", "123 Main St", "Springfield", "IL", "60652", "(651) 123-1234", "true")
             .build());
-
+        hasPartner = true;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -265,10 +278,9 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     }
     @Test
     void shouldDisplaySchoolInstructionsIfPartnerSelectsSchoolAndParentDoesNot(){
-        testPage.navigateToFlowScreen("gcc/submit-complete");
+        testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
-            .with("parentHasPartner", "true")
             .withParentPartnerDetails()
             .withChild("First", "Child", "Yes")
             .with("parentMailingAddressSameAsHomeAddress[]", List.of("no"))
@@ -276,7 +288,8 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
             .with("parentHomeExperiencingHomelessness[]", List.of())
             .with("activitiesParentPartnerChildcareReason[]", List.of("TANF_TRAINING", "SCHOOL"))
             .build());
-
+        hasPartner = true;
+        navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
@@ -289,5 +302,18 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
         assertThat(testPage.elementDoesNotExistById("school-upload-instruction")).isFalse();
+    }
+    void navigatePassedSignedName(boolean hasQualifiedPartner){
+        // submit-ccap-terms
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-ccap-terms.title"));
+        testPage.clickElementById("agreesToLegalTerms-true");
+        testPage.clickContinue();
+
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-sign-name.title"));
+        testPage.enter("signedName", "parent first parent last");
+        if(hasQualifiedPartner){
+            testPage.enter("partnerSignedName", "partner parent");
+        }
+        testPage.clickButton(getEnMessage("submit-sign-name.submit-application"));
     }
 }


### PR DESCRIPTION
…o upload.

#### 🔗 Jira ticket
CCAP-42

#### ✍️ Description

This PR should allow clients, with documents that we recommend they upload, to reach the `doc-upload-recommended-docs` screen from the `submit-complete` screen.  If we do not recommend they upload documents then we should skip the `submit-next-steps` screen and allow them to finish their application.  

#### 📷 Design reference
[Figma](https://www.figma.com/file/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Full-Flow-(WIP)?type=design&node-id=101-2535&mode=design&t=wgApbr4xbfqBviFS-0)

#### ✅ Completion tasks

##### Conditional logic
- A client would have recommended documents to submit and should be allowed to **Submit Documents** or **Skip and Finish**:
  - [ ] Parent jobs and income: when one or both parents select “working” on activities-parent-type page.
  - [ ] Self-employment: when one or both parents says yes to activities-self-employment.
  - [ ] School or training: when one or both parents selects “school or training” on the activities-parent-type page.
  - [ ] TANF Work training: show when one or more parents selects “TANF Training” on the activities-parent-type page.
  - [ ] Experiencing homelessness: Show when primary applicant selects “I am currently experiencing homelessness” on the home-address screen.
- Where a client has no recommended documents that they need to submit
   - [ ] they should see an alternative version of the `submit-complete` screen that hides information about verification documents and the link to the document upload section, and shows information about next steps
   - [ ] they should skip the `submit-next-steps` screen

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
