### PR TITLE
Generate a dummy family submission when going through provider flow

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -13,7 +13,7 @@ public class Providerresponse extends FlowInputs {
     private String providerResponseProviderNumber;
 
     @NotBlank(message = "{errors.provide-applicant-number}")
-    private String providerResponseFamilyConfirmationCode;
+    private String providerResponseFamilyShortCode;
 
     @NotBlank
     private String providerResponseAgreeToCare;

--- a/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
@@ -27,6 +27,5 @@ public class FindApplicationData implements Action {
            providerSubmission.getInputData().put("clientResponse", ProviderSubmissionUtilities.getApplicantSubmissionForProviderResponse(clientSubmission));
            providerSubmission.getInputData().put("clientResponseChildren", ProviderSubmissionUtilities.getChildrenDataForProviderResponse(clientSubmission.get()));
         }
-
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyClientSubmissionForDev.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyClientSubmissionForDev.java
@@ -1,0 +1,57 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
+import formflow.library.data.SubmissionRepositoryService;
+import jakarta.servlet.http.HttpSession;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GenerateDummyClientSubmissionForDev implements Action {
+    
+    private final SubmissionRepositoryService submissionRepositoryService;
+    private final SubmissionRepository submissionRepository;
+    private final HttpSession httpSession;
+    
+    @Autowired
+    Environment env;
+    
+    public GenerateDummyClientSubmissionForDev(SubmissionRepositoryService submissionRepositoryService,
+            SubmissionRepository submissionRepository, HttpSession httpSession) {
+        this.submissionRepositoryService = submissionRepositoryService;
+        this.submissionRepository = submissionRepository;
+        this.httpSession = httpSession;
+    }
+
+    @Override
+    public void run(Submission submission) {
+        String[] activeProfiles = env.getActiveProfiles();
+        boolean isDevProfile = Arrays.asList(activeProfiles).contains("dev");
+        if (isDevProfile) {
+            Optional<Submission> existingDummyClientSubmision = submissionRepositoryService.findByShortCode("DEV-123ABC");
+            existingDummyClientSubmision.ifPresent(submissionRepository::delete);
+
+            Map<String, Object> inputData = new HashMap<>();
+            inputData.put("familyIntendedProviderName", "Dev Provider");
+            inputData.put("parentFirstName", "Devy");
+            inputData.put("parentLastName", "McDeverson");
+            Submission dummyClientSubmission = new Submission();
+            dummyClientSubmission.setSubmittedAt(OffsetDateTime.now().minusDays(1));
+            dummyClientSubmission.setFlow("gcc");
+            dummyClientSubmission.setShortCode("DEV-123ABC");
+            dummyClientSubmission.setInputData(inputData);
+            
+            submissionRepositoryService.save(dummyClientSubmission);
+
+            httpSession.setAttribute("clientSubmissionId", dummyClientSubmission.getId());
+        }
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyClientSubmissionForDev.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyClientSubmissionForDev.java
@@ -1,15 +1,20 @@
 package org.ilgcc.app.submission.actions;
 
 import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import jakarta.servlet.http.HttpSession;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -32,17 +37,15 @@ public class GenerateDummyClientSubmissionForDev implements Action {
     }
 
     @Override
-    public void run(Submission submission) {
+    public void run(FormSubmission formSubmission, Submission submission) {
         String[] activeProfiles = env.getActiveProfiles();
         boolean isDevProfile = Arrays.asList(activeProfiles).contains("dev");
         if (isDevProfile) {
             Optional<Submission> existingDummyClientSubmision = submissionRepositoryService.findByShortCode("DEV-123ABC");
             existingDummyClientSubmision.ifPresent(submissionRepository::delete);
 
-            Map<String, Object> inputData = new HashMap<>();
-            inputData.put("familyIntendedProviderName", "Dev Provider");
-            inputData.put("parentFirstName", "Devy");
-            inputData.put("parentLastName", "McDeverson");
+            Map<String, Object> inputData = createFamilySubmission();
+
             Submission dummyClientSubmission = new Submission();
             dummyClientSubmission.setSubmittedAt(OffsetDateTime.now().minusDays(1));
             dummyClientSubmission.setFlow("gcc");
@@ -53,5 +56,110 @@ public class GenerateDummyClientSubmissionForDev implements Action {
 
             httpSession.setAttribute("clientSubmissionId", dummyClientSubmission.getId());
         }
+    }
+
+    private @NotNull Map<String, Object> createFamilySubmission() {
+        Map<String, Object> inputData = new HashMap<>();
+        inputData.put("familyIntendedProviderName", "Dev Provider");
+        inputData.put("parentFirstName", "Devy");
+        inputData.put("parentLastName", "McDeverson");
+        inputData.put("parentBirthMonth", "12");
+        inputData.put("parentBirthDay", "25");
+        inputData.put("parentBirthYear", "1985");
+        inputData.put("parentHomeStreetAddress1", "972 Mission St");
+        inputData.put("parentHomeStreetAddress2", "5th floor");
+        inputData.put("parentHomeCity", "San Francisco");
+        inputData.put("parentHomeState", "CA - California");
+        inputData.put("parentHomeZipCode", "94103");
+        inputData.put("parentHasPartner", "false");
+        
+        List<Map<String, Object>> children = new ArrayList<>();
+        Map<String, Object> child1 = new HashMap<>();
+        child1.put("uuid", "testerosa-testerson");
+        child1.put("childFirstName", "Testerosa");
+        child1.put("childLastName", "Testerson");
+        child1.put("childDateOfBirthMonth", "10");
+        child1.put("childDateOfBirthDay", "17");
+        child1.put("childDateOfBirthYear", "2015");
+        child1.put("childInCare", "true");
+        child1.put("needFinancialAssistanceForChild", "Yes");
+        child1.put("childIsUsCitizen", "Yes");
+        child1.put("ccapStartDate", "01/10/2025");
+        child1.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
+        
+        Map<String, Object> child2 = new HashMap<>();
+        child2.put("uuid", "testina-testerson");
+        child2.put("childFirstName", "Testina");
+        child2.put("childLastName", "Testerson");
+        child2.put("childDateOfBirthMonth", "12");
+        child2.put("childDateOfBirthDay", "25");
+        child2.put("childDateOfBirthYear", "2017");
+        child2.put("childInCare", "true");
+        child2.put("needFinancialAssistanceForChild", "Yes");
+        child2.put("childIsUsCitizen", "Yes");
+        child2.put("ccapStartDate", "01/10/2025");
+        child2.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
+        
+        children.add(child1);
+        children.add(child2);
+
+        IntStream.range(0, children.size()).forEach(i -> {
+            Map<String, Object> child = children.get(i);
+            setTime(child, "childcare", "Start", "AllDays", "8", "00", "AM");
+            setTime(child, "childcare", "End", "AllDays", "5", "00", "PM");
+
+            setTime(child, "childcare", "Start", "Monday", "", "", "");
+            setTime(child, "childcare", "End", "Monday", "", "", "");
+
+            setTime(child, "childcare", "Start", "Wednesday", "", "", "");
+            setTime(child, "childcare", "End", "Wednesday", "", "", "");
+
+            setTime(child, "childcare", "Start", "Friday", "", "", "");
+            setTime(child, "childcare", "End", "Friday", "", "", "");
+
+            child.put("childcareWeeklySchedule[]", List.of("Monday", "Wednesday", "Friday"));
+            child.put("childcareStartTimeWednesday", "");
+            child.put("childcareHoursSameEveryDay[]", List.of("yes"));
+
+            children.set(i, child);
+        });
+        inputData.put("children", children);
+
+        List<Map<String, Object>> applicantJob = new ArrayList<>();
+        Map<String, Object> job1 = new HashMap<>();
+        job1.put("uuid", "job1");
+        job1.put("companyName", "Test Co");
+        job1.put("employerStreetAddress", "123 Test St");
+        job1.put("employerCity", "Springfield");
+        job1.put("employerState", "IL");
+        job1.put("employerZipCode", "62629");
+        job1.put("employerPhoneNumber", "217-555-1234");
+        job1.put("isSelfEmployed", "false");
+        job1.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
+        applicantJob.add(job1);
+        inputData.put("jobs", applicantJob);
+
+        List<Map<String, Object>> partnerJob = new ArrayList<>();
+        Map<String, Object> partnerJob1 = new HashMap<>();
+        partnerJob1.put("uuid", "partnerJob1");
+        partnerJob1.put("companyName", "Testers Inc");
+        partnerJob1.put("employerStreetAddress", "456 Test St");
+        partnerJob1.put("employerCity", "Springfield");
+        partnerJob1.put("employerState", "IL");
+        partnerJob1.put("employerZipCode", "62629");
+        partnerJob1.put("employerPhoneNumber", "217-555-5678");
+        partnerJob1.put("isSelfEmployed", "false");
+        partnerJob1.put(Submission.ITERATION_IS_COMPLETE_KEY, true);
+        partnerJob.add(partnerJob1);
+        inputData.put("partnerJobs", partnerJob);
+        
+        return inputData;
+    }
+
+    public void setTime(Map<String, Object> data, String inputPrefix, String startOrEndKey, String dayPostFix,
+            String hour, String minute, String amOrPm) {
+        data.put(inputPrefix + startOrEndKey + "Time" + dayPostFix + "Hour", hour);
+        data.put(inputPrefix + startOrEndKey + "Time" + dayPostFix + "Minute", minute);
+        data.put(inputPrefix + startOrEndKey + "Time" + dayPostFix + "AmPm", amOrPm);
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/RemoveDummySubmissionForDev.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/RemoveDummySubmissionForDev.java
@@ -1,0 +1,34 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RemoveDummySubmissionForDev implements Action {
+    SubmissionRepository submissionRepository;
+    SubmissionRepositoryService submissionRepositoryService;
+    
+    @Autowired
+    Environment env;
+    
+    public RemoveDummySubmissionForDev(SubmissionRepository submissionRepository, 
+            SubmissionRepositoryService submissionRepositoryService) {
+        this.submissionRepository = submissionRepository;
+        this.submissionRepositoryService = submissionRepositoryService;
+    }
+    
+    @Override
+    public void run(Submission submission) {
+        String[] activeProfiles = env.getActiveProfiles();
+        boolean isDevProfile = Arrays.asList(activeProfiles).contains("dev");
+        if (isDevProfile) {
+            submissionRepositoryService.findByShortCode("DEV-123ABC").ifPresent(submissionRepository::delete);
+        }
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationId.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationId.java
@@ -19,7 +19,7 @@ public class SaveApplicationId implements Action {
     }
 
     @Override
-    public void run(FormSubmission formSubmission, Submission providerSubmission) {
+    public void run(Submission providerSubmission) {
         UUID clientSubmissionId = (UUID) httpSession.getAttribute("clientSubmissionId");
 
         if (null != clientSubmissionId && !clientSubmissionId.toString().isEmpty()){

--- a/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationId.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SaveApplicationId.java
@@ -22,7 +22,7 @@ public class SaveApplicationId implements Action {
     public void run(FormSubmission formSubmission, Submission providerSubmission) {
         UUID clientSubmissionId = (UUID) httpSession.getAttribute("clientSubmissionId");
 
-        if(!clientSubmissionId.toString().isEmpty()){
+        if (null != clientSubmissionId && !clientSubmissionId.toString().isEmpty()){
             providerSubmission.getInputData().put("familySubmissionId", clientSubmissionId);
         }
     }

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateConfirmationCodeAndSaveId.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateConfirmationCodeAndSaveId.java
@@ -40,7 +40,7 @@ public class ValidateConfirmationCodeAndSaveId implements Action {
         Map<String, List<String>> errorMessages = new HashMap<>();
 
         String providerProvidedConfirmationCode = (String) formSubmission.getFormData()
-                .getOrDefault("providerResponseFamilyConfirmationCode", "");
+                .getOrDefault("providerResponseFamilyShortCode", "");
 
         if (!providerProvidedConfirmationCode.isBlank()) {
             Optional<Submission> clientSubmission = submissionRepositoryService.findByShortCode(providerProvidedConfirmationCode);
@@ -62,7 +62,7 @@ public class ValidateConfirmationCodeAndSaveId implements Action {
 
     private void setErrorMessages(Map<String, List<String>> errorMessages) {
         Locale locale = LocaleContextHolder.getLocale();
-        errorMessages.put("providerResponseFamilyConfirmationCode",
+        errorMessages.put("providerResponseFamilyShortCode",
                 List.of(messageSource.getMessage("provider-response-application-id.error.invalid", null, locale)));
     }
 }

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -505,6 +505,7 @@ flow:
   ccap-registration:
     crossFieldValidationAction: ValidateProviderNumber
     onPostAction: SaveApplicationId
+    beforeSaveAction: GenerateDummyClientSubmissionForDev
     nextScreens:
       - name: application-id
   application-id:
@@ -542,6 +543,7 @@ flow:
     nextScreens:
       - name: submit-complete-final
   submit-complete-final:
+    beforeDisplayAction: RemoveDummySubmissionForDev
     nextScreens: null
 landmarks:
   firstScreen: submit-start

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -504,8 +504,8 @@ flow:
       - name: ccap-registration
   ccap-registration:
     crossFieldValidationAction: ValidateProviderNumber
-    onPostAction: SaveApplicationId
-    beforeSaveAction: GenerateDummyClientSubmissionForDev
+    beforeSaveAction: SaveApplicationId
+    onPostAction: GenerateDummyClientSubmissionForDev
     nextScreens:
       - name: application-id
   application-id:

--- a/src/main/resources/templates/fragments/inputs/overrides/number.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/number.html
@@ -26,7 +26,7 @@
                 th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
         <div class="text-input-group form-width--large">
             <input type="number" inputmode="numeric"
-                   class="text-input form-width--large"
+                   class="text-input form-width--large number-input"
                    th:id="${inputName}"
                    th:name="${inputName}"
                    th:placeholder="${placeholder}"

--- a/src/main/resources/templates/providerresponse/application-id.html
+++ b/src/main/resources/templates/providerresponse/application-id.html
@@ -10,7 +10,7 @@
     formAction=${formAction},
     inputContent=~{::inputContent})}">
   <th:block th:ref="inputContent">
-    <th:block th:replace="~{fragments/inputs/overrides/text ::
+    <th:block th:replace="~{fragments/inputs/text ::
       text(inputName='providerResponseFamilyShortCode',
       ariaLabel='header')}"/>
   </th:block>o

--- a/src/main/resources/templates/providerresponse/application-id.html
+++ b/src/main/resources/templates/providerresponse/application-id.html
@@ -10,15 +10,15 @@
     formAction=${formAction},
     inputContent=~{::inputContent})}">
   <th:block th:ref="inputContent">
-    <th:block th:replace="~{fragments/inputs/text ::
-      text(inputName='providerResponseFamilyConfirmationCode',
+    <th:block th:replace="~{fragments/inputs/overrides/text ::
+      text(inputName='providerResponseFamilyShortCode',
       ariaLabel='header')}"/>
   </th:block>o
 </th:block>
 
 <script th:inline="javascript">
   $(document).ready(function () {
-    const providerFamilyCode = $('#providerResponseFamilyConfirmationCode')
+    const providerFamilyCode = $('#providerResponseFamilyShortCode')
 
     if(!providerFamilyCode.text()){
       var confirmationCode = [[${session.confirmationCode}]];

--- a/src/main/resources/templates/providerresponse/submit-complete-final.html
+++ b/src/main/resources/templates/providerresponse/submit-complete-final.html
@@ -25,7 +25,7 @@
                                 th:replace="~{fragments/form :: form(action=${formAction}, content=~{::content})}">
                             <th:block th:ref="content">
                                 <div class="form-card__content"
-                                     th:with="confirmationCode=${submission.inputData.get('providerResponseFamilyConfirmationCode')}">
+                                     th:with="confirmationCode=${submission.inputData.get('providerResponseFamilyShortCode')}">
                                     <div class="notice--success">
                                         <p th:utext="${#messages.msg('provider-response-submit-complete-final.notice-pt1', confirmationCode)}"></p>
                                         <p th:text="#{provider-response-submit-complete-final.notice-pt2}"></p>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -47,7 +47,7 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
 
         // application-id
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-application-id.title"));
-        testPage.findElementTextById("providerResponseFamilyConfirmationCode").equals(CONF_CODE);
+        testPage.findElementTextById("providerResponseFamilyShortCode").equals(CONF_CODE);
         testPage.clickContinue();
 
         // response


### PR DESCRIPTION
This creates a dummy content family submission in the provider response flow if you are in the dev environment. 

This makes it so you don't need to fill out a family submission to get a short code before going through the provider response flow. 

Using this fake filler configuration fake filler will autofill the correct family short code for you on the corresponding page in the provider response flow. 

[fake-filler-2024-11-07.txt](https://github.com/user-attachments/files/17669521/fake-filler-2024-11-07.txt)
