### PR TITLE
Ccap 468 create providerresponse registration tax id ssn screen

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -107,8 +107,5 @@ public class Providerresponse extends FlowInputs {
     @NotBlank
     private String providerTaxIdType;
 
-    @NotBlank
-    @Pattern(regexp = "\\d{3}-\\d{2}-\\d{4}", message = "{registration-tax-id-ssn.error}")
     private String providerTaxIdSSN;
-
 }

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -103,6 +103,5 @@ public class Providerresponse extends FlowInputs {
     private String providerIdentityCheckDateOfBirthYear;
     private String providerIdentityCheckDateOfBirthDate;
 
-    @NotBlank
     private String providerTaxIdType;
 }

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -103,5 +103,6 @@ public class Providerresponse extends FlowInputs {
     private String providerIdentityCheckDateOfBirthYear;
     private String providerIdentityCheckDateOfBirthDate;
 
+    @NotBlank
     private String providerTaxIdType;
 }

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -5,6 +5,7 @@ import formflow.library.data.annotations.Phone;
 import formflow.library.utils.RegexUtils;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public class Providerresponse extends FlowInputs {
 
@@ -105,4 +106,9 @@ public class Providerresponse extends FlowInputs {
 
     @NotBlank
     private String providerTaxIdType;
+
+    @NotBlank
+    @Pattern(regexp = "\\d{3}-\\d{2}-\\d{4}", message = "{registration-tax-id-ssn.error}")
+    private String providerTaxIdSSN;
+
 }

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -5,7 +5,6 @@ import formflow.library.data.annotations.Phone;
 import formflow.library.utils.RegexUtils;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public class Providerresponse extends FlowInputs {
 

--- a/src/main/java/org/ilgcc/app/pdf/ProviderSSNPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderSSNPreparer.java
@@ -1,0 +1,46 @@
+package org.ilgcc.app.pdf;
+
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import formflow.library.pdf.PdfMap;
+import formflow.library.pdf.SingleField;
+import formflow.library.pdf.SubmissionField;
+import formflow.library.pdf.SubmissionFieldPreparer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProviderSSNPreparer implements SubmissionFieldPreparer {
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+    @Autowired
+    private ProviderSubmissionUtilities providerSubmissionUtilities;
+
+    @Override
+    public Map<String, SubmissionField> prepareSubmissionFields(Submission familySubmission, PdfMap pdfMap) {
+        var results = new HashMap<String, SubmissionField>();
+        Optional<Submission> providerSubmission = providerSubmissionUtilities.getProviderSubmissionFromId(
+                submissionRepositoryService, familySubmission);
+        if (providerSubmission.isEmpty()) {
+            return results;
+        }
+        var providerInputData = providerSubmission.get().getInputData();
+        if (providerInputData.containsKey("providerIdentityCheckSSN")) {
+                results.put("providerSSN",
+                    new SingleField("providerSSN", (String) providerInputData.getOrDefault("providerIdentityCheckSSN", ""),
+                        null));
+        }else if(providerInputData.containsKey("providerTaxIdSSN")){
+                results.put("providerSSN",
+                    new SingleField("providerSSN", (String) providerInputData.getOrDefault("providerTaxIdSSN", ""),
+                        null));
+        }else{
+            return results;
+        }
+        return results;
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateTaxIdSSN.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateTaxIdSSN.java
@@ -1,0 +1,46 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidateTaxIdSSN implements Action {
+    @Autowired
+    MessageSource messageSource;
+
+    public static final Locale locale = LocaleContextHolder.getLocale();
+
+    private final String INPUT_NAME = "providerTaxIdSSN";
+
+    @Override
+    public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {
+        Map<String, List<String>> errorMessages = new HashMap<>();
+        String inputValue = (String) formSubmission.getFormData().get(INPUT_NAME);
+
+        Locale locale = LocaleContextHolder.getLocale();
+
+        String regex = "^\\d{3}-\\d{2}-\\d{4}"; 
+
+        Pattern pattern = Pattern.compile(regex);
+        Matcher requiredSSNMatcher = pattern.matcher(inputValue);
+
+        if (!requiredSSNMatcher.matches()) {
+            errorMessages.put(INPUT_NAME,
+                    List.of(messageSource.getMessage("registration-home-provider-ssn.error", null, locale)));
+        }
+
+        return errorMessages;
+    }
+
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateTaxIdSSN.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateTaxIdSSN.java
@@ -21,7 +21,7 @@ public class ValidateTaxIdSSN implements Action {
 
     public static final Locale locale = LocaleContextHolder.getLocale();
 
-    private final String INPUT_NAME = "providerTaxIdSSN";
+    private static final String INPUT_NAME = "providerTaxIdSSN";
 
     @Override
     public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {

--- a/src/main/java/org/ilgcc/app/submission/conditions/NeedsSSNForTaxID.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/NeedsSSNForTaxID.java
@@ -1,0 +1,24 @@
+package org.ilgcc.app.submission.conditions;
+
+import static java.util.Collections.emptyList;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NeedsSSNForTaxID implements Condition {
+
+  @Value("${il-gcc.allow-provider-registration-flow}")
+  private boolean enableProviderRegistration;
+  @Override
+  public Boolean run(Submission submission) {
+    boolean hasNotProvidedSSN = submission.getInputData().getOrDefault("providerIdentityCheckSSN", "").equals("");
+    boolean hasSelectedTaxIdTypeSSN = submission.getInputData().getOrDefault("providerTaxIdType", "").equals("SSN");
+
+    return (enableProviderRegistration && hasNotProvidedSSN && hasSelectedTaxIdTypeSSN);
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -687,6 +687,7 @@ flow:
     nextScreens:
       - name: null
   registration-tax-id-ssn:
+    crossFieldValidationAction: ValidateTaxIdSSN
     condition: EnableProviderRegistration
     nextScreens:
       - name: registration-service-languages

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -682,6 +682,8 @@ flow:
     condition: EnableProviderRegistration
     nextScreens:
       - name: registration-tax-id-ssn
+        condition: NeedsSSNForTaxID
+      - name: registration-tax-id-ein
   registration-tax-id-ein:
     condition: EnableProviderRegistration
     nextScreens:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1375,6 +1375,13 @@ registration-tax-id.reveal-body=Providers can be paid by paper check, direct dep
 registration-tax-id.ssn=SSN (Social Security Number)
 registration-tax-id.fein=FEIN (Federal Employer Identification Number)
 
+#registration-tax-id-ssn
+registration-tax-id-ssn.title=SSN
+registration-tax-id-ssn.header=What is your Social Security Number?
+registration-tax-id-ssn.helper=You don't need it to register for CCAP, but you will need it to get paid.
+registration-tax-id-ssn.linkText=Your information is secure and will be handled in accordance with our <a id='link-to-ilgcc-privacy-policy' href="/privacy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
+registration-tax-id-ssn.error=Make sure the SSN is valid and 9 digits
+
 # registration-checks-trainings-intro
 registration-checks-trainings-intro.title=Background checks and trainings
 registration-checks-trainings-intro.1=Your background history

--- a/src/main/resources/pdf-map.yaml
+++ b/src/main/resources/pdf-map.yaml
@@ -168,6 +168,7 @@ inputFields:
   providerConviction: PROVIDER_CONVICTION
   providerConvictionExplanation: PROVIDER_CONVICTION_EXPLANATION
   providerIdentityCheckDateOfBirthDate: PROVIDER_DOB
+  providerSSN: PROVIDER_SSN
   providerSignature: PROVIDER_SIGNATURE
   providerSignatureDate: PROVIDER_SIGNATURE_DATE
   clientResponseConfirmationCode: APPLICATION_CONFIRMATION_CODE

--- a/src/main/resources/templates/providerresponse/registration-tax-id-ssn.html
+++ b/src/main/resources/templates/providerresponse/registration-tax-id-ssn.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{registration-tax-id-ssn.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,15 +8,32 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
+        <th:block th:replace="~{fragments/gcc-icons :: socialSecurity}"></th:block>
+        <th:block
+            th:replace="~{fragments/cardHeaderForSingleInputScreen ::
+              cardHeaderForSingleInputScreen(header=#{registration-tax-id-ssn.header}, subtext=#{registration-tax-id-ssn.helper}, required='true')}"/>
+        <th:block
+            th:replace="~{fragments/form :: form(action=${formAction}, content=~{::taxSSNContent})}">
+          <th:block th:ref="taxSSNContent">
+            <th:block th:ref="inputContent">
+              <div class="form-card__content">
+                <th:block
+                    th:replace="~{fragments/inputs/ssn :: ssn(inputName='providerTaxIdSSN', ariaLabel='header')}"/>
+                <div>
+
+                </div>
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                                  text=#{general.button.continue})}"/>
+                <div class="display-flex spacing-above-15">
+                  <div class="spacing-right-10">
+                    <th:block
+                        th:replace="~{fragments/icons :: filledLock}"></th:block>
+                  </div>
+                  <p class="text--small"
+                     th:utext="#{registration-tax-id-ssn.linkText}"></p>
+                </div>
+              </div>
+            </th:block>
           </th:block>
         </th:block>
       </main>

--- a/src/test/java/org/ilgcc/app/pdf/ProviderSSNPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderSSNPreparerTest.java
@@ -1,0 +1,67 @@
+package org.ilgcc.app.pdf;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import formflow.library.pdf.SingleField;
+import formflow.library.pdf.SubmissionField;
+import java.util.Map;
+import org.ilgcc.app.IlGCCApplication;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+        classes = IlGCCApplication.class,
+        properties = "il-gcc.dts.expand-existing-provider-flow=true"
+)
+@ActiveProfiles("test")
+public class ProviderSSNPreparerTest {
+
+
+    @Autowired
+    private ProviderSSNPreparer preparer;
+
+    @Autowired
+    private SubmissionRepositoryService submissionRepositoryService;
+
+    private Submission familySubmission;
+    private Submission providerSubmission;
+
+    @Test
+    public void shouldPrintProviderIdentityCheckSSNToPDFIfPresent() {
+        providerSubmission = new SubmissionTestBuilder()
+                .withFlow("providerresponse")
+                .withProviderSubmissionData()
+                .with("providerIdentityCheckSSN", "445-32-6666")
+                .with("providerTaxIdSSN", "555-55-5555")
+                .build();
+        submissionRepositoryService.save(providerSubmission);
+
+        familySubmission = new SubmissionTestBuilder()
+                .withFlow("gcc")
+                .with("providerResponseSubmissionId", providerSubmission.getId())
+                .build();
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
+        assertThat(result.get("providerSSN")).isEqualTo(new SingleField("providerSSN", "445-32-6666", null));
+    }
+    @Test
+    public void shouldPrintProviderTaxIdSSNIfPresent() {
+        providerSubmission = new SubmissionTestBuilder()
+            .withFlow("providerresponse")
+            .withProviderSubmissionData()
+            .with("providerTaxIdSSN", "444-44-4444")
+            .build();
+        submissionRepositoryService.save(providerSubmission);
+
+        familySubmission = new SubmissionTestBuilder()
+            .withFlow("gcc")
+            .with("providerResponseSubmissionId", providerSubmission.getId())
+            .build();
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
+        assertThat(result.get("providerSSN")).isEqualTo(new SingleField("providerSSN", "444-44-4444", null));
+    }
+}

--- a/src/test/java/org/ilgcc/app/submission/actions/NeedSSNForTaxIdTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/NeedSSNForTaxIdTest.java
@@ -1,0 +1,53 @@
+package org.ilgcc.app.submission.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import formflow.library.data.Submission;
+import org.ilgcc.app.IlGCCApplication;
+import org.ilgcc.app.submission.conditions.NeedsSSNForTaxID;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+    classes = IlGCCApplication.class,
+    properties = "il-gcc.allow-provider-registration-flow=true"
+)
+
+@ActiveProfiles("test")
+public class NeedSSNForTaxIdTest {
+  @Autowired
+  private NeedsSSNForTaxID needsSSNForTaxID;
+  private Submission submission;
+
+
+  @Test
+  public void shouldReturnTrueWhenProviderRegistrationFlowFlagIsOnProviderTaxIdTypeIsSSNAndProviderIdentityCheckSSNIsEmpty() {
+    submission = new SubmissionTestBuilder()
+        .withFlow("providerresponse")
+        .with("providerTaxIdType", "SSN")
+        .build();
+    assertThat(needsSSNForTaxID.run(submission)).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldReturnFalseWhenProviderTaxIdIsSSNAndProviderIdentityCheckSSNHasSSN() {
+    submission = new SubmissionTestBuilder()
+        .withFlow("providerresponse")
+        .with("providerTaxIdType", "SSN")
+        .with("providerIdentityCheckSSN", "333-33-3333")
+        .build();
+    assertThat(needsSSNForTaxID.run(submission)).isEqualTo(false);
+  }
+  @Test
+  public void shouldReturnFalseWhenProviderTaxIdIsNotSSN() {
+    submission = new SubmissionTestBuilder()
+        .withFlow("providerresponse")
+        .with("providerTaxIdType", "FEIN")
+        .build();
+    assertThat(needsSSNForTaxID.run(submission)).isEqualTo(false);
+  }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-468

#### ✍️ Description
- `registration-tax-id-ssn` was added to `providerresponse` flow.  
- `registration-tax-id-ssn` screen is only reached if `SSN` is selected as the `providerTaxIdType` and `providerIdentyCheckSSN` is not present
- `PROVIDER_SSN` has either `providerIdentityCheckSSN` or `providerTaxIdSSN` written to it

#### 📷 Design reference
[Figma](https://www.figma.com/design/lGFsTvWwHoOOJ9XQGPFNmu/IL-CCAP-Provider-Experiences?node-id=1487-6539&t=4uzbbS6PeBtH4Ums-4)
[Content Manager](https://docs.google.com/document/d/1ERZ8oqKu_K1HCdm8wQMgCDyYJR-3xF8-d8t7LK84Hmo/edit?tab=t.0#bookmark=id.whtp67m5445e)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
