### PR TITLE
[CCAP-409]

### DIFF
--- a/src/main/resources/templates/fragments/mixpanelTracking.html
+++ b/src/main/resources/templates/fragments/mixpanelTracking.html
@@ -55,9 +55,17 @@
             'element_id': elementId
           });
         } else if (elementDataMixpanel === 'provider-response') {
+          let value = "not_set";
+           if (document.getElementById("providerResponseAgreeToCare-true").checked){
+             value = "provider_agreed";
+           }
+          if (document.getElementById("providerResponseAgreeToCare-false").checked){
+            value = "provider_declined"
+          }
+
           mixpanel.track('provider_response', {
             'family_application_id': `[[ ${T(org.ilgcc.app.utils.SubmissionUtilities).getMixpanelValue(inputData, "familySubmissionId")} ]]`,
-            'provider_agrees_to_care': `[[ ${T(org.ilgcc.app.utils.SubmissionUtilities).getMixpanelValue(inputData, "providerResponseAgreeToCare")} ]]`,
+            'provider_agrees_to_care': value,
           });
         }
 


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-409

#### ✍️ Description
When the provider submits their response on the provider-response/response screen, fire a special event provider_response. That event should contain the unique id for the family application as a property on the event. That event should also contain a property indicating the response, either provider_agreed or provider declined. 


#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
