### PR TITLE
[CCAP-352] Allow providers to respond to application

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -607,4 +607,5 @@ public class Gcc extends FlowInputs {
     // submit-confirmation
     private String surveyDifficulty;
     private String surveyAdditionalComments;
+    private String providerResponseSubmissionId;
 }

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -4,6 +4,14 @@ import formflow.library.data.FlowInputs;
 import jakarta.validation.constraints.NotBlank;
 
 public class Providerresponse extends FlowInputs {
+    private String familySubmissionId;
+
     @NotBlank(message = "{errors.provide-provider-number}")
     private String providerResponseProviderNumber;
+
+    @NotBlank(message = "{errors.provide-applicant-number}")
+    private String providerResponseFamilyConfirmationCode;
+
+    @NotBlank
+    private String providerResponseAgreeToCare;
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/CheckClientSubmissionForProvider.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/CheckClientSubmissionForProvider.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.ChildCareProvider;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 import org.ilgcc.app.utils.enums.ProviderSubmissionStatus;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -57,7 +58,7 @@ public class CheckClientSubmissionForProvider implements Action {
 
                 LocalDate submittedAtDate = clientSubmissionInfo.getSubmittedAt().toLocalDate();
                 LocalDate todaysDate = LocalDate.now();
-                if (DAYS.between(submittedAtDate, todaysDate) >= 40) {
+                if (DAYS.between(ProviderSubmissionUtilities.threeBusinessDaysFromSubmittedAtDate(submittedAtDate), todaysDate) > 0) {
                     httpSession.setAttribute(SESSION_KEY_CLIENT_SUBMISSION_STATUS, ProviderSubmissionStatus.EXPIRED.name());
                 } else {
                     boolean hasResponse = false;

--- a/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
@@ -1,0 +1,32 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class FindApplicationData implements Action {
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+
+    @Override
+    public void run(Submission providerSubmission) {
+        Optional<UUID> clientID = ProviderSubmissionUtilities.getClientId(providerSubmission);
+        if(clientID != null &&  clientID.isPresent()){
+           Optional<Submission> clientSubmission = submissionRepositoryService.findById(clientID.get());
+           providerSubmission.getInputData().put("clientResponse", ProviderSubmissionUtilities.getApplicantSubmissionForProviderResponse(clientSubmission));
+           providerSubmission.getInputData().put("clientResponseChildren", ProviderSubmissionUtilities.getChildrenDataForProviderResponse(clientSubmission.get()));
+        }
+
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationId.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationId.java
@@ -1,0 +1,29 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import jakarta.servlet.http.HttpSession;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+@Slf4j
+@Component
+public class SaveApplicationId implements Action {
+
+    private final HttpSession httpSession;
+
+
+    public SaveApplicationId(HttpSession httpSession) {
+        this.httpSession = httpSession;
+    }
+
+    @Override
+    public void run(FormSubmission formSubmission, Submission providerSubmission) {
+        UUID clientSubmissionId = (UUID) httpSession.getAttribute("clientSubmissionId");
+
+        if(!clientSubmissionId.toString().isEmpty()){
+            providerSubmission.getInputData().put("familySubmissionId", clientSubmissionId);
+        }
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationIdFromApplicationId.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationIdFromApplicationId.java
@@ -1,0 +1,31 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SaveApplicationIdFromApplicationId implements Action {
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+    @Override
+    public void run(FormSubmission formSubmission, Submission providerSubmission) {
+        boolean hasApplicationID = providerSubmission.getInputData().containsKey("familySubmissionId");
+        String providerProvidedConfirmationCode = (String) formSubmission.getFormData().getOrDefault("providerResponseFamilyConfirmationCode", "");
+        if(!hasApplicationID && !providerProvidedConfirmationCode.isBlank()){
+            Optional<Submission> clientSubmission = submissionRepositoryService.findByShortCode(providerProvidedConfirmationCode);
+            if(clientSubmission.isPresent()){
+                providerSubmission.getInputData().put("familySubmissionId", clientSubmission.get().getId());
+            }
+        }
+    }
+}

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class ProviderSubmissionUtilities {
+    private final static Map<String, Integer> weekWithOffset = Map.of(
+            "MONDAY", 3, "TUESDAY", 3, "WEDNESDAY", 5, "THURSDAY", 5, "FRIDAY", 5, "SATURDAY", 4, "SUNDAY", 3);
 
     public static Optional<UUID> getClientId(Submission providerSubmission) {
         if (providerSubmission.getInputData().containsKey("familySubmissionId")) {
@@ -101,9 +103,6 @@ public class ProviderSubmissionUtilities {
     }
 
     public static LocalDate threeBusinessDaysFromSubmittedAtDate(LocalDate submittedAtDate) {
-        Map<String, Integer> weekWithOffset = Map.of(
-                "MONDAY", 3, "TUESDAY", 3, "WEDNESDAY", 5, "THURSDAY", 5, "FRIDAY", 5, "SATURDAY", 4, "SUNDAY", 3);
-
         Integer dayOffset = weekWithOffset.get(submittedAtDate.getDayOfWeek().toString());
         return submittedAtDate.plusDays(dayOffset);
     }

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -1,0 +1,110 @@
+package org.ilgcc.app.utils;
+
+import static org.ilgcc.app.utils.SubmissionUtilities.MM_DD_YYYY;
+
+import formflow.library.data.Submission;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ProviderSubmissionUtilities {
+
+    public static Optional<UUID> getClientId(Submission providerSubmission) {
+        if (providerSubmission.getInputData().containsKey("familySubmissionId")) {
+            String applicantID = (String) providerSubmission.getInputData().get("familySubmissionId");
+            return Optional.of(UUID.fromString(applicantID));
+        }
+        return null;
+    }
+
+    public static Map<String, String> getApplicantSubmissionForProviderResponse(Optional<Submission> applicantSubmission) {
+        Map<String, String> applicationData = new HashMap<>();
+
+        if (applicantSubmission.isPresent()) {
+            Map<String, Object> applicantInputs = applicantSubmission.get().getInputData();
+            applicationData.put("clientResponseConfirmationCode", applicantSubmission.get().getShortCode());
+            applicationData.put("clientResponseParentName", getApplicantName(applicantInputs));
+        }
+
+        return applicationData;
+    }
+
+    private static String getApplicantName(Map<String, Object> applicantInputData) {
+        String firstName = SubmissionUtilities.applicantFirstName(applicantInputData);
+        String lastName = (String) applicantInputData.get("parentLastName");
+
+        return String.format("%s %s", firstName, lastName);
+    }
+
+    public static List<Map<String, String>> getChildrenDataForProviderResponse(Submission applicantSubmission) {
+        List<Map<String, String>> children = new ArrayList<>();
+
+        if (SubmissionUtilities.getChildrenNeedingAssistance(applicantSubmission).size() > 0) {
+            for (var child : SubmissionUtilities.getChildrenNeedingAssistance(applicantSubmission)) {
+                Map<String, String> childObject = new HashMap<>();
+                String firstName = (String) child.get("childFirstName");
+                String lastName = (String) child.get("childLastName");
+
+                childObject.put("childName", String.format("%s %s", firstName, lastName));
+                childObject.put("childAge", String.format("Age %s", childAge(child)));
+                childObject.put("childCareHours", hoursRequested(child));
+                childObject.put("childStartDate", (String) child.get("ccapStartDate"));
+                children.add(childObject);
+            }
+        }
+        return children;
+    }
+
+    private static Integer childAge(Map<String, Object> child) {
+        var bdayString = String.format("%s/%s/%s", child.get("childDateOfBirthMonth"), child.get("childDateOfBirthDay"),
+                child.get("childDateOfBirthYear"));
+
+        LocalDate dateOfBirth = LocalDate.parse(bdayString, MM_DD_YYYY);
+        return Period.between(dateOfBirth, LocalDate.now()).getYears();
+    }
+
+    private static String formatHourschedule(Map<String, Object> child, String prefix, String day) {
+        String hour = (String) child.get("childcare" + prefix + "Time" + day + "Hour");
+        String minute = (String) child.get("childcare" + prefix + "Time" + day + "Minute");
+        String amPm = (String) child.get("childcare" + prefix + "Time" + day + "AmPm");
+
+        if (!hour.isEmpty() && !minute.isEmpty() && !amPm.isEmpty()) {
+            return String.format("%s:%s %s", hour, minute, amPm);
+        }
+
+        return "";
+    }
+
+    private static String hoursRequested(Map<String, Object> child) {
+        List sameHoursEveryday = (List) child.get("childcareHoursSameEveryDay[]");
+        List daysRequested = (List) child.get("childcareWeeklySchedule[]");
+        List<String> dateString = new ArrayList<>();
+        for (var day : daysRequested) {
+            if (sameHoursEveryday.equals(List.of("yes"))) {
+                dateString.add(String.format("<li>%s %s to %s</li>", day, formatHourschedule(child, "Start", "AllDays"),
+                        formatHourschedule(child, "End", "AllDays")));
+            } else {
+                dateString.add(String.format("<li>%s %s to %s</li>", day, formatHourschedule(child, "Start", (String) day),
+                        formatHourschedule(child, "End", (String) day)));
+            }
+        }
+        return String.join("", dateString);
+    }
+
+    public static LocalDate threeBusinessDaysFromSubmittedAtDate(LocalDate submittedAtDate) {
+        Map<String, Integer> weekWithOffset = Map.of(
+                "MONDAY", 3, "TUESDAY", 3, "WEDNESDAY", 5, "THURSDAY", 5, "FRIDAY", 5, "SATURDAY", 4, "SUNDAY", 3);
+
+        Integer dayOffset = weekWithOffset.get(submittedAtDate.getDayOfWeek().toString());
+        return submittedAtDate.plusDays(dayOffset);
+    }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -340,7 +340,7 @@ flow:
         condition: UnearnedIncomeSourceIsNone
       - name: unearned-income-amount
   unearned-income-amount:
-      nextScreens:
+    nextScreens:
       - name: unearned-income-assets
   unearned-income-assets:
     nextScreens:
@@ -443,6 +443,18 @@ flow:
     nextScreens:
       - name: ccap-registration
   ccap-registration:
+    onPostAction: SaveApplicationId
+    nextScreens:
+      - name: application-id
+  application-id:
+    onPostAction: SaveApplicationIdFromApplicationId
+    nextScreens:
+      - name: response
+  response:
+    beforeDisplayAction: FindApplicationData
+    nextScreens:
+      - name: submit-complete
+  submit-complete:
     nextScreens: null
 landmarks:
   firstScreen: submit-start

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -95,6 +95,7 @@ errors.provide-state=Please choose the state.
 errors.provide-zip=Please enter a zip code with 5 digits.
 errors.provide-program-name=Please provide a program name.
 errors.provide-provider-number=Please provide your provider number.
+errors.provide-applicant-number=Please provide the family's application number.
 errors.select-one-option=Please select one option
 errors.select-at-least-one-day=Please select at least one day
 errors.select-child-relationship=Please select a relationship.
@@ -1025,8 +1026,20 @@ faq.questions-about-the-process.how-do-i-maintain-benefits.a-renewal-form=About 
 faq.questions-about-the-process.how-long-will-it-take=After I apply, how long will it take to get child care assistance?
 faq.questions-about-the-process.how-long-will-it-take.you-should-get-an-application-response=You should get an application response within 45 calendar days. This is counted from the date your completed application was received by your CCR&R.
 
+#contact-provider-message
+contact-provider-message.title=Contact Provider Message
+contact-provider-message.header=Message your child care provider
+contact-provider-message.below-we-prepared=Below, we have prepared a message that can be copied directly into an email or text to {0} .
+contact-provider-message.it-includes=It includes your confirmation code: {0}
+contact-provider-message.email-message=Email message
+contact-provider-message.text-message=Text message
+contact-provider-message.message-p1=Hello - I just applied for CCAP and listed you as my provider. My confirmation code is: {0}
+contact-provider-message.message-p2=Please complete the application within 3 business days: {0}
+contact-provider-message.message-subject=New CCAP application received
+contact-provider-message.message-body=Hello - I just applied for CCAP and listed you as my provider. My confirmation code is: {1} \n\nPlease complete the application within 3 business days: {0}
 
 #provider-response
+#submit-start
 provider-response-submit-start.title=Submit Start
 provider-response-submit-start.active.header=Hi, {0}!
 provider-response-submit-start.active.notice=A family listed you as their child care provider on a Child Care Assistance (CCAP) application.
@@ -1043,18 +1056,33 @@ provider-response-submit-start.responded.button=Return to home
 
 provider-response-submit-start.provider-placeholder=child care provider
 
+#ccap-registration
 provider-response-ccap-registration.title=Provider Verification
 provider-response-ccap-registration.header=What is your provider number?
 provider-response-ccap-registration.subtext=This should be a 15 digit number. If yours is 14 digits, please add a "0" in front.
+provider-response-ccap-registration.no-provider-number=I don't have a provider number.
 
-#contact-provider-message
-contact-provider-message.title=Contact Provider Message
-contact-provider-message.header=Message your child care provider
-contact-provider-message.below-we-prepared=Below, we have prepared a message that can be copied directly into an email or text to {0} .
-contact-provider-message.it-includes=It includes your confirmation code: {0}
-contact-provider-message.email-message=Email message
-contact-provider-message.text-message=Text message
-contact-provider-message.message-p1=Hello - I just applied for CCAP and listed you as my provider. My confirmation code is: {0}
-contact-provider-message.message-p2=Please complete the application within 3 business days: {0}
-contact-provider-message.message-subject=New CCAP application received
-contact-provider-message.message-body=Hello - I just applied for CCAP and listed you as my provider. My confirmation code is: {1} \n\nPlease complete the application within 3 business days: {0}
+#application-id
+provider-response-application-id.title=Family Application Id
+provider-response-application-id.header=Respond to a family's application
+provider-response-application-id.subtext=<strong>What is the application confirmation code you're responding to?</strong><br/><br/>This is a combination of 6 numbers and letters. You can find it in the communication you received from the family about their application.
+
+#response
+provider-response-response.title=Provider Response
+provider-response-response.header=What is your response to the application?
+provider-response-response.confirmation-code=Confirmation code:
+provider-response-response.parent-name=Parent name:
+provider-response-response.child-name=Child name:
+provider-response-response.child-age=Child age:
+provider-response-response.hours=Hours of care requested:
+provider-response-response.start-date=Start date of care requested:
+provider-response-response.button.yes=Yes, I agree to care
+provider-response-response.button.no=No, I don't agree to care
+
+#submit-complete
+provider-response-submit-complete.title=Submit Response
+provider-response-submit-complete.header=Your response has been recorded
+provider-response-submit-complete.notice-yes=Next, we will collect your provider information. This should take 2-3 minutes.
+provider-response-submit-complete.notice-no=We will notify the CCR&R of your response.
+provider-response-submit-complete.button-no=Return to home
+

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -110,8 +110,7 @@ a, .button--link {
 
 .slab a:not(.button):not(.reveal__link):not(.text--red),
 .slab a:not(.button):not(.reveal__link):not(.text--red):focus,
-.button--link, .button--link:focus
-{
+.button--link, .button--link:focus {
   color: var(--idhs-base-blue);
 }
 
@@ -140,9 +139,10 @@ a, .button--link {
   margin: 0;
 }
 
-img.img-center{
+img.img-center {
   width: 462px;
 }
+
 .img-left {
   display: block;
   margin-right: 0;
@@ -161,53 +161,64 @@ img.img-center{
   align-items: center;
   gap: 30px;
 }
+
 .index-child-care-image-container img:first-child {
   margin-bottom: 41px;
   margin-left: 14px;
   margin-right: 13px;
 }
+
 .eligibility-table {
   width: 100%;
   border-collapse: collapse;
 }
+
 .eligibility-table th {
   font-weight: normal;
   font-size: 1.6rem;
   color: var(--idhs-dark-blue);
   padding-bottom: 1rem;
 }
+
 .family-income-table {
   width: 80%;
   font-weight: normal;
   border: 1px solid black;
   border-collapse: collapse;
 }
+
 .family-income-table thead {
   border: 1px solid black;
 }
+
 .family-income-table th {
   font-weight: normal;
   align-content: center;
   min-width: 13rem;
   border: 1px solid black
 }
+
 .family-income-table td {
   border: 1px solid black
 
 }
+
 .family-income-table tr {
   text-align: center;
   border: 1px solid black
 
 }
+
 .faq-situation-table {
   font-weight: normal;
   border: 1px solid black;
   border-collapse: collapse;
 }
+
 .faq-situation-table thead {
   border: 1px solid black;
 }
+
 .faq-situation-table th {
   font-weight: normal;
   min-width: 13rem;
@@ -216,13 +227,16 @@ img.img-center{
   text-align: left;
   padding: 1rem;
 }
+
 .faq-situation-table td {
   border: 1px solid black;
   padding: 1rem;
 }
+
 .faq-situation-table tr {
   border: 1px solid black
 }
+
 .paragraph-large {
   font-size: 2.5rem;
   margin-bottom: 25px;
@@ -284,6 +298,7 @@ p.normal {
   border-radius: 3px;
   max-width: 35rem;
 }
+
 .legal-stuff-header {
   padding: 2.5rem 0 -2.5rem 0;
   margin: auto;
@@ -297,6 +312,7 @@ p.normal {
   overflow-y: scroll;
   padding-right: calc(1.5rem + 12px);
 }
+
 .textarea-readonly::-webkit-scrollbar {
   -webkit-appearance: none;
 }
@@ -358,7 +374,7 @@ p.normal {
   text-align: center;
 }
 
-.vertical-steps:before{
+.vertical-steps:before {
   content: '';
   display: block;
   position: absolute;
@@ -385,7 +401,7 @@ p.normal {
   gap: 10px;
 }
 
-.zero-flex-shrink svg{
+.zero-flex-shrink svg {
   flex-shrink: 0;
 }
 
@@ -413,18 +429,18 @@ p.normal {
   max-width: 25em;
 }
 
-.time-input{
-  display:flex;
-  width:100%;
-  font-size:1.9rem;
-  font-weight:700;
-  height:6.4rem;
-  padding:0 1.5rem;
-  margin-bottom:1.5rem;
-  box-shadow:inset 0px 2px 0px rgba(0,0,0,0.15);
-  border:2px solid #121111;
-  border-radius:0;
-  background-color:white
+.time-input {
+  display: flex;
+  width: 100%;
+  font-size: 1.9rem;
+  font-weight: 700;
+  height: 6.4rem;
+  padding: 0 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: inset 0px 2px 0px rgba(0, 0, 0, 0.15);
+  border: 2px solid #121111;
+  border-radius: 0;
+  background-color: white
 }
 
 .form-width--long-time {
@@ -502,19 +518,19 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
 }
 
 .list--material-get-app li:before {
-      background-image: none;
-      font-family: 'Material Icons';
-      content: "get_app";
-      top: 1rem;
-      color: currentColor;
-      font-size: 3rem;
+  background-image: none;
+  font-family: 'Material Icons';
+  content: "get_app";
+  top: 1rem;
+  color: currentColor;
+  font-size: 3rem;
 }
 
 .list--material-get-app li {
-    padding-left: 4rem;
+  padding-left: 4rem;
 }
 
-.required-input{
+.required-input {
   color: var(--hc-red);
 }
 
@@ -541,7 +557,7 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
   width: 100%;
 }
 
-.form-question-stack .select{
+.form-question-stack .select {
   width: 100%;
 }
 
@@ -550,10 +566,11 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
 }
 
 @media only screen and (max-width: 500px) {
-  .form-question-stack{
+  .form-question-stack {
     flex: 1 1 50px;
   }
-  .form-question-stack .select__element{
+
+  .form-question-stack .select__element {
     padding: 0 4rem 0 1.5rem;
   }
 }
@@ -573,5 +590,43 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
   .notice--toolbar {
     margin-left: -3.5rem;
     margin-right: -3.5rem;
+  }
+}
+
+.providerResponse {
+  width: 100%;
+  height: 100%;
+  padding-top: 17px;
+  padding-bottom: 18px;
+  padding-left: 25px;
+  padding-right: 25px;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 2px #008060 solid;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 15px;
+  line-height: 25px;
+  word-wrap: break-word
+}
+
+.providerResponse {
+  .category {
+    margin-bottom: 0px;
+    margin-top: 2rem;
+    font-weight: 700;
+  }
+
+  .response {
+    margin-bottom: 0px;
+    font-weight: 400;
+  }
+
+  .list--bulleted {
+    margin-top: 0px;
+  }
+
+  .list--bulleted li{
+    margin-bottom: 0px;
   }
 }

--- a/src/main/resources/templates/fragments/inputs/screenWithOneInputAndSkip.html
+++ b/src/main/resources/templates/fragments/inputs/screenWithOneInputAndSkip.html
@@ -1,0 +1,51 @@
+<th:block
+        th:fragment="screenWithOneInputAndSkip"
+        th:with="
+      hasIconFragment=${!#strings.isEmpty(iconFragment)},
+      hasSkipLocation=${!#strings.isEmpty(skipLocation)},
+      hasSkipTextValue=${!#strings.isEmpty(skipText)},
+      hasIconName=${!#strings.isEmpty(iconName)}"
+        th:assert="
+      ${!#strings.isEmpty(title)},
+      ${!#strings.isEmpty(header)},
+      ${!#strings.isEmpty(formAction)},
+      ${inputContent != null}">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=${title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+      <div class="grid">
+        <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="${hasIconName} ? ~{'fragments/icons' :: ${iconName}} : _"/>
+          <th:block th:replace="${hasIconFragment} ? ${iconFragment} : _"/>
+          <th:block
+                  th:replace="~{fragments/cardHeaderForSingleInputScreen ::
+              cardHeaderForSingleInputScreen(header=${header}, subtext=${subtext}, inputName=${inputName}, required=${required})}"/>
+          <th:block
+                  th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent">
+              <div class="form-card__content">
+                <th:block th:replace="${inputContent}"/>
+              </div>
+              <div class="form-card__footer">
+                <th:block
+                        th:replace="~{fragments/inputs/submitButton :: submitButton(text=${buttonLabel != null ? buttonLabel : 'Submit'})}"/>
+                <div>
+                  <a th:if="hasSkipLocation" th:text="${hasSkipTextValue ? skipText : 'Skip'}"
+                     th:href="${flow} + ${skipLocation}"></a>
+                </div>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/fragments/mixpanelTracking.html
+++ b/src/main/resources/templates/fragments/mixpanelTracking.html
@@ -42,32 +42,37 @@
     }
 
     mixpanel.track('page_load', tracking_params);
-
     function buttonClickEvent() {
-        const elementId = $(this).attr("id");
-        tracking_params['element_id'] = elementId
+      const elementId = $(this).attr("id");
+      const elementDataMixpanel = $(this).attr("data-mixpanel");
+      tracking_params['element_id'] = elementId
         mixpanel.track('button_click', tracking_params);
 
         if (elementId === 'language-menu') {
-            mixpanel.track('language_picker_click', {
-                'page_name': pageName,
-                'language': htmlLang,
-                'element_id': elementId
-            });
+          mixpanel.track('language_picker_click', {
+            'page_name': pageName,
+            'language': htmlLang,
+            'element_id': elementId
+          });
+        } else if (elementDataMixpanel === 'provider-response') {
+          mixpanel.track('provider_response', {
+            'family_application_id': `[[ ${T(org.ilgcc.app.utils.SubmissionUtilities).getMixpanelValue(inputData, "familySubmissionId")} ]]`,
+            'provider_agrees_to_care': `[[ ${T(org.ilgcc.app.utils.SubmissionUtilities).getMixpanelValue(inputData, "providerResponseAgreeToCare")} ]]`,
+          });
         }
 
         if (pageName.startsWith("/flow/gcc/onboarding-language-pref")) {
-            let form = $('form')
-            if (form.length > 0 && (form[0]).getAttribute('action').indexOf('?') > 0) {
-                const langCodes = new Map();
-                langCodes.set('Spanish', 'es');
-                langCodes.set('English', 'en');
-                mixpanel.track('language_change', {
-                    'previous_language': htmlLang,
-                    'selected_language': langCodes.get($('#languageRead')[0].value),
-                    'element_id': 'language_change_dropdown'
-                });
-            }
+          let form = $('form')
+          if (form.length > 0 && (form[0]).getAttribute('action').indexOf('?') > 0) {
+            const langCodes = new Map();
+            langCodes.set('Spanish', 'es');
+            langCodes.set('English', 'en');
+            mixpanel.track('language_change', {
+              'previous_language': htmlLang,
+              'selected_language': langCodes.get($('#languageRead')[0].value),
+              'element_id': 'language_change_dropdown'
+            });
+          }
         }
     }
 
@@ -152,5 +157,5 @@
             });
         });
 
-    });
+  });
 </script>

--- a/src/main/resources/templates/providerresponse/application-id.html
+++ b/src/main/resources/templates/providerresponse/application-id.html
@@ -1,0 +1,30 @@
+<th:block
+  th:replace="~{fragments/screens/screenWithOneInput ::
+  screenWithOneInput(
+    title=#{provider-response-application-id.title},
+    header=#{provider-response-application-id.header},
+    subtext=#{provider-response-application-id.subtext},
+    iconFragment=~{fragments/gcc-icons :: clipboardWithEnvelope},
+    buttonLabel=#{general.button.continue},
+    required='true',
+    formAction=${formAction},
+    inputContent=~{::inputContent})}">
+  <th:block th:ref="inputContent">
+    <th:block th:replace="~{fragments/inputs/text ::
+      text(inputName='providerResponseFamilyConfirmationCode',
+      ariaLabel='header')}"/>
+  </th:block>o
+</th:block>
+
+<script th:inline="javascript">
+  $(document).ready(function () {
+    const providerFamilyCode = $('#providerResponseFamilyConfirmationCode')
+
+    if(!providerFamilyCode.text()){
+      var confirmationCode = [[${session.confirmationCode}]];
+      if(confirmationCode){
+        providerFamilyCode.val(confirmationCode)
+      }
+    }
+  });
+</script>

--- a/src/main/resources/templates/providerresponse/ccap-registration.html
+++ b/src/main/resources/templates/providerresponse/ccap-registration.html
@@ -1,30 +1,18 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}">
-<head th:replace="~{fragments/head :: head(title=#{'provider-response-ccap-registration.title'})}"></head>
-<body>
-<div class="page-wrapper">
-    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-    <section class="slab">
-        <div class="grid">
-            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
-                    <th:block
-                            th:replace="~{fragments/gcc-icons :: registeredProvider }"></th:block>
-                    <th:block
-                            th:replace="~{fragments/cardHeader :: cardHeader(header=#{provider-response-ccap-registration.header}, subtext=#{provider-response-ccap-registration.subtext})}"/>
-
-                    <th:block th:replace="~{fragments/inputs/text :: text(inputName='providerResponseProviderNumber', ariaLabel='header')}"/>
-
-                    <div class="form-card__footer">
-                        <div>
-                            <th:block th:replace="~{fragments/continueButton :: continue(text=#{general.button.continue})}"/>
-                        </div>
-                    </div>
-            </main>
-        </div>
-    </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
-:
+<th:block
+  th:replace="~{fragments/inputs/screenWithOneInputAndSkip ::
+  screenWithOneInputAndSkip(
+    title=#{'provider-response-ccap-registration.title'},
+    iconFragment=~{fragments/gcc-icons :: registeredProvider},
+    header=#{provider-response-ccap-registration.header},
+    required='true',
+    subtext=#{provider-response-ccap-registration.subtext},
+    skipLocation='/ccap-registration-unregistered',
+    skipText=#{provider-response-ccap-registration.no-provider-number},
+    buttonLabel=#{general.button.continue},
+    formAction=${formAction},
+    inputContent=~{::inputContent})}">
+  <th:block th:ref="inputContent">
+      <th:block
+              th:replace="~{fragments/inputs/text :: text(inputName='providerResponseProviderNumber', ariaLabel='header', required='true')}"/>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/providerresponse/response.html
+++ b/src/main/resources/templates/providerresponse/response.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{provider-response-response.title})}"></head>
+<body>
+<div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/gcc-icons :: clipboardWithEnvelope}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeaderForSingleInputScreen :: cardHeaderForSingleInputScreen(header=#{provider-response-response.header}, inputName='providerResponseAgreeToCare', required='true')}"/>
+                <th:block
+                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+                    <th:block th:ref="formContent">
+                        <div class="form-card__content">
+                            <div class="providerResponse">
+                                <th:block
+                                        th:if="${submission.getInputData().containsKey('familySubmissionId')}"
+                                        th:with="applicationData=${submission.getInputData().get('clientResponse')}, children=${submission.getInputData().get('clientResponseChildren')}">
+
+                                    <p class="category" th:text="#{provider-response-response.confirmation-code}"></p>
+                                    <p class="response" th:id="confirmation-code"
+                                       th:text="${applicationData.getOrDefault('clientResponseConfirmationCode', 'n/a')}"></p>
+
+                                    <p class="category" th:text="#{provider-response-response.parent-name}"></p>
+                                    <p class="response" th:id="parent-name"
+                                       th:text="${applicationData.getOrDefault('clientResponseParentName', 'n/a')}"></p>
+
+                                    <th:block
+                                            th:each="child : ${submission.getInputData().get('clientResponseChildren')}">
+                                        <p class="category" th:text="#{provider-response-response.child-name}"></p>
+                                        <p class="response" th:id="${'child-name-'+childStat.index}"
+                                           th:text="${child.getOrDefault('childName', 'n/a')}"></p>
+
+                                        <p class="category" th:text="#{provider-response-response.child-age}"></p>
+                                        <p th:id="${'child-age-'+childStat.index}" th:text="${child.getOrDefault('childAge', 'n/a')}"></p>
+
+                                        <p class="category" th:text="#{provider-response-response.hours}"></p>
+                                        <ul class="list--bulleted" th:id="${'child-schedule-'+childStat.index}"
+                                            th:utext="${child.get('childCareHours')}"></ul>
+
+                                        <p class="category" th:text="#{provider-response-response.start-date}"></p>
+                                        <p class="response" th:id="${'child-start-'+childStat.index}"
+                                           th:text="${child.getOrDefault('childStartDate', 'n/a')}"></p>
+                                    </th:block>
+                                </th:block>
+                            </div>
+                        </div>
+                        <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                                          radioFieldset(inputName='providerResponseAgreeToCare',
+                                          ariaLabel=#{provider-response-response.title},
+                                          content=~{::providerResponse})}">
+                            <th:block th:ref="providerResponse">
+                                <th:block
+                                        th:replace="~{fragments/inputs/radio :: radio(inputName='providerResponseAgreeToCare',value='true', label=#{provider-response-response.button.yes})}"/>
+                                <th:block
+                                        th:replace="~{fragments/inputs/radio :: radio(inputName='providerResponseAgreeToCare',value='false', label=#{provider-response-response.button.no})}"/>
+                            </th:block>
+                        </th:block>
+                        <button id="form-submit-button"
+                                class="button button--primary"
+                                type="submit"
+                                data-mixpanel="provider-response"
+                                th:text="#{general.inputs.continue}">
+                        </button>
+                    </th:block>
+                </th:block>
+            </main>
+        </div>
+    </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>
+
+
+

--- a/src/main/resources/templates/providerresponse/submit-complete.html
+++ b/src/main/resources/templates/providerresponse/submit-complete.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{'provider-response-submit-complete.title'})}"></head>
+<body>
+<div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <div class="grid">
+        <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+        <main id="content" role="main" class="form-card spacing-above-35">
+            <th:block
+                    th:replace="~{fragments/gcc-icons :: greenCheck}"></th:block>
+            <th:block
+                    th:replace="~{fragments/cardHeader :: cardHeader(header=#{'provider-response-submit-complete.header'})}"/>
+            <th:block th:with="response=${submission.getInputData.get('providerResponseAgreeToCare')}">
+                <th:block th:if="${response.equals('true')}">
+                    <div class="notice spacing-below-60 notice--gray"
+                         th:text="#{'provider-response-submit-complete.notice-yes'}"></div>
+                    <div class="form-card__footer">
+                        <th:block th:replace="~{fragments/continueButton :: continue}"/>
+                    </div>
+                </th:block>
+                <th:block th:unless="${response.equals('true')}">
+                    <div class="notice spacing-below-60 notice--gray"
+                         th:text="#{'provider-response-submit-complete.notice-no'}"></div>
+                    <div class="form-card__footer">
+                        <a th:href="'/faq'"
+                           th:text="#{'provider-response-submit-complete.button-no'}"
+                           class="button button--primary"
+                           id="continue-link"></a>
+                    </div>
+                </th:block>
+
+
+            </th:block>
+
+    </div>
+    </th:block>
+    </main>
+</div>
+</section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>
+:

--- a/src/test/java/org/ilgcc/app/journeys/ProviderResponseShortLinkJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderResponseShortLinkJourneyTest.java
@@ -1,0 +1,71 @@
+package org.ilgcc.app.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import formflow.library.data.SubmissionRepository;
+import java.time.OffsetDateTime;
+import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProviderResponseShortLinkJourneyTest extends AbstractBasePageTest {
+
+    @Autowired
+    SubmissionRepository repository;
+
+    private static String VALID_CONF_CODE="A2123B";
+    private static String PROVIDER_NAME="BROWN_BEAR_DAYCARE";
+    @Test
+    void activeApplicationShowsSuccess() {
+        testPage.navigateToFlowScreen("gcc/activities-parent-intro");
+
+        saveSubmission(getSessionSubmissionTestBuilder()
+                .with("dayCareChoice", PROVIDER_NAME)
+                .withParentDetails()
+                .with("parentPreferredName", "FirstName")
+                .withChild("First", "Child", "Yes")
+                .withConstantChildcareSchedule(0)
+                .withSubmittedAtDate(OffsetDateTime.now())
+                .withShortCode(VALID_CONF_CODE)
+                .build());
+
+        testPage.clickContinue();
+
+        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_source=test".formatted(localServerPort,
+                VALID_CONF_CODE));
+
+        // submit-start
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-start.title"));
+        assertThat(testPage.getHeader()).isEqualTo(getEnMessageWithParams("provider-response-submit-start.active.header", new Object[]{"Brown Bear Daycare"}));
+
+        testPage.clickButton(getEnMessage("provider-response-submit-start.active.button"));
+    }
+
+    @Test
+    void oldApplicationShowsExpiration() {
+        testPage.navigateToFlowScreen("gcc/activities-parent-intro");
+
+        saveSubmission(getSessionSubmissionTestBuilder()
+                .with("dayCareChoice", PROVIDER_NAME)
+                .withParentDetails()
+                .with("parentPreferredName", "FirstName")
+                .withChild("First", "Child", "Yes")
+                .withConstantChildcareSchedule(0)
+                .withSubmittedAtDate(OffsetDateTime.now().minusDays(4))
+                .withShortCode(VALID_CONF_CODE)
+                .build());
+
+        testPage.clickContinue();
+
+        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_source=test".formatted(localServerPort,
+                VALID_CONF_CODE));
+
+        // submit-start
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-start.title"));
+        assertThat(testPage.getHeader()).isEqualTo(getEnMessageWithParams("provider-response-submit-start.expired.header", new Object[]{"Brown Bear Daycare"}));
+
+        testPage.clickButton(getEnMessage("provider-response-submit-start.expired.button"));
+    }
+
+//    TODO: Add already submitted logic once provider response can be submitted
+}

--- a/src/test/java/org/ilgcc/app/journeys/ProviderResponseShortLinkJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderResponseShortLinkJourneyTest.java
@@ -31,7 +31,7 @@ public class ProviderResponseShortLinkJourneyTest extends AbstractBasePageTest {
 
         testPage.clickContinue();
 
-        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_source=test".formatted(localServerPort,
+        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_medium=test".formatted(localServerPort,
                 VALID_CONF_CODE));
 
         // submit-start
@@ -51,13 +51,13 @@ public class ProviderResponseShortLinkJourneyTest extends AbstractBasePageTest {
                 .with("parentPreferredName", "FirstName")
                 .withChild("First", "Child", "Yes")
                 .withConstantChildcareSchedule(0)
-                .withSubmittedAtDate(OffsetDateTime.now().minusDays(4))
+                .withSubmittedAtDate(OffsetDateTime.now().minusDays(7))
                 .withShortCode(VALID_CONF_CODE)
                 .build());
 
         testPage.clickContinue();
 
-        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_source=test".formatted(localServerPort,
+        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_medium=test".formatted(localServerPort,
                 VALID_CONF_CODE));
 
         // submit-start

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -1,0 +1,85 @@
+package org.ilgcc.app.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import formflow.library.data.SubmissionRepository;
+import java.time.OffsetDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
+
+    @Autowired
+    SubmissionRepository repository;
+
+    private static String CONF_CODE="A2123B";
+
+    @Test
+    void ProviderresponseWithShortLinkFlowJourneyTest() {
+        testPage.navigateToFlowScreen("gcc/activities-parent-intro");
+
+        saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
+                .withParentDetails()
+                .with("parentPreferredName", "FirstName")
+                .withChild("First", "Child", "Yes")
+                .withChild("Second", "Child", "No")
+                .withChild("NoAssistance", "Child", "No")
+                .withConstantChildcareSchedule(0)
+                .withSubmittedAtDate(OffsetDateTime.now())
+                .withShortCode(CONF_CODE)
+                .build());
+
+        testPage.clickContinue();
+
+        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_source=test".formatted(localServerPort, CONF_CODE));
+
+        // submit-start when application is still active
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-start.title"));
+        testPage.clickButton(getEnMessage("provider-response-submit-start.active.button"));
+
+        // ccap-registration
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-ccap-registration.title"));
+        testPage.enter("providerResponseProviderNumber", "123456789012345");
+        testPage.clickContinue();
+
+        // application-id
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-application-id.title"));
+        testPage.findElementTextById("providerResponseFamilyConfirmationCode").equals(CONF_CODE);
+        testPage.clickContinue();
+
+        // response
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
+        assertThat(testPage.findElementTextById("confirmation-code")).isEqualTo(CONF_CODE);
+        assertThat(testPage.findElementTextById("parent-name")).isEqualTo("FirstName parent last");
+
+        assertThat(testPage.findElementTextById("child-name-0")).isEqualTo("First Child");
+        assertThat(testPage.findElementTextById("child-age-0")).isEqualTo("Age 22");
+        assertThat(testPage.findElementTextById("child-schedule-0")).isNotNull();
+        assertThat(testPage.findElementTextById("child-start-0")).isEqualTo("01/10/2025");
+
+        assertThat(testPage.elementDoesNotExistById("child-name-1")).isTrue();
+        assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
+
+        testPage.clickElementById("providerResponseAgreeToCare-true-label");
+        testPage.clickContinue();
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-complete.title"));
+        assertThat(testPage.findElementsByClass("notice").get(0).getText()).isEqualTo(getEnMessage("provider-response-submit-complete.notice-yes"));
+
+        testPage.goBack();
+
+        // response
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
+        testPage.clickElementById("providerResponseAgreeToCare-false-label");
+        testPage.clickContinue();
+
+        // submit-complete
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-complete.title"));
+        assertThat(testPage.findElementsByClass("notice").get(0).getText()).isEqualTo(getEnMessage("provider-response-submit-complete.notice-no"));
+    }
+
+}

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -34,7 +34,7 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
 
         testPage.clickContinue();
 
-        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_source=test".formatted(localServerPort, CONF_CODE));
+        driver.navigate().to("http://localhost:%s/providerresponse/submit?conf_code=%s&utm_medium=test".formatted(localServerPort, CONF_CODE));
 
         // submit-start when application is still active
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-start.title"));

--- a/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
@@ -36,6 +36,11 @@ public class SubmissionTestBuilder {
         return this;
     }
 
+    public SubmissionTestBuilder withShortCode(String shortCode) {
+        submission.setShortCode(shortCode);
+        return this;
+    }
+
     public SubmissionTestBuilder withDayCareProvider() {
         submission.getInputData().put("dayCareChoice", "OPEN_SESAME");
         return this;
@@ -152,11 +157,12 @@ public class SubmissionTestBuilder {
         child.put("childFirstName", firstName);
         child.put("childLastName", lastName);
         child.put("childInCare", "true");
-        child.put("childBirthdateDay", "10");
-        child.put("childBirthdateMonth", "11");
-        child.put("childBirthdateYear", "2001");
+        child.put("childDateOfBirthMonth", "10");
+        child.put("childDateOfBirthDay", "11");
+        child.put("childDateOfBirthYear", "2001");
         child.put("needFinancialAssistanceForChild", needFinancialAssistanceForChild);
         child.put("childIsUsCitizen", "Yes");
+        child.put("ccapStartDate", "01/10/2025");
         child.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
         children.add(child);
         submission.getInputData().put("children", children);

--- a/src/test/java/org/ilgcc/app/utils/TimeOption.java
+++ b/src/test/java/org/ilgcc/app/utils/TimeOption.java
@@ -3,17 +3,17 @@ package org.ilgcc.app.utils;
 public enum TimeOption {
 
     NOTIME("", "", ""),
-    TIME8AM("8", "0", "AM"),
-    TIME9AM("9", "0", "AM"),
-    TIME10AM("10", "0", "AM"),
-    TIME1PM("1", "0", "PM"),
+    TIME8AM("8", "00", "AM"),
+    TIME9AM("9", "00", "AM"),
+    TIME10AM("10", "00", "AM"),
+    TIME1PM("1", "00", "PM"),
     TIME113PM("1", "13", "PM"),
-    TIME12PM("12", "0", "PM"),
-    TIME3PM("3", "0", "PM"),
+    TIME12PM("12", "00", "PM"),
+    TIME3PM("3", "00", "PM"),
     TIME310PM("3", "10", "PM"),
     TIME345PM("3", "45", "PM"),
-    TIME5PM("5", "0", "PM"),
-    TIME7PM("7", "0", "PM");
+    TIME5PM("5", "00", "PM"),
+    TIME7PM("7", "00", "PM");
 
     private final String hour;
     private final String minute;


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-352](https://codeforamerica.atlassian.net/browse/CCAP-352)

#### ✍️ Description
- Continuation of [creating new provider flow](https://github.com/codeforamerica/il-gcc-form-flow/pull/633) and [handling confirmation codes](https://github.com/codeforamerica/il-gcc-form-flow/pull/615)
- Implements CCAP-registration form
- application-id screen which pre-fills the family application code
- implements /response which displays details for the family application
- implements submit-complete with the appropriate details depending on what the provider has decided
- mixpanel analytics on provider decision


--- 

Tests the happy path of the provider flow
Tests the Expired and Active statuses using the short link. 


#### 📷 Design reference
[Figma Designs here](https://www.figma.com/design/lGFsTvWwHoOOJ9XQGPFNmu/IL-CCAP-Provider-Experiences-(WIP)?node-id=1-8804&node-type=frame&t=CGaMnVGlHRKZkx40-0)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-352]: https://codeforamerica.atlassian.net/browse/CCAP-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ