### PR TITLE
[CCAP-443] making it possible to turn on Datadog replays by environment

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -74,3 +74,17 @@ ENCRYPTION_KEY=
 
 # Turns the Jobrunr Dashboard on by default in dev, will be set via a property for Staging/Production
 JOBRUNR_DASHBOARD_ENABLED=true
+
+#######################################################################################
+# SHORT IO link shortener keys in LastPass
+#######################################################################################
+SHORT_IO_API_KEY=
+SHORT_IO_DOMAIN=
+
+#######################################################################################
+# DATADOG keys in LastPass
+#######################################################################################
+DATADOG_ENVIRONMENT=dev
+DATADOG_SESSION_REPLAY_SAMPLE_RATE=0
+DATADOG_RUM_APPLICATION_ID=
+DATADOG_RUM_CLIENT_TOKEN=

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -24,7 +24,7 @@
                 service: 'il-gcc-front-end',
                 env: '[[${@environment.getProperty("DATADOG_ENVIRONMENT")}]]',
                 sessionSampleRate: 100,
-                sessionReplaySampleRate: 0,
+                sessionReplaySampleRate: '[[${@environment.getProperty("DATADOG_SESSION_REPLAY_SAMPLE_RATE")}]]',
                 trackUserInteractions: true,
                 trackResources: true,
                 trackLongTasks: true,


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-443

#### ✍️ Description
Turns on Datadog replays by environment. Will set up these keys in Staging and Prod immediately after PR approval.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
