### PR TITLE
Fix error messages so spacing displays correctly

### DIFF
--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -658,7 +658,8 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
   align-items: flex-start;
   gap: 15px;
   line-height: 25px;
-  word-wrap: break-word
+  word-wrap: break-word;
+  margin-bottom: 3rem;
 }
 
 .providerResponse {

--- a/src/main/resources/templates/fragments/inputError.html
+++ b/src/main/resources/templates/fragments/inputError.html
@@ -1,4 +1,4 @@
-<p th:if="${null != errorMessages}" th:fragment="validationError(inputName)" class="text--error"
+<p th:if="${null != errorMessages && null != errorMessages.get(inputName)}" th:fragment="validationError(inputName)" class="text--error"
    th:assert="${!#strings.isEmpty(inputName)}"
    th:title="#{error.error}"
    th:id="${inputName} + '-error-p'">


### PR DESCRIPTION
Fixes a spacing issue pointed out by Carl:
https://codeforamerica.atlassian.net/browse/CCAP-478?atlOrigin=eyJpIjoiYjM0NzVmOGE0MDIwNGE1Mjk2NWY5ZGFlMzJjMjM1ZGMiLCJwIjoiaiJ9
