### PR TITLE
[CCAP-314] Optimize scripts and move them to footer

### DIFF
--- a/src/main/resources/templates/fragments/doc-upload-head.html
+++ b/src/main/resources/templates/fragments/doc-upload-head.html
@@ -32,12 +32,8 @@
         });
       })
     </script>
-    <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowDropZone.js"></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js" defer></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowDisableMultipleFormSubmit.js" defer></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowFollowUpQuestion.js" defer></script>
     <th:block th:replace="~{fragments/mixpanelTracking :: mixpanelTracking}"></th:block>
+    <script src="/webjars/form-flow/0.0.1/js/formFlowDropZone.js"></script>
     <link href="/webjars/form-flow/0.0.1/css/honeycrisp.min.css" rel="stylesheet"/>
     <link href="/webjars/form-flow/0.0.1/css/libraryStyles.css" rel="stylesheet"/>
     <link href="/webjars/form-flow/0.0.1/css/customDropzone.css" rel="stylesheet"/>

--- a/src/main/resources/templates/fragments/doc-upload-head.html
+++ b/src/main/resources/templates/fragments/doc-upload-head.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:text="${errorMessages == null ? title : #messages.msg('errors.general-title')}"></title>
+    <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
     <script>
       (function (h, o, u, n, d) {
         h = h[d] = h[d] || {
@@ -24,7 +25,7 @@
           service: 'il-gcc-front-end',
           env: '[[${@environment.getProperty("DATADOG_ENVIRONMENT")}]]',
           sessionSampleRate: 100,
-          sessionReplaySampleRate: '[[${@environment.getProperty("DATADOG_SESSION_REPLAY_SAMPLE_RATE")}]]',
+          sessionReplaySampleRate: [[${@environment.getProperty("DATADOG_SESSION_REPLAY_SAMPLE_RATE")}]],
           trackUserInteractions: true,
           trackResources: true,
           trackLongTasks: true,

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -17,7 +17,6 @@
       </div>
     </div>
   </div>
-  <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
   <script src="/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js" defer></script>
   <script src="/webjars/form-flow/0.0.1/js/formFlowDisableMultipleFormSubmit.js" defer></script>
   <script src="/webjars/form-flow/0.0.1/js/formFlowFollowUpQuestion.js" defer></script>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -17,4 +17,8 @@
       </div>
     </div>
   </div>
+  <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
+  <script src="/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js" defer></script>
+  <script src="/webjars/form-flow/0.0.1/js/formFlowDisableMultipleFormSubmit.js" defer></script>
+  <script src="/webjars/form-flow/0.0.1/js/formFlowFollowUpQuestion.js" defer></script>
 </footer>

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:text="${errorMessages == null ? title : #messages.msg('errors.general-title')}"></title>
+    <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
     <script>
         (function (h, o, u, n, d) {
             h = h[d] = h[d] || {

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -32,10 +32,6 @@
             });
         })
     </script>
-    <script src="/webjars/form-flow/0.0.1/js/honeycrisp.min.js"></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowLanguageSelector.js" defer></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowDisableMultipleFormSubmit.js" defer></script>
-    <script src="/webjars/form-flow/0.0.1/js/formFlowFollowUpQuestion.js" defer></script>
     <th:block th:replace="~{fragments/mixpanelTracking :: mixpanelTracking}"></th:block>
     <link href="/webjars/form-flow/0.0.1/css/honeycrisp.min.css" rel="stylesheet"/>
     <link href="/webjars/form-flow/0.0.1/css/libraryStyles.css" rel="stylesheet"/>


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-314

#### ✍️ Description

- Move all <scripts> from the <head> to the footer. This moves scripts from render blocking, but it makes our tests fail, which I wasn’t able to resolve quickly.
- Use [capo.js](https://rviscomi.github.io/capo.js/) to re-arrange the <head> to be the most optimized
