### PR TITLE
[CCAP-635] Fixing small logic flaw in TransmissionsRecurringJob

### DIFF
--- a/src/main/java/org/ilgcc/jobs/TransmissionsRecurringJob.java
+++ b/src/main/java/org/ilgcc/jobs/TransmissionsRecurringJob.java
@@ -81,6 +81,6 @@ public class TransmissionsRecurringJob {
     }
 
     private boolean hasProviderResponse(Submission submission) {
-        return submission.getInputData().containsKey("providerResponseSubmissionId");
+        return submission.getInputData().containsKey("providerResponseSubmissionId") && submission.getSubmittedAt() != null;
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-635

#### ✍️ Description
In Staging and Demo, so far not in Production, there seems to be a scenario where you can start a provider response, agree to care, and then not have a submitted_at date. This causes the PDF to never transmit -- but if the provider never ever submits their response, we should treat it as such and send the PDF as a no provider response.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
