### PR TITLE
[CCAP-433] Adjust logic and flows for submission and document upload screens

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -397,9 +397,6 @@ flow:
     afterSaveAction: UploadSubmissionToS3
     nextScreens:
       - name: submit-complete
-#  GCC submit complete screen should either goto doc-upload-recommended-docs if the user has recommended docs
-#  or Goto the doc-upload-add-files page if there are no recommended docs  This page should hide the recommended docs
-#  accordion if there are no recommended docs
   submit-complete:
     nextScreens:
       - name: doc-upload-recommended-docs

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -397,18 +397,15 @@ flow:
     afterSaveAction: UploadSubmissionToS3
     nextScreens:
       - name: submit-complete
+#  GCC submit complete screen should either goto doc-upload-recommended-docs if the user has recommended docs
+#  or Goto the doc-upload-add-files page if there are no recommended docs  This page should hide the recommended docs
+#  accordion if there are no recommended docs
   submit-complete:
     nextScreens:
-      - name: submit-next-steps
-  submit-next-steps:
-    nextScreens:
-      - name: submit-confirmation
-  submit-confirmation:
-    beforeDisplayAction: FormatSubmittedAtDate
-    nextScreens:
-      - name: submit-confirmation
+      - name: doc-upload-recommended-docs
+        condition: HasRecommendedDocumentsToUpload
+      - name: doc-upload-add-files
   doc-upload-recommended-docs:
-    condition: HasRecommendedDocumentsToUpload
     nextScreens:
       - name: doc-upload-add-files
   doc-upload-add-files:
@@ -432,6 +429,13 @@ flow:
   submit-provider-agreement-handoff:
     nextScreens:
       - name: next-steps-pdf-delivery
+  submit-next-steps:
+    nextScreens:
+      - name: submit-confirmation
+  submit-confirmation:
+    beforeDisplayAction: FormatSubmittedAtDate
+    nextScreens:
+      - name: submit-confirmation
   next-steps-pdf-delivery:
     nextScreens:
       - name: complete-submit-confirmation

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -701,7 +701,7 @@ unearned-income-referral-services.housing-support=Housing support and homelessne
 unearned-income-referral-services.disability-support=Services for people living with a physical or mental disability
 
 #
-submit-intro.step=Step 5 of 5
+submit-intro.step=Step 5 of 6
 submit-intro.title=Sign and Submit
 submit-intro.box.header=We'll ask about
 submit-intro.box.one=Verification documents
@@ -727,14 +727,12 @@ submit-sign-name.legal-name.label=Your Full Legal Name
 submit-sign-name.partner-legal-name.label=Partner's Full Legal Name
 submit-sign-name.submit-application=Submit application
 submit-complete.title=Your application has been submitted!
-submit-complete.header=<p>Your application has been submitted!</p><p>You have the option to submit verification documents now.</p>
-submit-complete-no-documents-to-upload.header=Your application has been submitted!
-submit-complete-no-documents-to-upload.subtext=Please review your next steps:
-submit-complete-no-documents-to-upload.finish-application=Finish application
-submit-complete.info-box=<p>Verification documents are due within 10 business days of application submission.</p><p>We will share document recommendations on the next page. If you don't have your documents now, it's okay. You will get a Request for Information form in the mail.</p>
-submit-complete.button.submit-docs=Submit documents now
-submit-complete.button.skip=Skip and finish
-submit-complete.email-notice=A copy of your application has been emailed to {0}.
+submit-complete.header=Do you want to add any verification documents to your application?
+submit-complete.info-box.pg-1=<p>Verification documents are due within <strong>10 business days</strong> of application submission.</p>
+submit-complete.info-box.pg-2=<p>If you don't have your documents ready now, it's okay. You can submit them in-person or by mail later. You will get a request form in the mail telling you what documents to submit.</p>
+submit-complete.yes-add-document-now=Yes, add documents now
+submit-complete.button.do-this-later=No, I'll do this later
+
 submit-next-steps.title=Next Steps
 submit-next-steps.subtext=Please review:
 submit-next-steps.notice=<ul class="list--numbered"><li>A worker will process your application within 10 business days.</li><li>You will get a letter in the mail or email about your case.</li><li>You may be asked to send additional verification documents within the next 10 days.</li></ul>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -701,7 +701,7 @@ unearned-income-referral-services.housing-support=Housing support and homelessne
 unearned-income-referral-services.disability-support=Services for people living with a physical or mental disability
 
 #
-submit-intro.step=Step 5 of 6
+submit-intro.step=Step 5 of 5
 submit-intro.title=Sign and Submit
 submit-intro.box.header=We'll ask about
 submit-intro.box.one=Verification documents

--- a/src/main/resources/templates/gcc/submit-complete.html
+++ b/src/main/resources/templates/gcc/submit-complete.html
@@ -13,53 +13,24 @@
                 <div th:if="${lockedSubmissionMessage}" class="notice--warning">
                     <p th:text="${lockedSubmissionMessage}"></p>
                 </div>
-                <!-- Display document verification information and Document Upload Links-->
-                <div th:if="${showDocumentUploadInfo}">
-                    <header class="form-card__header">
+                <div>
+                    <header class="form-card__header spacing-below-0">
                         <h1 id="header-doc-upload" class="h2" th:utext="#{submit-complete.header}"></h1>
                     </header>
-                    <div class="form-card__content">
-                        <div class="notice notice--gray" th:utext="#{submit-complete.info-box}"></div>
+                    <div class="form-card__content notice notice--gray">
+                        <div th:utext="#{submit-complete.info-box.pg-1}"></div>
+                        <p th:utext="#{submit-complete.info-box.pg-2}"></p>
                     </div>
                     <div class="form-card__footer">
-                        <a href="/flow/gcc/doc-upload-recommended-docs"
-                           th:text="#{submit-complete.button.submit-docs}"
-                           class="button button--primary"
-                           id="continue-link"></a>
-                        <th:block
-                                th:if="${@environment.getProperty('il-gcc.dts.expand-existing-provider-flow') == 'true'}">
+                        <th:block th:id="continue-link" th:replace="~{fragments/continueButton :: continue(text=#{submit-complete.yes-add-document-now})}" />
+
+                        <th:block>
                             <a th:href="'/flow/' + ${flow} + '/contact-provider-intro'"
                                data-mixpanel="skip-link"
                                class="button"
-                               th:text="#{submit-complete.button.skip}"                            ></a>
+                               id="skip-to-contact-provider-intro-link"
+                               th:text="#{submit-complete.button.do-this-later}"                            ></a>
                         </th:block>
-                        <th:block
-                                th:unless="${@environment.getProperty('il-gcc.dts.expand-existing-provider-flow') == 'true'}">
-                            <a href="/flow/gcc/submit-next-steps"
-                               th:text="#{submit-complete.button.skip}"
-                               class="button"
-                               id="skip-link"
-                               data-mixpanel="skip-link"></a>
-                        </th:block>
-
-                    </div>
-                </div>
-                <!-- Show information about next steps -->
-                <div th:if="${!showDocumentUploadInfo}">
-                    <header class="form-card__header">
-                        <h1 id="header-next-steps" class="h2" th:text="#{submit-complete-no-documents-to-upload.header}"></h1>
-                        <p id="header-help-message" th:text="#{submit-complete-no-documents-to-upload.subtext}"></p>
-                    </header>
-                    <div class="form-card__content">
-                        <div class="notice--success">
-                            <th:block th:utext="#{submit-next-steps.notice}"></th:block>
-                        </div>
-                    </div>
-                    <div class="form-card__footer">
-                        <a href="/flow/gcc/submit-confirmation"
-                           th:text="#{submit-complete-no-documents-to-upload.finish-application}"
-                           class="button button--primary"
-                           id="finish-application-link"></a>
                     </div>
                 </div>
             </main>

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -30,7 +30,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     assertThat(testPage.elementDoesNotExistById("controlId")).isTrue();
     }
     @Test
-    void DisplaysRecommendedDocumentsScreenIfDocsAreRequired()
+    void DisplaysRecommendedDocumentsScreenIfDocsAreRequired(){
         testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -30,7 +30,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     assertThat(testPage.elementDoesNotExistById("controlId")).isTrue();
     }
     @Test
-    void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredAndShouldDisplayRecommendedDocumentsAccordionOnTheDocUploadAddFilesScreen(){
+    void DisplaysRecommendedDocumentsScreenIfDocsAreRequired()
         testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
     boolean hasPartner = false;
     @Test
-    void SkipsRecommendedDocumentsScreenIfNoneAreRequiredFor(){
+    void SkipsRecommendedDocumentsScreenIfNoneAreRequired(){
     testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
     saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
         .withParentDetails()

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
     boolean hasPartner = false;
     @Test
-    void shouldSkipDocUploadPromptIfNoDocumentsAreRequiredForParentOrSpouseAndShouldHideRecommendedDocumentsAccordionOnTheDocuUploadAddFilesScreen(){
+    void SkipsRecommendedDocumentsScreenIfNoneAreRequiredFor(){
     testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
     saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
         .withParentDetails()

--- a/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/DocumentUploadConditionalLogicJourneyTest.java
@@ -3,12 +3,11 @@ package org.ilgcc.app.journeys;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.ilgcc.app.utils.AbstractBasePageTest;
-import org.ilgcc.app.utils.ChildCareProvider;
 import org.junit.jupiter.api.Test;
 public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageTest {
     boolean hasPartner = false;
     @Test
-    void shouldSkipDocUploadPromptIfNoDocumentsAreRequiredForParentOrSpouse(){
+    void shouldSkipDocUploadPromptIfNoDocumentsAreRequiredForParentOrSpouseAndShouldHideRecommendedDocumentsAccordionOnTheDocuUploadAddFilesScreen(){
     testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
     saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
         .withParentDetails()
@@ -24,13 +23,14 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
     navigatePassedSignedName(hasPartner);
     // submit-complete
     assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-    testPage.clickButton(getEnMessage("submit-complete-no-documents-to-upload.finish-application"));
+    testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
-    assertThat(testPage.getTitle()).isEqualTo(getEnMessageWithParams("submit-confirmation.title", List.of(ChildCareProvider.OPEN_SESAME.getDisplayName()).toArray()));
-
+    //doc-upload-add-files
+    assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+    assertThat(testPage.elementDoesNotExistById("controlId")).isTrue();
     }
     @Test
-    void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredForParent(){
+    void skipNotSkipDocUploadRecommendedDocsScreenIfOneDocumentIsRequiredAndShouldDisplayRecommendedDocumentsAccordionOnTheDocUploadAddFilesScreen(){
         testPage.navigateToFlowScreen("gcc/submit-ccap-terms");
         saveSubmission(getSessionSubmissionTestBuilder().withDayCareProvider()
             .withParentDetails()
@@ -45,9 +45,16 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
 
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
+
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+
+        //doc-upload-add-files
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-add-files.title"));
+        assertThat(testPage.elementDoesNotExistById("controlId")).isFalse();
+        assertThat(testPage.elementDoesNotExistById("tanf-upload-instruction")).isFalse();
     }
 
     @Test
@@ -65,7 +72,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -94,7 +101,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -122,7 +129,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -150,7 +157,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("submit-complete.button.submit-docs"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -178,7 +185,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -207,7 +214,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -236,7 +243,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -265,7 +272,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
@@ -292,7 +299,7 @@ public class DocumentUploadConditionalLogicJourneyTest extends AbstractBasePageT
         navigatePassedSignedName(hasPartner);
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));

--- a/src/test/java/org/ilgcc/app/journeys/FamilyProviderOnboardingScreensTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/FamilyProviderOnboardingScreensTest.java
@@ -685,7 +685,7 @@ public class FamilyProviderOnboardingScreensTest extends AbstractBasePageTest {
 
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("submit-complete.button.skip"));
+        testPage.clickButton(getEnMessage("submit-complete.button.do-this-later"));
 
         // contact-provider-intro
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("contact-provider-intro.title"));
@@ -693,7 +693,7 @@ public class FamilyProviderOnboardingScreensTest extends AbstractBasePageTest {
         // submit-complete
         testPage.goBack();
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));

--- a/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccFlowJourneyTest.java
@@ -639,7 +639,7 @@ public class GccFlowJourneyTest extends AbstractBasePageTest {
 
         // submit-complete
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-complete.title"));
-        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.submit"));
+        testPage.clickButton(getEnMessage("submit-complete.yes-add-document-now"));
 
         // doc-upload-recommended docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-433

#### ✍️ Description
Change the logic of the `submit-complete` screen and to match Figma

#### 📷 Design reference
[Figma](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Full-Flow?node-id=11016-30028&t=PQgZayvwiDX0aqQf-4)

#### ✅ Completion tasks
- [ ] Remove the alternative version of the submit-complete screen for users without recommended documents 
- [ ] Update the submit-complete screen for all users to match the Figma designs with content from the content manager.
- [ ] Skip the doc-upload-recommended-docs screen if a user has no recommended documents

- [ ] Hide the accordion on the doc-upload-add-files screen if a user has no recommended documents
- [ ] This work can be implemented right away in the current flow and does not need to be hidden by a feature flag

#### 👍 Acceptance
- [ ] Added relevant tests
- [ ] Meets acceptance criteria
