### PR TITLE
[CCAP-476] - update design response screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 }
 
 def profile = props.getProperty('SPRING_PROFILES_ACTIVE')
-def formFlowLibraryVersion = '1.6.19'
+def formFlowLibraryVersion = '1.6.20'
 def useLocalLibrary = props.getProperty('USE_LOCAL_LIBRARY')
 
 dependencies {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1255,12 +1255,15 @@ registration-start.button=Register now
 #response
 provider-response-response.title=Provider Response
 provider-response-response.header=What is your response to the application?
-provider-response-response.confirmation-code=Confirmation code:
-provider-response-response.parent-name=Parent name:
-provider-response-response.child-name=Child name:
-provider-response-response.child-age=Child age:
-provider-response-response.hours=Hours of care requested:
-provider-response-response.start-date=Start date of care requested:
+provider-response-response.family-details=Family Details
+provider-response-response.confirmation-code=<strong>Confirmation code:</strong> {0}
+provider-response-response.parent-name=<strong>Parent name:</strong> {0}
+provider-response-response.care-request.1-child=<strong>Care request for:</strong> 1 child
+provider-response-response.care-request.multiple-children=<strong>Care request for:</strong> {0} children
+provider-response-response.child-name=<Strong>Child {0}:</Strong> {1}
+provider-response-response.child-age=<Strong>Age:</Strong> {0}
+provider-response-response.hours=<Strong>Hours of care needed:</Strong>
+provider-response-response.start-date=<Strong>Requested start date:</Strong>
 provider-response-response.button.yes=Yes, I agree to care
 provider-response-response.button.no=No, I don't agree to care
 

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -679,14 +679,9 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
   }
 }
 
-.providerResponse {
-  width: 100%;
-  height: 100%;
-  padding-top: 17px;
-  padding-bottom: 18px;
-  padding-left: 25px;
-  padding-right: 25px;
-  border-radius: 10px;
+
+.familyDetails {
+  padding: 1.5rem 1.5rem 0 1.5rem;
   overflow: hidden;
   border: 2px #008060 solid;
   justify-content: flex-start;
@@ -695,20 +690,28 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
   line-height: 25px;
   word-wrap: break-word;
   margin-bottom: 3rem;
+  font-weight: 400;
 }
 
-.providerResponse {
-  .category {
-    margin-bottom: 0px;
-    margin-top: 2rem;
-    font-weight: 700;
+.familyDetailsReveal {
+  .reveal{
+    background-color: #EBFFFA;
+    border: 2px #008060 solid;
   }
-
-  .response {
-    margin-bottom: 0px;
-    font-weight: 400;
+  .reveal__button {
+    background-color: #EBFFFA;
+    border: none;
   }
+  .reveal__content {
+    background-color: #EBFFFA;
+    border: none;
+  }
+  .response-header{
+    margin: 0;
+  }
+}
 
+.familyDetails {
   .list--bulleted {
     margin-top: 0px;
   }

--- a/src/main/resources/templates/gcc/doc-upload-add-files.html
+++ b/src/main/resources/templates/gcc/doc-upload-add-files.html
@@ -25,7 +25,7 @@
                 controlId='r1',
                 linkLabel=~{::revealLabel1},
                 content=~{::revealContent1},
-                forceShowContent='true')}">
+                forceShowContent='false')}">
                   <th:block th:ref="revealLabel1">
                     <i class="icon-">&#xE862;</i>
                     <th:span th:text="#{doc-upload-add-files.accordion-1.title}"></th:span>

--- a/src/main/resources/templates/providerresponse/mailing-address.html
+++ b/src/main/resources/templates/providerresponse/mailing-address.html
@@ -1,5 +1,4 @@
 <th:block
-<th:block
         th:replace="~{fragments/screens/enter-address ::
       screen(
         title='provider-response.mailing-address.title',
@@ -10,7 +9,6 @@
         sameAsPreviousAddressInputName='providerMailingAddressSameAsServiceAddress',
         addressGroupInputPrefix='providerMailing'
       )}">
-</th:block>
 </th:block>
 <script th:inline="javascript">
   $(document).ready(function () {

--- a/src/main/resources/templates/providerresponse/provider-number.html
+++ b/src/main/resources/templates/providerresponse/provider-number.html
@@ -16,7 +16,7 @@
             controlId='r1',
             linkLabel=~{::revealLabel1},
             content=~{::revealContent1},
-            forceShowContent='true')}">
+            forceShowContent='false')}">
               <th:block th:ref="revealLabel1">
                   <th:span th:text="#{provider-response-provider-number.accordion.title}"></th:span>
               </th:block>

--- a/src/main/resources/templates/providerresponse/registration-checks-trainings-notice.html
+++ b/src/main/resources/templates/providerresponse/registration-checks-trainings-notice.html
@@ -16,7 +16,7 @@
                 controlId='r1',
                 linkLabel=~{::revealLabel1},
                 content=~{::revealContent1},
-                forceShowContent='true')}">
+                forceShowContent='false')}">
             <th:block th:ref="revealLabel1">
               <th:span th:text="#{registration-checks-trainings-notice.accordion.label1}"></th:span>
             </th:block>
@@ -33,7 +33,7 @@
                 controlId='r2',
                 linkLabel=~{::revealLabel2},
                 content=~{::revealContent2},
-                forceShowContent='true')}">
+                forceShowContent='false')}">
             <th:block th:ref="revealLabel2">
               <th:span th:text="#{registration-checks-trainings-notice.accordion.label2}"></th:span>
             </th:block>

--- a/src/main/resources/templates/providerresponse/registration-doc-upload-add-files.html
+++ b/src/main/resources/templates/providerresponse/registration-doc-upload-add-files.html
@@ -22,7 +22,7 @@
                   controlId='r1',
                   linkLabel=~{::revealLabel1},
                   content=~{::revealContent1},
-                  forceShowContent='true')}">
+                  forceShowContent='false')}">
                   <th:block th:ref="revealLabel1">
                     <th:i class="icon-">&#xE862;</th:i>
                     <th:span th:text="#{registration-doc-upload-add-files.accordion-1.title}"></th:span>

--- a/src/main/resources/templates/providerresponse/registration-tax-id.html
+++ b/src/main/resources/templates/providerresponse/registration-tax-id.html
@@ -15,7 +15,7 @@
         controlId='r1',
         linkLabel=~{::revealLabel},
         content=~{::revealContent},
-        forceShowContent='true')}">
+        forceShowContent='false')}">
           <th:block th:ref="revealLabel">
             <th:span th:text="#{registration-tax-id.reveal-header}"></th:span>
           </th:block>

--- a/src/main/resources/templates/providerresponse/response.html
+++ b/src/main/resources/templates/providerresponse/response.html
@@ -15,38 +15,53 @@
                         th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
                     <th:block th:ref="formContent">
                         <div class="form-card__content">
-                            <div class="providerResponse">
-                                <th:block
-                                        th:if="${submission.getInputData().containsKey('familySubmissionId')}"
-                                        th:with="applicationData=${submission.getInputData().get('clientResponse')}, children=${submission.getInputData().get('clientResponseChildren')}">
+                            <h3 th:text="#{provider-response-response.family-details}"></h3>
+                            <th:block
+                                    th:if="${submission.getInputData().containsKey('familySubmissionId')}"
+                                    th:with="applicationData=${submission.getInputData().get('clientResponse')}, children=${submission.getInputData().get('clientResponseChildren')}">
+                                <div class="radio-button familyDetails">
+                                    <p th:utext="${#messages.msg('provider-response-response.parent-name', applicationData.getOrDefault('clientResponseParentName', 'n/a'))}"></p>
 
-                                    <p class="category" th:text="#{provider-response-response.confirmation-code}"></p>
-                                    <p class="response" th:id="confirmation-code"
-                                       th:text="${applicationData.getOrDefault('clientResponseConfirmationCode', 'n/a')}"></p>
-
-                                    <p class="category" th:text="#{provider-response-response.parent-name}"></p>
-                                    <p class="response" th:id="parent-name"
-                                       th:text="${applicationData.getOrDefault('clientResponseParentName', 'n/a')}"></p>
-
-                                    <th:block
-                                            th:each="child : ${submission.getInputData().get('clientResponseChildren')}">
-                                        <p class="category" th:text="#{provider-response-response.child-name}"></p>
-                                        <p class="response" th:id="${'child-name-'+childStat.index}"
-                                           th:text="${child.getOrDefault('childName', 'n/a')}"></p>
-
-                                        <p class="category" th:text="#{provider-response-response.child-age}"></p>
-                                        <p th:id="${'child-age-'+childStat.index}" th:text="${child.getOrDefault('childAge', 'n/a')}"></p>
-
-                                        <p class="category" th:text="#{provider-response-response.hours}"></p>
-                                        <ul class="list--bulleted" th:id="${'child-schedule-'+childStat.index}"
-                                            th:utext="${child.get('childCareHours')}"></ul>
-
-                                        <p class="category" th:text="#{provider-response-response.start-date}"></p>
-                                        <p class="response" th:id="${'child-start-'+childStat.index}"
-                                           th:text="${child.getOrDefault('childStartDate', 'n/a')}"></p>
+                                    <th:block th:if="${children.size().equals(1)}">
+                                        <p th:utext="#{'provider-response-response.care-request.1-child'}"></p>
                                     </th:block>
-                                </th:block>
-                            </div>
+                                    <th:block th:unless="${children.size().equals(1)}">
+                                        <p th:utext="${#messages.msg('provider-response-response.care-request.multiple-children', children.size())}"></p>
+                                    </th:block>
+
+                                    <p th:utext="${#messages.msg('provider-response-response.confirmation-code', applicationData.getOrDefault('clientResponseConfirmationCode', 'n/a'))}"></p>
+                                </div>
+                                <div class="familyDetailsReveal">
+                                    <th:block
+                                            th:each="child, iter : ${children}">
+                                        <th:block th:replace="~{fragments/honeycrisp/reveal :: reveal(
+                                            controlId='r1',
+                                            linkLabel=~{::ref1},
+                                            content=~{::revealContent},
+                                            forceShowContent=${children.size().equals(1)})}">
+                                            <th:block th:ref="ref1">
+                                                <th:span
+                                                        th:utext="${#messages.msg('provider-response-response.child-name', iter.index + 1, child.getOrDefault('childName', 'n/a'))}"></th:span>
+                                            </th:block>
+                                            <th:block th:ref="revealContent">
+                                                <p th:utext="${#messages.msg('provider-response-response.child-age', child.getOrDefault('childAge', 'n/a'))}"></p>
+
+                                                <p class="response-header"
+                                                   th:utext="#{provider-response-response.hours}"></p>
+                                                <ul class="list--bulleted"
+                                                    th:id="${'child-schedule-'+iter.index}"
+                                                    th:utext="${child.get('childCareHours')}"></ul>
+
+                                                <p class="response-header"
+                                                   th:utext="#{provider-response-response.start-date}"></p>
+                                                <p
+                                                   th:id="${'child-start-'+iter.index}"
+                                                   th:text="${child.getOrDefault('childStartDate', 'n/a')}"></p>
+                                            </th:block>
+                                        </th:block>
+                                    </th:block>
+                                </div>
+                            </th:block>
                         </div>
                         <th:block th:replace="~{fragments/inputs/radioFieldset ::
                                           radioFieldset(inputName='providerResponseAgreeToCare',

--- a/src/main/resources/templates/providerresponse/response.html
+++ b/src/main/resources/templates/providerresponse/response.html
@@ -20,7 +20,7 @@
                                     th:if="${submission.getInputData().containsKey('familySubmissionId')}"
                                     th:with="applicationData=${submission.getInputData().get('clientResponse')}, children=${submission.getInputData().get('clientResponseChildren')}">
                                 <div class="radio-button familyDetails">
-                                    <p th:utext="${#messages.msg('provider-response-response.parent-name', applicationData.getOrDefault('clientResponseParentName', 'n/a'))}"></p>
+                                    <p th:id="parent-name" th:utext="${#messages.msg('provider-response-response.parent-name', applicationData.getOrDefault('clientResponseParentName', 'n/a'))}"></p>
 
                                     <th:block th:if="${children.size().equals(1)}">
                                         <p th:utext="#{'provider-response-response.care-request.1-child'}"></p>
@@ -29,7 +29,7 @@
                                         <p th:utext="${#messages.msg('provider-response-response.care-request.multiple-children', children.size())}"></p>
                                     </th:block>
 
-                                    <p th:utext="${#messages.msg('provider-response-response.confirmation-code', applicationData.getOrDefault('clientResponseConfirmationCode', 'n/a'))}"></p>
+                                    <p th:id="confirmation-code" th:utext="${#messages.msg('provider-response-response.confirmation-code', applicationData.getOrDefault('clientResponseConfirmationCode', 'n/a'))}"></p>
                                 </div>
                                 <div class="familyDetailsReveal">
                                     <th:block
@@ -40,11 +40,11 @@
                                             content=~{::revealContent},
                                             forceShowContent=${children.size().equals(1)})}">
                                             <th:block th:ref="ref1">
-                                                <th:span
+                                                <th:span th:id="${'child-name-'+iter.index}"
                                                         th:utext="${#messages.msg('provider-response-response.child-name', iter.index + 1, child.getOrDefault('childName', 'n/a'))}"></th:span>
                                             </th:block>
                                             <th:block th:ref="revealContent">
-                                                <p th:utext="${#messages.msg('provider-response-response.child-age', child.getOrDefault('childAge', 'n/a'))}"></p>
+                                                <p th:id="${'child-age-'+iter.index}" th:utext="${#messages.msg('provider-response-response.child-age', child.getOrDefault('childAge', 'n/a'))}"></p>
 
                                                 <p class="response-header"
                                                    th:utext="#{provider-response-response.hours}"></p>

--- a/src/main/resources/templates/providerresponse/submit-start.html
+++ b/src/main/resources/templates/providerresponse/submit-start.html
@@ -24,7 +24,7 @@
                                 controlId='r1',
                                 linkLabel=~{::revealLabel1},
                                 content=~{::revealContent1},
-                                forceShowContent='true')}">
+                                forceShowContent='false')}">
                                 <th:block th:ref="revealLabel1">
                                     <th:span
                                             th:text="#{provider-response-submit-start.active.reveal-header-1}"></th:span>
@@ -37,7 +37,7 @@
                                 controlId='r2',
                                 linkLabel=~{::revealLabel2},
                                 content=~{::revealContent2},
-                                forceShowContent='true')}">
+                                forceShowContent='false')}">
                                 <th:block th:ref="revealLabel2">
                                     <th:span
                                             th:text="#{provider-response-submit-start.active.reveal-header-2}"></th:span>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -50,13 +50,10 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
 
         // response
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
-        assertThat(testPage.findElementTextById("confirmation-code")).isEqualTo(CONF_CODE);
-        assertThat(testPage.findElementTextById("parent-name")).isEqualTo("FirstName parent last");
+        assertThat(testPage.findElementTextById("confirmation-code")).contains(CONF_CODE);
+        assertThat(testPage.findElementTextById("parent-name")).contains("FirstName parent last");
 
-        assertThat(testPage.findElementTextById("child-name-0")).isEqualTo("First Child");
-        assertThat(testPage.findElementTextById("child-age-0")).isEqualTo("Age 22");
-        assertThat(testPage.findElementTextById("child-schedule-0")).isNotNull();
-        assertThat(testPage.findElementTextById("child-start-0")).isEqualTo("01/10/2025");
+        assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
 
         assertThat(testPage.elementDoesNotExistById("child-name-1")).isTrue();
         assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
@@ -102,13 +99,10 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
 
         // response
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
-        assertThat(testPage.findElementTextById("confirmation-code")).isEqualTo(CONF_CODE);
-        assertThat(testPage.findElementTextById("parent-name")).isEqualTo("FirstName parent last");
+        assertThat(testPage.findElementTextById("confirmation-code")).contains(CONF_CODE);
+        assertThat(testPage.findElementTextById("parent-name")).contains("FirstName parent last");
 
-        assertThat(testPage.findElementTextById("child-name-0")).isEqualTo("First Child");
-        assertThat(testPage.findElementTextById("child-age-0")).isEqualTo("Age 22");
-        assertThat(testPage.findElementTextById("child-schedule-0")).isNotNull();
-        assertThat(testPage.findElementTextById("child-start-0")).isEqualTo("01/10/2025");
+        assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
 
         assertThat(testPage.elementDoesNotExistById("child-name-1")).isTrue();
         assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
@@ -190,13 +184,10 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
 
         // response
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
-        assertThat(testPage.findElementTextById("confirmation-code")).isEqualTo(CONF_CODE);
-        assertThat(testPage.findElementTextById("parent-name")).isEqualTo("FirstName parent last");
+        assertThat(testPage.findElementTextById("confirmation-code")).contains(CONF_CODE);
+        assertThat(testPage.findElementTextById("parent-name")).contains("FirstName parent last");
 
-        assertThat(testPage.findElementTextById("child-name-0")).isEqualTo("First Child");
-        assertThat(testPage.findElementTextById("child-age-0")).isEqualTo("Age 22");
-        assertThat(testPage.findElementTextById("child-schedule-0")).isNotNull();
-        assertThat(testPage.findElementTextById("child-start-0")).isEqualTo("01/10/2025");
+        assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
 
         assertThat(testPage.elementDoesNotExistById("child-name-1")).isTrue();
         assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-476](https://codeforamerica.atlassian.net/browse/CCAP-476)
#### ✍️ Description
- Implements design changes to the response screen
- Upgrades library to 1.6.20 to include updates to reveal component which allow the screen to load open or closed
- Changes the forceShowContent to false in most components so that they correctly load closed
#### Screenshots

Tests from the heroku branch
<img width="764" alt="Screenshot 2025-03-18 at 5 23 43 PM" src="https://github.com/user-attachments/assets/51b0927b-b2f9-40a0-9c8a-5741e46fc112" />
<img width="395" alt="Screenshot 2025-03-18 at 5 28 14 PM" src="https://github.com/user-attachments/assets/fa54c14e-8a7a-447a-86fa-b276bec71788" />


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-476]: https://codeforamerica.atlassian.net/browse/CCAP-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ