### PR TITLE
[CCAP-470] Writes User Input into Other Detail fields

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ProviderLanguagesPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderLanguagesPreparer.java
@@ -47,6 +47,7 @@ public class ProviderLanguagesPreparer extends ProviderSubmissionFieldPreparer {
         if (otherLanguages.isEmpty()) {
           results.put("providerLanguageOther", new SingleField("providerLanguageOther", "true", null));
         }
+        otherLanguages.add((String) providerInputData.getOrDefault("providerLanguagesOffered_other", ""));
       }
 
       if (!otherLanguages.isEmpty()) {

--- a/src/test/java/org/ilgcc/app/pdf/ProviderLanguagePreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderLanguagePreparerTest.java
@@ -118,7 +118,7 @@ public class ProviderLanguagePreparerTest {
     }
 
     @Test
-    public void whenOtherIsIncludedAsProviderLanguageOfferedSelectOtherCheckbox() {
+    public void whenOtherIsIncludedAsProviderLanguageOfferedSelectOtherCheckboxAndAddDetails() {
         String providerLanguagesOfferedOtherString = "test, double test, gibberish";
         providerSubmission = new SubmissionTestBuilder()
                 .withFlow("providerresponse")
@@ -134,11 +134,11 @@ public class ProviderLanguagePreparerTest {
                 .build();
         Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
         assertThat(result.get("providerLanguageOther")).isEqualTo(new SingleField("providerLanguageOther", "true", null));
-        assertThat(result.get("providerLanguageOtherDetail")).isEqualTo(null);
+        assertThat(result.get("providerLanguageOtherDetail")).isEqualTo(new SingleField("providerLanguageOtherDetail", providerLanguagesOfferedOtherString, null));
     }
 
     @Test
-    public void shouldSelectOtherCheckboxAndAllOtherLanguagesExceptManuallyInputedLanguagesWhenOtherProviderLanguagesAreSelected() {
+    public void shouldSelectOtherCheckboxAndAllOtherLanguagesWhenOtherProviderLanguagesAreSelected() {
         String providerLanguagesOfferedOtherString = "test, double gibberish";
         providerSubmission = new SubmissionTestBuilder()
                 .withFlow("providerresponse")
@@ -155,11 +155,11 @@ public class ProviderLanguagePreparerTest {
         Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
         assertThat(result.get("providerLanguageOther")).isEqualTo(new SingleField("providerLanguageOther", "true", null));
         assertThat(result.get("providerLanguageOtherDetail")).isEqualTo(new SingleField("providerLanguageOtherDetail",
-            TAGALOG.getProviderLanguageOtherDetailPdfFieldValue(), null));
+            String.format("%s, %s", TAGALOG.getProviderLanguageOtherDetailPdfFieldValue(), providerLanguagesOfferedOtherString) , null));
     }
 
     @Test
-    public void shouldSelectLanguagesWithCheckboxesAndOtherLanguagesCheckboxesExceptManuallyInputedLanguagesWhenLanguagesWithCheckboxesAndOtherProviderLanguagesAreSelected() {
+    public void shouldSelectLanguagesWithCheckboxesAndOtherLanguagesWhenOtherProviderLanguagesAreSelected() {
         String providerLanguagesOfferedOtherString = "test, double gibberish";
         providerSubmission = new SubmissionTestBuilder()
             .withFlow("providerresponse")
@@ -178,7 +178,7 @@ public class ProviderLanguagePreparerTest {
         assertThat(result.get("providerLanguageSpanish")).isEqualTo(new SingleField("providerLanguageSpanish", "true", null));
         assertThat(result.get("providerLanguageOther")).isEqualTo(new SingleField("providerLanguageOther", "true", null));
         assertThat(result.get("providerLanguageOtherDetail")).isEqualTo(new SingleField("providerLanguageOtherDetail",
-            String.format("%s, %s", TAGALOG.getProviderLanguageOtherDetailPdfFieldValue(), HINDI.getProviderLanguageOtherDetailPdfFieldValue()), null));
+            String.format("%s, %s, %s", TAGALOG.getProviderLanguageOtherDetailPdfFieldValue(), HINDI.getProviderLanguageOtherDetailPdfFieldValue(), providerLanguagesOfferedOtherString), null));
         assertThat(result.get("providerLanguageChinese")).isNotEqualTo(new SingleField("providerLanguageChinese", "true", null));
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-631

#### ✍️ Description
- Any provider language text written into the Other checkbox should be added to the pdf.  

#### 📷 Design reference

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
