### PR TITLE
[CCAP-397] Error prevention on provider number input

### DIFF
--- a/src/main/resources/templates/fragments/inputs/overrides/number.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/number.html
@@ -1,0 +1,42 @@
+<th:block
+        th:fragment="number"
+        th:with="
+      hasHelpText=${!#strings.isEmpty(helpText)},
+      hasTitle=${!#strings.isEmpty(title)},
+      hasLabel=${!#strings.isEmpty(label)},
+      hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
+      requiredInputsForFlow=${requiredInputs.get(flow)},
+      isRequiredInput=${(requiredInputsForFlow != null && requiredInputsForFlow.getOrDefault(inputName, false)) || (required != null && required)},
+      hasError=${
+        errorMessages != null &&
+        errorMessages.get(inputName) != null &&
+        (#arrays.length(errorMessages.get(inputName)) > 0) }"
+        th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+    <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+        <label th:if="${hasLabel}" th:for="${inputName}" class="form-question">
+            <span th:text="${label}"></span>
+            <span th:if="${isRequiredInput  && !hasAriaLabel}" class="required-input" th:text="#{general.required-field}"></span>
+        </label>
+        <p class="text--help"
+           th:if="${hasHelpText}"
+           th:id="${inputName + '-help-text'}"
+           th:text="${helpText}"></p>
+        <th:block
+                th:if="${hasError}"
+                th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+        <div class="text-input-group form-width--large">
+            <input type="text" inputmode="numeric"
+                   class="text-input form-width--large"
+                   th:id="${inputName}"
+                   th:name="${inputName}"
+                   th:placeholder="${placeholder}"
+                   th:attr="
+              title=${hasTitle ? title : #messages.msg('general.inputs.number')},
+              aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
+              aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
+              aria-invalid=${hasError}"
+                   th:value="${fieldData.getOrDefault(inputName, '')}">
+            <div th:if="${postfix != null}" th:text="${postfix}" class="text-input-group__postfix"></div>
+        </div>
+    </div>
+</th:block>

--- a/src/main/resources/templates/providerresponse/ccap-registration.html
+++ b/src/main/resources/templates/providerresponse/ccap-registration.html
@@ -13,6 +13,6 @@
     inputContent=~{::inputContent})}">
   <th:block th:ref="inputContent">
       <th:block
-              th:replace="~{fragments/inputs/text :: text(inputName='providerResponseProviderNumber', ariaLabel='header', required='true')}"/>
+              th:replace="~{fragments/inputs/overrides/number :: number(inputName='providerResponseProviderNumber', ariaLabel='header', required='true')}"/>
   </th:block>
 </th:block>


### PR DESCRIPTION
#### 🔗 Jira ticket
 https://github.com/codeforamerica/il-gcc-form-flow/pull/new/marc-CCAP-397

#### ✍️ Description
The first two bullet points of this ticket:
- The provider number field should only accept digits 0-9
- The provider number should be limited to a maximum of 15 digits
were accomplished in CCAP-424

The final bullet point:
- On mobile, the numeric input should be displayed when the provider number input field is activated
is accomplished with this PR.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
