### PR TITLE
Remove incomplete iterations from subflows

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/RemoveIncompleteChildIterations.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/RemoveIncompleteChildIterations.java
@@ -1,0 +1,33 @@
+package org.ilgcc.app.submission.actions;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RemoveIncompleteChildIterations implements Action {
+    
+    private final SubmissionRepositoryService submissionRepositoryService;
+
+    public RemoveIncompleteChildIterations(SubmissionRepositoryService submissionRepositoryService) {
+        this.submissionRepositoryService = submissionRepositoryService;
+    }
+    
+    @Override
+    public void run(Submission submission) {
+        var subflowData = (List<Map<String, Object>>) submission.getInputData().getOrDefault("children", emptyList());
+        if (!subflowData.isEmpty()) {
+            log.info("Removing incomplete child iterations from submission {}", submission.getId());
+            subflowData.removeIf(childIteration -> !(boolean) childIteration.getOrDefault("iterationIsComplete", false));
+            submissionRepositoryService.save(submission);
+        }
+    }
+}
+

--- a/src/main/java/org/ilgcc/app/submission/actions/RemoveIncompleteJobIterations.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/RemoveIncompleteJobIterations.java
@@ -1,0 +1,33 @@
+package org.ilgcc.app.submission.actions;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RemoveIncompleteJobIterations implements Action {
+    
+    private final SubmissionRepositoryService submissionRepositoryService;
+
+    public RemoveIncompleteJobIterations(SubmissionRepositoryService submissionRepositoryService) {
+        this.submissionRepositoryService = submissionRepositoryService;
+    }
+    
+    @Override
+    public void run(Submission submission) {
+        var subflowData = (List<Map<String, Object>>) submission.getInputData().getOrDefault("jobs", emptyList());
+        if (!subflowData.isEmpty()) {
+            log.info("Removing incomplete job iterations from submission {}", submission.getId());
+            subflowData.removeIf(job -> !(boolean) job.getOrDefault("iterationIsComplete", false));
+            submissionRepositoryService.save(submission);
+        }
+    }
+}
+

--- a/src/main/java/org/ilgcc/app/submission/actions/RemoveIncompletePartnerJobIterations.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/RemoveIncompletePartnerJobIterations.java
@@ -1,0 +1,33 @@
+package org.ilgcc.app.submission.actions;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RemoveIncompletePartnerJobIterations implements Action {
+    
+    private final SubmissionRepositoryService submissionRepositoryService;
+
+    public RemoveIncompletePartnerJobIterations(SubmissionRepositoryService submissionRepositoryService) {
+        this.submissionRepositoryService = submissionRepositoryService;
+    }
+    
+    @Override
+    public void run(Submission submission) {
+        var subflowData = (List<Map<String, Object>>) submission.getInputData().getOrDefault("partnerJobs", emptyList());
+        if (!subflowData.isEmpty()) {
+            log.info("Removing incomplete partner job iterations from submission {}", submission.getId());
+            subflowData.removeIf(partnerJob -> !(boolean) partnerJob.getOrDefault("iterationIsComplete", false));
+            submissionRepositoryService.save(submission);
+        }
+    }
+}
+

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -103,6 +103,7 @@ flow:
     nextScreens:
       - name: children-add
   children-add:
+    beforeDisplayAction: RemoveIncompleteChildIterations
     nextScreens:
       - name: activities-parent-intro
   children-info-basic:
@@ -162,7 +163,7 @@ flow:
         condition: PartnerInSchool
       - name: unearned-income-intro
   activities-add-jobs:
-    subflow: jobs
+    beforeDisplayAction: RemoveIncompleteJobIterations
     nextScreens:
       - name: activities-add-ed-program
         condition: LearningIsOneReasonForChildcareNeed
@@ -250,7 +251,7 @@ flow:
         condition: PartnerInSchool
       - name: unearned-income-intro
   activities-partner-add-job:
-    subflow: partnerJobs
+    beforeDisplayAction: RemoveIncompletePartnerJobIterations
     nextScreens:
       - name: activities-partner-add-ed-program
         condition: PartnerInSchool

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -247,7 +247,23 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickYes();
         //children-add (with children listed)
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("children-add.title"));
+        // Add an incomplete iteration and assert that it is removed
+        testPage.clickButton(getEnMessage("children-add.add-button"));
+        testPage.enter("childFirstName", "ShouldBe");
+        testPage.enter("childLastName", "Removed");
+        testPage.enter("childDateOfBirthMonth", "1");
+        testPage.enter("childDateOfBirthDay", "1");
+        testPage.enter("childDateOfBirthYear", "2022");
+        testPage.selectFromDropdown("childRelationship", getEnMessage("children-ccap-info.relationship-option.child"));
+        testPage.selectRadio("needFinancialAssistanceForChild", "Yes");
+        testPage.clickContinue();
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("children-ccap-info.title"));
+        // Go back to the children-add page and assert that the incomplete iteration is removed
+        testPage.goBack();
+        testPage.goBack();
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("children-add.title"));
         List<String> li = testPage.getTextBySelector(".child-name");
+        assertThat(li).doesNotContain("ShouldBe Removed");
         assertThat(li).containsExactly("mugully glopklin", "child mcchild");
         testPage.clickButton(getEnMessage("children-add.thats-all"));
 


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-396?atlOrigin=eyJpIjoiNGRlZWYyNDA1Y2ZlNGMwNGJmODQ5NDlhYmFkNmNlZGMiLCJwIjoiaiJ9

#### ✍️ Description
When a user lands on the review screen for one of the subflows (children, jobs, partner jobs), an action will be triggered that removes any incomplete iterations from said subflow and saves the submission with the updated subflow that no longer includes incomplete iterations.

This should also stop incomplete iterations from being mapped to the PDF since they will no longer be present in the submission.
