### PR TITLE
Fixes an issue where jobrunr tests would fail if the app was running

### DIFF
--- a/src/test/java/org/ilgcc/jobs/PdfTransmissionJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/PdfTransmissionJobTest.java
@@ -93,7 +93,7 @@ class PdfTransmissionJobTest {
         jobScheduler = JobRunr.configure()
                 .useStorageProvider(storageProvider)
                 .useJobActivator(this::jobActivator)
-                .useDashboard()
+                .useDashboard(1337)
                 .useBackgroundJobServer(usingStandardBackgroundJobServerConfiguration()
                         .andPollInterval(ofMillis(200))).initialize().getJobScheduler();
 
@@ -145,6 +145,6 @@ class PdfTransmissionJobTest {
     }
 
     private String getSucceededJobs() {
-        return getJson("http://localhost:8000/api/jobs?state=SUCCEEDED");
+        return getJson("http://localhost:1337/api/jobs?state=SUCCEEDED");
     }
 }

--- a/src/test/java/org/ilgcc/jobs/SampleJobsTest.java
+++ b/src/test/java/org/ilgcc/jobs/SampleJobsTest.java
@@ -30,7 +30,7 @@ public class SampleJobsTest {
   public void startJobRunr() {
     testService = new SampleJobProcessor();
 
-    JobRunr.configure().useStorageProvider(storageProvider).useJobActivator(this::jobActivator).useDashboard()
+    JobRunr.configure().useStorageProvider(storageProvider).useJobActivator(this::jobActivator).useDashboard(1337)
         .useBackgroundJobServer(usingStandardBackgroundJobServerConfiguration().andPollInterval(ofMillis(200))).initialize();
   }
 
@@ -88,15 +88,15 @@ public class SampleJobsTest {
   }
 
   private String getSucceededJobs() {
-    return getJson("http://localhost:8000/api/jobs?state=SUCCEEDED");
+    return getJson("http://localhost:1337/api/jobs?state=SUCCEEDED");
   }
 
   private String getEnqueuedJobs() {
-    return getJson("http://localhost:8000/api/jobs?state=ENQUEUED");
+    return getJson("http://localhost:1337/api/jobs?state=ENQUEUED");
   }
 
   private String getProcessingJobs() {
-    return getJson("http://localhost:8000/api/jobs?state=PROCESSING");
+    return getJson("http://localhost:1337/api/jobs?state=PROCESSING");
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
This fixes an issue where if the main application was running when you ran tests, the jobrunr tests would fail because they would attempt to load the jobrunr dashboard at the same address as the main apps dashboard. 

This fixes the issue by changing the port used in test. 
