### PR TITLE
[CCAP-310] Only load dropzone related JS and CSS on doc upload screens

### DIFF
--- a/src/main/resources/templates/fragments/doc-upload-head.html
+++ b/src/main/resources/templates/fragments/doc-upload-head.html
@@ -3,42 +3,44 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:text="${errorMessages == null ? title : #messages.msg('errors.general-title')}"></title>
     <script>
-        (function (h, o, u, n, d) {
-            h = h[d] = h[d] || {
-                q: [], onReady: function (c) {
-                    h.q.push(c)
-                }
-            }
-            d = o.createElement(u);
-            d.async = 1;
-            d.src = n
-            n = o.getElementsByTagName(u)[0];
-            n.parentNode.insertBefore(d, n)
-        })(window, document, 'script',
-            'https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum.js', 'DD_RUM')
-        window.DD_RUM.onReady(function () {
-            window.DD_RUM.init({
-                clientToken: '[[${@environment.getProperty("DATADOG_RUM_CLIENT_TOKEN")}]]',
-                applicationId: '[[${@environment.getProperty("DATADOG_RUM_APPLICATION_ID")}]]',
-                site: 'datadoghq.com',
-                service: 'il-gcc-front-end',
-                env: '[[${@environment.getProperty("DATADOG_ENVIRONMENT")}]]',
-                sessionSampleRate: 100,
-                sessionReplaySampleRate: '[[${@environment.getProperty("DATADOG_SESSION_REPLAY_SAMPLE_RATE")}]]',
-                trackUserInteractions: true,
-                trackResources: true,
-                trackLongTasks: true,
-                defaultPrivacyLevel: 'mask-user-input',
-            });
-        })
+      (function (h, o, u, n, d) {
+        h = h[d] = h[d] || {
+          q: [], onReady: function (c) {
+            h.q.push(c)
+          }
+        }
+        d = o.createElement(u);
+        d.async = 1;
+        d.src = n
+        n = o.getElementsByTagName(u)[0];
+        n.parentNode.insertBefore(d, n)
+      })(window, document, 'script',
+          'https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum.js', 'DD_RUM')
+      window.DD_RUM.onReady(function () {
+        window.DD_RUM.init({
+          clientToken: '[[${@environment.getProperty("DATADOG_RUM_CLIENT_TOKEN")}]]',
+          applicationId: '[[${@environment.getProperty("DATADOG_RUM_APPLICATION_ID")}]]',
+          site: 'datadoghq.com',
+          service: 'il-gcc-front-end',
+          env: '[[${@environment.getProperty("DATADOG_ENVIRONMENT")}]]',
+          sessionSampleRate: 100,
+          sessionReplaySampleRate: '[[${@environment.getProperty("DATADOG_SESSION_REPLAY_SAMPLE_RATE")}]]',
+          trackUserInteractions: true,
+          trackResources: true,
+          trackLongTasks: true,
+          defaultPrivacyLevel: 'mask-user-input',
+        });
+      })
     </script>
     <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
+    <script src="/webjars/form-flow/0.0.1/js/formFlowDropZone.js"></script>
     <script src="/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js" defer></script>
     <script src="/webjars/form-flow/0.0.1/js/formFlowDisableMultipleFormSubmit.js" defer></script>
     <script src="/webjars/form-flow/0.0.1/js/formFlowFollowUpQuestion.js" defer></script>
     <th:block th:replace="~{fragments/mixpanelTracking :: mixpanelTracking}"></th:block>
     <link href="/webjars/form-flow/0.0.1/css/honeycrisp.min.css" rel="stylesheet"/>
     <link href="/webjars/form-flow/0.0.1/css/libraryStyles.css" rel="stylesheet"/>
+    <link href="/webjars/form-flow/0.0.1/css/customDropzone.css" rel="stylesheet"/>
     <link href="/assets/css/custom.css" rel="stylesheet"/>
     <link rel="preload" href="/webjars/form-flow/0.0.1/fonts/MaterialIcons-Regular.eot?ia7soh"
           as="font"

--- a/src/main/resources/templates/gcc/doc-upload-add-files.html
+++ b/src/main/resources/templates/gcc/doc-upload-add-files.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}">
-<head th:replace="~{fragments/head :: head(title=#{doc-upload-add-files.title})}"></head>
+<head th:replace="~{fragments/doc-upload-head :: head(title=#{doc-upload-add-files.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -42,7 +42,6 @@
               </div>
               <th:block
                   th:replace="~{fragments/inputs/overrides/fileUploader :: fileUploader(inputName='uploadDocuments')}"></th:block>
-
             </div>
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-310

#### ✍️ Description
Make dropzone related JS and CSS only load on doc upload screen. 
