### PR TITLE
[CCAP-502] Do not map no response from provider for family PDF download

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
@@ -11,11 +11,16 @@ import formflow.library.pdf.SingleField;
 import formflow.library.pdf.SubmissionField;
 import formflow.library.pdf.SubmissionFieldPreparer;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.ChildCareProvider;
@@ -224,6 +229,11 @@ public class ProviderApplicationPreparer implements SubmissionFieldPreparer {
                 }
             }
         }
-        return "No response from provider";
+        ZoneId chicagoTimeZone = ZoneId.of("America/Chicago");
+        ZonedDateTime todaysDate = OffsetDateTime.now().atZoneSameInstant(chicagoTimeZone);
+        if (ProviderSubmissionUtilities.providerApplicationHasExpired(familySubmission, todaysDate)) {
+            return "No response from provider";
+        }
+        return "";
     }
 }

--- a/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerFlagOnTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerFlagOnTest.java
@@ -33,9 +33,10 @@ public class ProviderApplicationPreparerFlagOnTest {
     private Submission providerSubmission;
 
     @Test
-    public void setsNoResponseWhenNoProviderSubmissionExists() {
+    public void setsNoResponseWhenNoProviderSubmissionExistsAndSubmissionIsExpired() {
         familySubmission = new SubmissionTestBuilder()
                 .withFlow("gcc")
+                .withSubmittedAtDate(OffsetDateTime.now().minusDays(5))
                 .withDayCareProvider()
                 .with("familyIntendedProviderName", "ProviderName")
                 .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
@@ -56,6 +57,22 @@ public class ProviderApplicationPreparerFlagOnTest {
         assertThat(result.get("dayCareAddressCity")).isEqualTo(null);
         assertThat(result.get("dayCareAddressState")).isEqualTo(null);
         assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
+    }
+    
+    @Test
+    public void shouldNotMapNoProviderResponseIfSubmissionHasNotExpired() {
+        familySubmission = new SubmissionTestBuilder()
+                .withFlow("gcc")
+                .withSubmittedAtDate(OffsetDateTime.now().minusDays(1))
+                .withDayCareProvider()
+                .with("familyIntendedProviderName", "ProviderName")
+                .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
+                .with("familyIntendedProviderEmail", "mail@test.com")
+                .build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
+        assertThat(result.get("providerResponse")).isEqualTo(
+                new SingleField("providerResponse", "", null));
     }
 
     @Test
@@ -199,7 +216,5 @@ public class ProviderApplicationPreparerFlagOnTest {
         assertThat(result.get("dayCareIdNumber")).isEqualTo(null);
         assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
         assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
-
     }
-
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-502

#### ✍️ Description
Will not map the provider response field on page 14 of the PDF if you download the PDF in the client flow. This is done by not mapping it unless 3 business days have passed which should be well after the clients session has expired. 
