### PR TITLE
[CCAP-478, CCAP-479] Split info screen to info and address screens

### DIFF
--- a/src/main/java/org/ilgcc/app/file_transfer/DocumentTransferRequestService.java
+++ b/src/main/java/org/ilgcc/app/file_transfer/DocumentTransferRequestService.java
@@ -57,7 +57,7 @@ public class DocumentTransferRequestService implements DocumentTransferRequest {
             throw new RuntimeException(errorMessage, e);
         }
 
-        try (BufferedReader br = new BufferedReader(
+        try (BufferedReader br = new BufferedReader (
                 new InputStreamReader(httpUrlConnection.getInputStream(), StandardCharsets.UTF_8))) {
             StringBuilder response = new StringBuilder();
             String responseLine = null;

--- a/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyClientSubmissionForDev.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyClientSubmissionForDev.java
@@ -28,7 +28,7 @@ public class GenerateDummyClientSubmissionForDev implements Action {
     
     @Autowired
     Environment env;
-    
+
     public GenerateDummyClientSubmissionForDev(SubmissionRepositoryService submissionRepositoryService,
             SubmissionRepository submissionRepository, HttpSession httpSession) {
         this.submissionRepositoryService = submissionRepositoryService;
@@ -44,7 +44,7 @@ public class GenerateDummyClientSubmissionForDev implements Action {
             Optional<Submission> existingDummyClientSubmision = submissionRepositoryService.findByShortCode("DEV-123ABC");
             existingDummyClientSubmision.ifPresent(submissionRepository::delete);
 
-            Map<String, Object> inputData = createFamilySubmission();
+            Map<String, Object> inputData = createFamilySubmission(submission);
 
             Submission dummyClientSubmission = new Submission();
             dummyClientSubmission.setSubmittedAt(OffsetDateTime.now().minusDays(1));
@@ -58,7 +58,7 @@ public class GenerateDummyClientSubmissionForDev implements Action {
         }
     }
 
-    private @NotNull Map<String, Object> createFamilySubmission() {
+    private @NotNull Map<String, Object> createFamilySubmission(Submission providerSubmission) {
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("familyIntendedProviderName", "Dev Provider");
         inputData.put("parentFirstName", "Devy");
@@ -72,6 +72,7 @@ public class GenerateDummyClientSubmissionForDev implements Action {
         inputData.put("parentHomeState", "CA - California");
         inputData.put("parentHomeZipCode", "94103");
         inputData.put("parentHasPartner", "false");
+        inputData.put("providerResponseSubmissionId", providerSubmission.getId().toString());
         
         List<Map<String, Object>> children = new ArrayList<>();
         Map<String, Object> child1 = new HashMap<>();

--- a/src/main/java/org/ilgcc/app/submission/actions/UploadProviderSubmissionToS3.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/UploadProviderSubmissionToS3.java
@@ -56,9 +56,9 @@ public class UploadProviderSubmissionToS3 implements Action {
     public void run(Submission providerSubmission) {
         if (waitForProviderResponseFlag) {
             var clientId = ProviderSubmissionUtilities.getClientId(providerSubmission);
-            if(clientId !=null && clientId.isPresent()){
+            if (clientId !=null && clientId.isPresent()) {
                 Optional<Submission> familySubmissionOptional = submissionRepositoryService.findById(clientId.get());
-                if(familySubmissionOptional.isPresent()){
+                if (familySubmissionOptional.isPresent()) {
                     log.info("Provider submitted response for client ID {}, enqueuing transfer of documents.", clientId.get());
                     Submission familySubmission = familySubmissionOptional.get();
                     familySubmission.getInputData().put("providerResponseSubmissionId", providerSubmission.getId().toString());
@@ -67,10 +67,10 @@ public class UploadProviderSubmissionToS3 implements Action {
                         familySubmission, FileNameUtility.getFileNameForPdf(familySubmission, "Provider-Responded"));
                     enqueueDocumentTransfer.enqueueUploadedDocumentBySubmission(userFileRepositoryService,
                         uploadedDocumentTransmissionJob, s3PresignService, familySubmission);
-                }else{
+                } else {
                     log.error(String.format("We can not find a match for your family submission: %s", clientId.get()));
                 }
-            }else{
+            } else {
                 log.error(String.format("Family Submission Id is Blank for the provider submission: %s.", providerSubmission.getId().toString()));
             }
 

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -577,10 +577,7 @@ flow:
   info:
     nextScreens:
       - name: service-address
-        condition: EnableProviderRegistration
-      - name: confirm-address
   service-address:
-    condition: EnableProviderRegistration
     nextScreens:
       - name: confirm-address
   confirm-address:
@@ -594,7 +591,6 @@ flow:
     nextScreens:
       - name: submit-complete-final
   submit-complete-final:
-    beforeDisplayAction: RemoveDummySubmissionForDev
     nextScreens:
       - name: registration-getting-started
         condition: EnableProviderRegistration

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1196,6 +1196,8 @@ provider-response-submit-complete.notice-no=We will notify the CCR&R of your res
 provider-response-submit-complete.button-no=Return to home
 
 #info
+provider-response-info.title=Tell us about yourself
+provider-response-info.header=Tell us about yourself
 provider-response-info.business-name=Business name
 provider-response-info.business-name-help=If you have one, enter the business name you are registered under.
 provider-response-info.first-name=First name

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1196,17 +1196,19 @@ provider-response-submit-complete.notice-no=We will notify the CCR&R of your res
 provider-response-submit-complete.button-no=Return to home
 
 #info
-provider-response-info.title=Provider Info
-provider-response-info.header=Your provider information
 provider-response-info.business-name=Business name
 provider-response-info.business-name-help=If you have one, enter the business name you are registered under.
 provider-response-info.first-name=First name
 provider-response-info.first-name-help=Enter your first name.
 provider-response-info.last-name=Last name
 provider-response-info.last-name-help=Enter your last name.
+
+#provider-address
+provider-response-provider-service-address.title=Child care location
+provider-response-provider-service-address.header=Where are you providing the child care?
 provider-response-info.street-address=Street address
 provider-response-info.street-address-help=Provide the location where care is taking place. If you are a relative or friend providing care, use your home address.
-provider-response-info.street-address-2=Street address line 2
+provider-response-info.street-address-2=Apartment #
 provider-response-info.street-address-2-help=This is optional.
 provider-response-info.city=City
 provider-response-info.state=State

--- a/src/main/resources/templates/providerresponse/info.html
+++ b/src/main/resources/templates/providerresponse/info.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{provider-response-info.title})}"></head>
+<head th:replace="~{fragments/head :: head(title=#{parent-info-basic-1.title})}"></head>
 <body>
 <div class="page-wrapper">
     <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -10,15 +10,11 @@
             <main id="content" role="main" class="form-card spacing-above-35">
                 <th:block th:replace="~{fragments/gcc-icons :: caring}"></th:block>
                 <th:block
-                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{provider-response-info.header})}"/>
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-info-basic-1.title})}"/>
                 <th:block
                         th:replace="~{fragments/form :: form(action=${formAction}, content=~{::info})}">
                     <th:block th:ref="info">
                         <div class="form-card__content">
-                            <th:block th:replace="~{fragments/inputs/text ::
-                              text(inputName='providerResponseBusinessName',
-                              label=#{provider-response-info.business-name},
-                              helpText=#{provider-response-info.business-name-help})}"/>
                             <th:block th:replace="~{fragments/inputs/text ::
                               text(inputName='providerResponseFirstName',
                               label=#{provider-response-info.first-name},
@@ -27,12 +23,10 @@
                               text(inputName='providerResponseLastName',
                               label=#{provider-response-info.last-name},
                               helpText=#{provider-response-info.last-name-help})}"/>
-                            <th:block th:replace="~{fragments/inputs/overrides/address ::
-                                              address(
-                                                validate=true,
-                                                requireAddressFields=true,
-                                                inputName='providerResponseService'
-                                              )}"/>
+                            <th:block th:replace="~{fragments/inputs/text ::
+                              text(inputName='providerResponseBusinessName',
+                              label=#{provider-response-info.business-name},
+                              helpText=#{provider-response-info.business-name-help})}"/>
                         </div>
                         <div class="form-card__footer">
                             <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(

--- a/src/main/resources/templates/providerresponse/info.html
+++ b/src/main/resources/templates/providerresponse/info.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{parent-info-basic-1.title})}"></head>
+<head th:replace="~{fragments/head :: head(title=#{provider-response-info.title})}"></head>
 <body>
 <div class="page-wrapper">
     <div th:replace="~{fragments/toolbar :: toolbar}"></div>

--- a/src/main/resources/templates/providerresponse/info.html
+++ b/src/main/resources/templates/providerresponse/info.html
@@ -10,7 +10,7 @@
             <main id="content" role="main" class="form-card spacing-above-35">
                 <th:block th:replace="~{fragments/gcc-icons :: caring}"></th:block>
                 <th:block
-                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{parent-info-basic-1.title})}"/>
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{provider-response-info.header})}"/>
                 <th:block
                         th:replace="~{fragments/form :: form(action=${formAction}, content=~{::info})}">
                     <th:block th:ref="info">

--- a/src/main/resources/templates/providerresponse/service-address.html
+++ b/src/main/resources/templates/providerresponse/service-address.html
@@ -1,27 +1,38 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{provider-response-provider-service-address.title})}"></head>
 <body>
 <div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/gcc-icons :: caring}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{provider-response-provider-service-address.header})}"/>
+                <th:block
+                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::info})}">
+                    <th:block th:ref="info">
+                        <div class="form-card__content">
+                            <th:block th:replace="~{fragments/inputs/overrides/address ::
+                                              address(
+                                                validate=true,
+                                                streetAddress2Label=#{general.street-address-2},
+                                                streetAddress2HelpText=#{provider-response-info.street-address-2-help},
+                                                requireAddressFields=true,
+                                                inputName='providerResponseService'
+                                              )}"/>
+                        </div>
+                        <div class="form-card__footer">
+                            <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{general.inputs.continue})}"/>
+                        </div>
+                    </th:block>
+                </th:block>
+            </main>
+        </div>
+    </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
 </body>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -87,6 +87,10 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
         testPage.enter("providerResponseBusinessName", "Business Name");
         testPage.enter("providerResponseFirstName", "First Name");
         testPage.enter("providerResponseLastName", "Last Name");
+        testPage.clickButton("Continue");
+
+        // service-address
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-service-address.title"));
         testPage.enter("providerResponseServiceStreetAddress1", "123 Main St");
         testPage.enter("providerResponseServiceCity", "City");
         testPage.selectFromDropdown("providerResponseServiceState", "IL - Illinois");

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -189,6 +189,10 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
         testPage.enter("providerResponseBusinessName", "Business Name");
         testPage.enter("providerResponseFirstName", "First Name");
         testPage.enter("providerResponseLastName", "Last Name");
+        testPage.clickButton("Continue");
+        
+        // service-address
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-service-address.title"));
         testPage.enter("providerResponseServiceStreetAddress1", "123 Main St");
         testPage.enter("providerResponseServiceCity", "City");
         testPage.selectFromDropdown("providerResponseServiceState", "IL - Illinois");


### PR DESCRIPTION
- Keeps mapping / inputs the same with some minor changes to allow exporting the PDF before the flow is completed

#### 🔗 Jira ticket
CCAP-478 and CCAP-479

#### ✍️ Description
Splits the info screen into info (first and last name, business name) and address as two seperate screens. 