### PR TITLE
[CCAP-410] - Updated provider name in submit-start screen and updated screen to ma…

### DIFF
--- a/src/main/java/org/ilgcc/app/utils/enums/ProviderSubmissionStatus.java
+++ b/src/main/java/org/ilgcc/app/utils/enums/ProviderSubmissionStatus.java
@@ -6,24 +6,22 @@ import lombok.Getter;
 public enum ProviderSubmissionStatus {
 
     ACTIVE("caring", "provider-response-submit-start.active.header", "provider-response-submit-start.active.notice",
-            "provider-response-submit-start.active.button", ""),
+            "provider-response-submit-start.active.button"),
     EXPIRED("orangeClock", "provider-response-submit-start.expired.header", "provider-response-submit-start.expired.notice",
-            "provider-response-submit-start.expired.button", "provider-response-submit-start.expired.subtext"),
+            "provider-response-submit-start.expired.button"),
     RESPONDED("docValidation", "provider-response-submit-start.responded.header",
-            "provider-response-submit-start.responded.notice", "provider-response-submit-start.responded.button", "");
+            "provider-response-submit-start.responded.notice", "provider-response-submit-start.responded.button");
 
     private final String icon;
     private final String headerLabel;
     private final String noticeLabel;
     private final String buttonLabel;
-    private final String subtextLabel;
 
-    ProviderSubmissionStatus(String icon, String headerLabel, String noticeLabel, String buttonLabel, String subtextLabel) {
+    ProviderSubmissionStatus(String icon, String headerLabel, String noticeLabel, String buttonLabel) {
         this.icon = icon;
         this.headerLabel = headerLabel;
         this.noticeLabel = noticeLabel;
         this.buttonLabel = buttonLabel;
-        this.subtextLabel = subtextLabel;
     }
 }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -96,8 +96,8 @@ errors.provide-state=Please choose the state.
 errors.provide-zip=Please enter a zip code with 5 digits.
 errors.provide-county=Select a county
 errors.provide-program-name=Please provide a program name.
-errors.provide-provider-number=Please provide your provider number.
-errors.provide-applicant-number=Please provide the family's application number.
+errors.provide-provider-number=Enter your provider number.
+errors.provide-applicant-number=Enter a code with 6 numbers and letters.
 errors.select-one-option=Please select one option
 errors.select-at-least-one-day=Please select at least one day
 errors.select-child-relationship=Please select a relationship.
@@ -1085,16 +1085,15 @@ contact-provider-message.faq-answer=<p>If your chosen child care provider doesn'
 #submit-start
 provider-response-submit-start.title=Submit Start
 provider-response-submit-start.active.header=Hi, {0}!
-provider-response-submit-start.active.notice=A family listed you as their child care provider on a Child Care Assistance (CCAP) application.
+provider-response-submit-start.active.notice=<div class='notice spacing-below-60 notice--gray'><p>A family listed you as their child care provider on a Child Care Assistance Program (CCAP) application.</p><br><p>You have 3 business days to respond to a family's application.</p></div>
 provider-response-submit-start.active.button=Continue to see details
 
 provider-response-submit-start.expired.header=Sorry, {0}. This link has expired.
-provider-response-submit-start.expired.subtext=You have 3 business days to respond to a family's application.
-provider-response-submit-start.expired.notice=This link expires after 3 business days. The family's application has been sent to the CCR&R without your response.
+provider-response-submit-start.expired.notice=<div class='notice spacing-below-60 notice--warning'><p>This application has been sent to the CCR&R without your response.</p><br><p>A family listed you as their child care provider on a Child Care Assistance (CCAP) application and <strong>you had 3 business days</strong> to respond.</p></div>
 provider-response-submit-start.expired.button=Return to home
 
 provider-response-submit-start.responded.header=Hi, {0}. A response has already been recorded for this application.
-provider-response-submit-start.responded.notice=The family's application has been sent to the CCR&R for processing.
+provider-response-submit-start.responded.notice=<div class='notice spacing-below-60 notice--gray'><p>The family's Child Care Assistance (CCAP) application has been sent to the CCR&R for processing.</p></div>
 provider-response-submit-start.responded.button=Return to home
 
 provider-response-submit-start.provider-placeholder=child care provider

--- a/src/main/resources/templates/providerresponse/submit-start.html
+++ b/src/main/resources/templates/providerresponse/submit-start.html
@@ -13,17 +13,7 @@
                     <th:block
                             th:replace="~{fragments/gcc-icons :: ${providerSubmissionStatus.getIcon()}}"></th:block>
                     <th:block
-                            th:unless="${providerSubmissionStatus.equals(T(org.ilgcc.app.utils.enums.ProviderSubmissionStatus).EXPIRED)}">
-                        <th:block
-                                th:replace="~{fragments/cardHeader :: cardHeader(header=#{${providerSubmissionStatus.getHeaderLabel()}(${session.selectedProviderName})})}"/>
-                    </th:block>
-                    <th:block
-                            th:if="${providerSubmissionStatus.equals(T(org.ilgcc.app.utils.enums.ProviderSubmissionStatus).EXPIRED)}">
-                        <th:block
-                                th:replace="~{fragments/cardHeader :: cardHeader(header=#{${providerSubmissionStatus.getHeaderLabel()}(${session.selectedProviderName})}, subtext=#{${providerSubmissionStatus.getSubtextLabel()}})}"/>
-                    </th:block>
-                    <div th:class="'notice spacing-below-60 '+ ${providerSubmissionStatus.equals(T(org.ilgcc.app.utils.enums.ProviderSubmissionStatus).EXPIRED) ? 'notice--error' : 'notice--gray'}"
-                         th:text="#{${providerSubmissionStatus.getNoticeLabel()}}"></div>
+                            th:replace="~{fragments/cardHeader :: cardHeader(header=#{${providerSubmissionStatus.getHeaderLabel()}(${session.selectedProviderName})}, subtext=#{${providerSubmissionStatus.getNoticeLabel()}})}"/>
                     <div class="form-card__footer">
                         <div>
                             <th:block
@@ -38,7 +28,6 @@
                                    class="button button--primary"
                                    id="continue-link"></a>
                             </th:block>
-
                         </div>
                     </div>
                 </th:block>


### PR DESCRIPTION
…tch design

#### 🔗 Jira ticket
[CCAP-410](https://codeforamerica.atlassian.net/browse/CCAP-410)
Also small fry:
[CCAP-412](https://codeforamerica.atlassian.net/browse/CCAP-412)

#### ✍️ Description
- When family inputs the new data, uses `familyIntendedProviderName` instead of provider details
- Updates copy on submit-start screen (link to content manager: https://docs.google.com/document/d/1vwtwI1-GcqrGDGf3l1UEk161ahoGqVlCAX0BhmoYnlY/edit?tab=t.0#bookmark=id.8x1sew3ig1f3)
- Updates error messages for CCAP-application and application-id

#### 📷 Design reference
n/a

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-410]: https://codeforamerica.atlassian.net/browse/CCAP-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCAP-412]: https://codeforamerica.atlassian.net/browse/CCAP-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ