### PR TITLE
Remove onboarding-provider-info from flow

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -433,8 +433,6 @@ landmarks:
     - doc-upload-recommended-docs
     - doc-upload-add-files
     - doc-upload-submit-confirmation
-    - onboarding-provider-info
-    - contact-provider-message
 ---
 name: providerresponse
 flow:

--- a/src/main/resources/templates/gcc/submit-complete.html
+++ b/src/main/resources/templates/gcc/submit-complete.html
@@ -26,7 +26,7 @@
                            th:text="#{submit-complete.button.submit-docs}"
                            class="button button--primary"
                            id="continue-link"></a>
-                        <a href="/flow/gcc/onboarding-provider-info"
+                        <a href="/flow/gcc/submit-next-steps"
                            th:text="#{submit-complete.button.skip}"
                            class="button"
                            id="skip-link"></a>


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-343

#### ✍️ Description
- [ ] Remove the `onboarding-provider-info` and `contact-provider-message` from the gcc **after submit** screen list
- [ ] Change `Skip and finish` button of `submit-complete` screen to link to `submit-next-steps` screen

#### 📷 Design reference
[Figma](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Full-Flow?node-id=524-9414&t=re9NsFmQ3PTvNFQO-4)

#### ✅ Completion tasks

##### Meets acceptance criteria
- [ ] Test that a user is not sent to the `onboarding-provider-info` screen when they arrive at the `submit-complete` screen and they click on the 'Skip and finish` button
- [ ] Test that they can jump into the `onboarding-provider-info` screen once they have clicked on the `Apply-Now` button on the home screen and started they application.  


