### PR TITLE
[CCAP-6678] Add environment specific CCMS-API-configuration

### DIFF
--- a/src/main/resources/application-demo.yaml
+++ b/src/main/resources/application-demo.yaml
@@ -15,3 +15,8 @@ form-flow:
         creation-point: creation
 il-gcc:
   enable-emails: ${ENABLE_EMAILS_FLAG:false}
+  ccms-api:
+    api-subscription-key: ${OCP_APIM_SUBSCRIPTION_KEY}
+    base-url: ${CCMS_API_BASE_URL}
+    username: ${CCMS_API_USERNAME}
+    password: ${CCMS_API_PASSWORD}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -29,7 +29,7 @@ il-gcc:
   dts:
     processing-org: '4c-ccap-apps-testing'
   ccms-api:
-    api-subscription-key: ${CCMS_API_SUBSCRIPTION_KEY}
+    api-subscription-key: ${OCP_APIM_SUBSCRIPTION_KEY}
     base-url: ${CCMS_API_BASE_URL}
     username: ${CCMS_API_USERNAME}
     password: ${CCMS_API_PASSWORD}

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -32,3 +32,8 @@ il-gcc:
   enable-emails: ${ENABLE_EMAILS_FLAG:true}
   dts:
     processing-org: '4c-ccap-apps-testing'
+  ccms-api:
+    api-subscription-key: ${OCP_APIM_SUBSCRIPTION_KEY}
+    base-url: ${CCMS_API_BASE_URL}
+    username: ${CCMS_API_USERNAME}
+    password: ${CCMS_API_PASSWORD}


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-667

#### ✍️ Description
Add environment specific CCMS-API-Configuration
- [ ] We are updating our environment configuration files to pass in CCMS creds
      - [ ] application-demo.yaml
      - [ ] application-dev.yaml
      - [ ] application-staging.yaml
 We are not updating application-production.yaml because do not have those credentials yet.
 - Each field has been added to Github secrets with the UAT credentials
 - dev should pass there credentials into there local environments


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
