### PR TITLE
Create onboarding-provider-info screen

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -24,6 +24,12 @@ public class Gcc extends FlowInputs {
     private String dayCareChoice;
     private String languageRead;
     private String languageSpeak;
+    
+    // onboarding-provider-info
+    @NotBlank(message = "{errors.provide-provider-name}")
+    private String familyIntendedProviderName;
+    private String familyIntendedProviderEmail;
+    private String familyIntendedProviderPhoneNumber;
 
     // parent-info-basic-1
     @NotBlank(message = "{errors.provide-first-name}")

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -8,6 +8,8 @@ flow:
       - name: pilot-offboard
         condition: NoProviderChosen
       - name: onboarding-confirm-provider
+  onboarding-provider-info:
+    nextScreens: null
   pilot-offboard:
     nextScreens: null
   onboarding-confirm-provider:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -100,6 +100,7 @@ errors.select-child-relationship=Please select a relationship.
 errors.select-yes-or-no=Please select "Yes" or "No" to continue.
 errors.choose-provider=Please choose a provider from the list or select "none of the above".
 errors.required-financial-assistance=Please answer whether you need child care assistance funding for this child
+errors.provide-provider-name=Please provide a name for your child care provider.
 errors.invalid-date-format=Make sure the date you entered is in this format: mm/dd/yyyy
 errors.invalid-birthdate-format=Make sure the birthdate you entered is in this format: mm/dd/yyyy
 errors.invalid-date-range=Make sure the date you entered is between 01/01/1901 and today.
@@ -178,6 +179,15 @@ onboarding-choose-provider.childrens-learning-center=Children's Learning Center
 onboarding-choose-provider.the-growing-place=The Growing Place
 onboarding-choose-provider.open-sesame=Open Sesame
 onboarding-choose-provider.none=None of the above
+#
+onboarding-provider-info.title=Provider Info
+onboarding-provider-info.header=Tell us about your child care provider
+onboarding-provider-info.name=Name
+onboarding-provider-info.name-help=Either first and last name, or name of child care center.
+onboarding-provider-info.email=Email address
+onboarding-provider-info.email-help=We recommend adding their email if you have it.
+onboarding-provider-info.phone=Phone number
+onboarding-provider-info.phone-help=We recommend adding their phone number if you have it.
 #
 onboarding-confirm-provider.title=Confirm provider
 onboarding-confirm-provider.header=Please confirm your child care provider

--- a/src/main/resources/templates/gcc/onboarding-provider-info.html
+++ b/src/main/resources/templates/gcc/onboarding-provider-info.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{onboarding-provider-info.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/gcc-icons :: caring}"></th:block>
+        <th:block
+            th:replace="~{fragments/cardHeader :: cardHeader(header=#{onboarding-provider-info.header})}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{:: content})}">
+            <th:block th:ref="content">
+              <div class="form-card__content">
+                <th:block th:replace="~{fragments/inputs/text ::
+                  text(inputName='familyIntendedProviderName',
+                  label=#{onboarding-provider-info.name},
+                  helpText=#{onboarding-provider-info.name-help})}" />
+                <th:block th:replace="~{fragments/inputs/text ::
+                  text(inputName='familyIntendedProviderEmail',
+                  label=#{onboarding-provider-info.email},
+                  helpText=#{onboarding-provider-info.email-help})}" />
+                <th:block th:replace="~{fragments/inputs/text ::
+                  text(inputName='familyIntendedProviderPhoneNumber',
+                  label=#{onboarding-provider-info.phone},
+                  helpText=#{onboarding-provider-info.phone-help})}" />
+              </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}" />
+</body>
+</html>


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-350?atlOrigin=eyJpIjoiNDI2NjBhOTEzNjQ2NDA5YmJkMjNhOTBmMjZiMTI2ZTQiLCJwIjoiaiJ9

#### ✍️ Description
Adds onboarding provider info screen with no flow access - only accessible by directly going to `/flow/gcc/onboarding-provider-info`

#### 📷 Design reference
https://www.figma.com/design/lGFsTvWwHoOOJ9XQGPFNmu/IL-CCAP-Provider-Designs-(WIP)?node-id=1-9659&t=8qTLsVjPdYBhfhWr-4