### PR TITLE
[CCAP-539] Adding error messages for parent and partner activities

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -250,8 +250,10 @@ public class Gcc extends FlowInputs {
     private String earliestChildcareStartDate;
 
     // activities-parent-type
+    @NotEmpty(message = "{activities-type.error.required}")
     private List<String> activitiesParentChildcareReason;
     private String activitiesParentChildcareReason_other;
+    @NotEmpty(message = "{activities-type.error.required}")
     private List<String> activitiesParentPartnerChildcareReason;
     private String activitiesParentPartnerChildcareReason_other;
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -458,6 +458,7 @@ activities-parent-type.going-to-school=Going to school or training
 activities-parent-type.tanf-training=TANF training
 activities-parent-type.other=Other
 activities-parent-type.other-follow-up=Please tell us why you need child care.
+activities-type.error.required=Please select at least one activity
 
 activities-parent-partner-type.doing-while-in-care=What are they doing while the child is in care?
 activities-parent-partner-type.working=Working

--- a/src/main/resources/templates/fragments/cardHeader.html
+++ b/src/main/resources/templates/fragments/cardHeader.html
@@ -1,5 +1,5 @@
 <header
-        th:fragment="requiredCardHeader"
+        th:fragment="cardHeader"
         th:with="hasSubtext=${!#strings.isEmpty(subtext)},
             isRequiredInput=${(required != null && required)}"
         th:assert="${!#strings.isEmpty(header)}"

--- a/src/main/resources/templates/fragments/requiredCardHeader.html
+++ b/src/main/resources/templates/fragments/requiredCardHeader.html
@@ -1,0 +1,13 @@
+<header
+        th:fragment="requiredCardHeader"
+        th:with="hasSubtext=${!#strings.isEmpty(subtext)},
+            isRequiredInput=${(required != null && required)}"
+        th:assert="${!#strings.isEmpty(header)}"
+        class="form-card__header">
+    <h1 id="header" class="h2" >
+        <span th:text="${header + ' '}"></span><span th:if="${isRequiredInput}" class="required-input" th:text="#{general.required-field}"></span>
+    </h1>
+    <p id="header-help-message"
+       th:if="${hasSubtext}"
+       th:utext="${subtext}"></p>
+</header>

--- a/src/main/resources/templates/gcc/activities-parent-type.html
+++ b/src/main/resources/templates/gcc/activities-parent-type.html
@@ -10,7 +10,7 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:replace="~{fragments/gcc-icons :: careFinancial}"></th:block>
         <th:block
-            th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-parent-type.header})}"/>
+            th:replace="~{fragments/requiredCardHeader :: requiredCardHeader(header=#{activities-parent-type.header}, required='true')}"/>
         <th:block
             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">

--- a/src/main/resources/templates/gcc/activities-parent-type.html
+++ b/src/main/resources/templates/gcc/activities-parent-type.html
@@ -10,7 +10,7 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:replace="~{fragments/gcc-icons :: careFinancial}"></th:block>
         <th:block
-            th:replace="~{fragments/requiredCardHeader :: requiredCardHeader(header=#{activities-parent-type.header}, required='true')}"/>
+            th:replace="~{fragments/cardHeader :: cardHeader(header=#{activities-parent-type.header}, required='true')}"/>
         <th:block
             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-539

#### ✍️ Description
This was easy to fix for the error messages themselves, but the header -- since this is not a single input field -- needed a new fragment.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
