### PR TITLE
[CCAP-417] Add submit-provider-agreement-handoff screen

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -422,6 +422,9 @@ flow:
   contact-provider-info:
     nextScreens:
       - name: contact-provider-message
+  submit-provider-agreement-handoff:
+    nextScreens:
+      - name: next-steps-pdf-delivery
   contact-provider-message:
     nextScreens:
       - name: complete-notice

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -807,6 +807,13 @@ contact-provider-info.header=Ask your provider to complete their part of the app
 contact-provider-info.subtext=<p>On the next page, you will text or email message a secure link to your child care provider.</p><br><p>Using the link, your provider can complete their part of the application.</p>
 contact-provider-info.skip=I'd prefer to print and deliver my application in-person.
 
+#submit-provider-agreement-handoff
+submit-provider-agreement-handoff.title=Download application
+submit-provider-agreement-handoff.header=Deliver your application in person
+submit-provider-agreement-handoff.body=To complete this process, download and print the application you've already filled out. Deliver it to your child care provider to complete. Then submit it to your CCR&R for processing.
+submit-provider-agreement-handoff.download=Download my application
+submit-provider-agreement-handoff.next=View next steps
+
 #complete-notice
 complete-notice.title=title
 complete-notice.header=header

--- a/src/main/resources/templates/fragments/gcc-icons.html
+++ b/src/main/resources/templates/fragments/gcc-icons.html
@@ -1605,7 +1605,7 @@
         <tr>
             <td>providerEnvelope</td>
             <td>
-                <svg th:fragment="providerEnvelope" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <svg th:fragment="providerEnvelope" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <g clip-path="url(#clip0_9629_31931)">
                         <path fill-rule="evenodd" clip-rule="evenodd" d="M14.6951 19.1551C19.2925 12.7384 27.1169 10.1366 34.3156 6.81454C41.6617 3.42442 48.8398 -1.08062 56.9121 -0.327408C65.5118 0.475003 73.9525 4.42372 79.4582 11.0267C84.8529 17.4966 85.6039 26.3097 86.1055 34.6842C86.5853 42.6946 86.5911 51.076 82.2627 57.8511C78.0229 64.4875 70.4267 67.8382 63.0649 70.7486C55.9729 73.5523 48.5148 75.4388 40.9825 74.1708C33.2211 72.8644 26.1805 69.0569 20.5552 63.5928C14.643 57.8502 9.66845 50.8447 8.59607 42.7127C7.50892 34.4686 9.84216 25.9287 14.6951 19.1551Z" fill="#769BF3"/>
                         <line x1="4" y1="29.5" x2="23" y2="29.5" stroke="#121111" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
@@ -1627,6 +1627,26 @@
                             <rect width="100" height="75" fill="white" transform="translate(0.5)"/>
                         </clipPath>
                     </defs>
+                </svg>
+
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <td>clipboardWithEnvelope</td>
+                <svg th:fragment="clipboardWithEnvelope" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M32.2903 68.5636C26.1328 65.5239 19.3046 62.8861 15.736 57.0167C12.0774 50.9991 12.2464 43.5404 12.8045 36.5141C13.3699 29.3947 14.4287 21.9642 18.9587 16.4407C23.4519 10.962 30.5411 8.67831 37.3178 6.62433C43.8713 4.638 50.7714 2.94211 57.3569 4.80237C63.8329 6.63166 68.8052 11.58 73.1264 16.7393C77.2393 21.6498 79.8154 27.4265 81.488 33.6133C83.2726 40.2142 85.2862 47.1658 83.1057 53.6515C80.8788 60.2755 75.4793 65.3811 69.5602 69.0926C63.854 72.6706 57.1564 74.2377 50.4271 74.1422C43.9701 74.0505 38.0788 71.4211 32.2903 68.5636Z" fill="#769BF3"/>
+                    <path d="M59.0637 7.61987H9.5V65.4277H59.0637V7.61987Z" fill="white" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M49.7942 59.4778H18.6056C16.6448 59.4778 15.0547 57.8945 15.0547 55.942V14.1517C15.0547 12.1993 16.6448 10.616 18.6056 10.616H49.8298C51.7693 10.616 53.3451 12.1851 53.3451 14.1162V19.3347V55.9349C53.3451 57.8945 51.7551 59.4778 49.7942 59.4778Z" fill="white" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M20.9658 42.4167H47.4411" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M20.9658 36.1121H47.4411" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M20.9658 48.6221H47.4411" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M34.2854 24.8088C32.5313 24.8088 31.1123 26.2217 31.1123 27.9683V30.1409H37.4584V27.9683C37.4513 26.2217 36.0323 24.8088 34.2854 24.8088Z" fill="#DAFFF8"/>
+                    <path d="M34.2854 24.8088C35.6164 24.8088 36.6954 23.7344 36.6954 22.4091C36.6954 21.0837 35.6164 20.0093 34.2854 20.0093C32.9543 20.0093 31.8753 21.0837 31.8753 22.4091C31.8753 23.7344 32.9543 24.8088 34.2854 24.8088Z" fill="#DAFFF8"/>
+                    <path d="M34.2854 24.8088C32.5313 24.8088 31.1123 26.2217 31.1123 27.9683V30.1409H37.4584V27.9683C37.4513 26.2217 36.0323 24.8088 34.2854 24.8088ZM34.2854 24.8088C35.6164 24.8088 36.6954 23.7344 36.6954 22.4091C36.6954 21.0837 35.6164 20.0093 34.2854 20.0093C32.9543 20.0093 31.8753 21.0837 31.8753 22.4091C31.8753 23.7344 32.9543 24.8088 34.2854 24.8088Z" stroke="#121111" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M44.2108 12.7815H24.3525V11.0634C24.3525 7.71218 27.0764 5 30.4419 5H38.1285C41.4941 5 44.2179 7.71218 44.2179 11.0634V12.7815H44.2108Z" fill="#DAFFF8" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M38.5327 46L38.5 70.9107L84.4673 71L84.5 46.0893L38.5327 46Z" fill="#FFE8CE" stroke="#121111" stroke-width="3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M39 47.5L62.5 58.5L84 47.5" stroke="#121111" stroke-width="3" stroke-linejoin="round"/>
                 </svg>
 
             </td>

--- a/src/main/resources/templates/gcc/contact-provider-info.html
+++ b/src/main/resources/templates/gcc/contact-provider-info.html
@@ -16,7 +16,7 @@
                 </div>
                 <div class="form-card__footer">
                     <th:block th:replace="~{fragments/continueButton :: continue}"/>
-                    <div><a href="/"
+                    <div><a href="/flow/gcc/submit-provider-agreement-handoff"
                             th:text="#{contact-provider-info.skip}"
                             id="print-application-in-person"></a></div>
                 </div>

--- a/src/main/resources/templates/gcc/submit-provider-agreement-handoff.html
+++ b/src/main/resources/templates/gcc/submit-provider-agreement-handoff.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{submit-provider-agreement-handoff.title})}"></head>
+<body>
+<div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/icons :: clipboardWithEnvelope}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-provider-agreement-handoff.header}, subtext=#{submit-provider-agreement-handoff.body})}"/>
+                <th:block
+                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::content})}">
+                    <th:block th:ref="content">
+                        <div class="form-card__content">
+                            <a th:href="'/download/gcc/' + ${submission.getId()}" class="button button--wide">
+                                <i class="icon-get_app"></i>
+                                <span th:text="#{submit-provider-agreement-handoff.download}"></span>
+                            </a>
+                        </div>
+                        <div class="form-card__footer">
+                            <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{submit-provider-agreement-handoff.next})}"/>
+                        </div>
+                    </th:block>
+                </th:block>
+            </main>
+        </div>
+    </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-417

#### ✍️ Description

- Implement submit-provider-agreement-handoff screen
- The screen matches the designs
- All content is voiced by the screen reader
- All the interactive elements are navigable using the keyboard
- The submit-provider-agreement-handoff screen is the destination for the “I’d prefer to print and deliver my application in-person.” link on the Contact-provider-info screen

#### 📷 Design reference
https://www.figma.com/design/lGFsTvWwHoOOJ9XQGPFNmu/IL-CCAP-Provider-Experiences-(WIP)?node-id=1-9189&t=Rw698undoDqscCAV-4
