### PR TITLE
[CCAP-495] Send confirmation email to family with no provider

### DIFF
--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -21,7 +21,7 @@ public class ILGCCEmail {
 
     public ILGCCEmail(String senderEmailAddress, String senderName, String recipientAddress, String subject, Content body, EmailType emailType,
             UUID submissionId) {
-        this.senderEmail = new Email(FROM_ADDRESS, senderName);
+        this.senderEmail = new Email(senderEmailAddress, senderName);
         this.recipientEmail = new Email(recipientAddress);
         this.subject = subject;
         this.body = body;

--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -10,6 +10,7 @@ public class ILGCCEmail {
 
     public static final String FROM_ADDRESS = "contact@getchildcareil.org";
     public static final String EMAIL_SENDER_KEY = "email.general.sender-name";
+    public static final String FROM_ADDRESS_WITH_NO_PROVIDER = "noreply@getchildcareil.org";
 
     private Email senderEmail;
     private String subject;
@@ -18,7 +19,7 @@ public class ILGCCEmail {
     private UUID submissionId;
     private Email recipientEmail;
 
-    public ILGCCEmail(String senderName, String recipientAddress, String subject, Content body, EmailType emailType,
+    public ILGCCEmail(String senderEmailAddress, String senderName, String recipientAddress, String subject, Content body, EmailType emailType,
             UUID submissionId) {
         this.senderEmail = new Email(FROM_ADDRESS, senderName);
         this.recipientEmail = new Email(recipientAddress);
@@ -31,18 +32,25 @@ public class ILGCCEmail {
 
     public static ILGCCEmail createProviderConfirmationEmail(String senderName, String recipientAddress, String subject,
             Content body, UUID submissionId) {
-        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.PROVIDER_CONFIRMATION_EMAIL, submissionId);
+        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.PROVIDER_CONFIRMATION_EMAIL, submissionId);
     }
 
     public static ILGCCEmail createFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
             Content body, UUID submissionId) {
-        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL, submissionId);
+        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL, submissionId);
+    }
+
+    public static ILGCCEmail createNoProviderFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
+        Content body, UUID submissionId) {
+        return new ILGCCEmail(FROM_ADDRESS_WITH_NO_PROVIDER, senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER, submissionId);
     }
 
     public static ILGCCEmail createProviderAgreesToCareFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
             Content body, UUID submissionId) {
-        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL, submissionId);
+        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL, submissionId);
     }
+
+
 
     @Getter
     public enum EmailType {

--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -10,7 +10,6 @@ public class ILGCCEmail {
 
     public static final String FROM_ADDRESS = "contact@getchildcareil.org";
     public static final String EMAIL_SENDER_KEY = "email.general.sender-name";
-    public static final String FROM_ADDRESS_WITH_NO_PROVIDER = "noreply@getchildcareil.org";
 
     private Email senderEmail;
     private String subject;
@@ -19,9 +18,9 @@ public class ILGCCEmail {
     private UUID submissionId;
     private Email recipientEmail;
 
-    public ILGCCEmail(String senderEmailAddress, String senderName, String recipientAddress, String subject, Content body, EmailType emailType,
+    public ILGCCEmail(String senderName, String recipientAddress, String subject, Content body, EmailType emailType,
             UUID submissionId) {
-        this.senderEmail = new Email(senderEmailAddress, senderName);
+        this.senderEmail = new Email(FROM_ADDRESS, senderName);
         this.recipientEmail = new Email(recipientAddress);
         this.subject = subject;
         this.body = body;
@@ -32,22 +31,22 @@ public class ILGCCEmail {
 
     public static ILGCCEmail createProviderConfirmationEmail(String senderName, String recipientAddress, String subject,
             Content body, UUID submissionId) {
-        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.PROVIDER_CONFIRMATION_EMAIL, submissionId);
+        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.PROVIDER_CONFIRMATION_EMAIL, submissionId);
     }
 
     public static ILGCCEmail createFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
             Content body, UUID submissionId) {
-        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL, submissionId);
+        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL, submissionId);
     }
 
     public static ILGCCEmail createNoProviderFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
         Content body, UUID submissionId) {
-        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER, submissionId);
+        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER, submissionId);
     }
 
     public static ILGCCEmail createProviderAgreesToCareFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
             Content body, UUID submissionId) {
-        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL, submissionId);
+        return new ILGCCEmail(senderName, recipientAddress, subject, body, EmailType.PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL, submissionId);
     }
 
 

--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -42,7 +42,7 @@ public class ILGCCEmail {
 
     public static ILGCCEmail createNoProviderFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,
         Content body, UUID submissionId) {
-        return new ILGCCEmail(FROM_ADDRESS_WITH_NO_PROVIDER, senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER, submissionId);
+        return new ILGCCEmail(FROM_ADDRESS, senderName, recipientAddress, subject, body, EmailType.FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER, submissionId);
     }
 
     public static ILGCCEmail createProviderAgreesToCareFamilyConfirmationEmail(String senderName, String recipientAddress, String subject,

--- a/src/main/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmail.java
@@ -39,6 +39,8 @@ public class SendFamilyConfirmationEmail implements Action {
     @Override
     public void run(Submission familySubmission) {
         if (!skipEmailSend(familySubmission)) {
+            boolean hasProvider = familySubmission.getInputData().getOrDefault("hasChosenProvider", "false").equals("true");
+
             Optional<Map<String, Object>> emailData = getEmailData(familySubmission);
 
             if (emailData.isEmpty()) {
@@ -48,10 +50,14 @@ public class SendFamilyConfirmationEmail implements Action {
             locale = emailData.get().get("familyPreferredLanguage").equals("Spanish") ? Locale.forLanguageTag(
                     "es") : Locale.ENGLISH;
 
-            ILGCCEmail email = ILGCCEmail.createFamilyConfirmationEmail(getSenderName(locale),
+            ILGCCEmail email = hasProvider ? ILGCCEmail.createFamilyConfirmationEmail(getSenderName(locale),
                     getRecipientEmail(emailData.get()),
                     setSubject(emailData.get(), locale), new Content("text/html", setBodyCopy(emailData.get(), locale)),
-                    familySubmission.getId());
+                    familySubmission.getId()) :
+                    ILGCCEmail.createNoProviderFamilyConfirmationEmail(getSenderName(locale),
+                        getRecipientEmail(emailData.get()),
+                        setSubject(emailData.get(), locale), new Content("text/html", setNoProviderEmailBody(emailData.get(), locale)) ,familySubmission.getId()
+                        );
             sendEmail(email, familySubmission);
         }
     }
@@ -86,20 +92,35 @@ public class SendFamilyConfirmationEmail implements Action {
     }
 
     protected String setBodyCopy(Map<String, Object> emailData, Locale locale) {
-        String p1 = messageSource.getMessage("email.family-confirmation.p1", new Object[]{emailData.get("parentFirstName")},
+        String p1 = messageSource.getMessage("email.family-confirmation.hi", new Object[]{emailData.get("parentFirstName")},
                 locale);
-        String p2 = messageSource.getMessage("email.family-confirmation.p2", null, locale);
-        String p3 = messageSource.getMessage("email.family-confirmation.p3", new Object[]{emailData.get("shareableLink")}, locale);
-        String p4 = messageSource.getMessage("email.family-confirmation.p4",
+        String p2 = messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale);
+        String p3 = messageSource.getMessage("email.family-confirmation.you-need-to-email-or-text", new Object[]{emailData.get("shareableLink")}, locale);
+        String p4 = messageSource.getMessage("email.family-confirmation.you-will-recieve-mail",
                 new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
-        String p5 = messageSource.getMessage("email.family-confirmation.p5",
+        String p5 = messageSource.getMessage("email.family-confirmation.pending-review",
                 new Object[]{emailData.get("confirmationCode"), emailData.get("submittedDate")},
                 locale);
-        String p6 = messageSource.getMessage("email.family-confirmation.p6", null, locale);
-        String p7 = messageSource.getMessage("email.family-confirmation.p7", null, locale);
+        String p6 = messageSource.getMessage("email.family-confirmation.what-happens", null, locale);
+        String p7 = messageSource.getMessage("email.family-confirmation.what-are-the-next", null, locale);
         String p8 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
         String p9 = messageSource.getMessage("email.general.footer.cfa", null, locale);
         return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+    }
+
+    protected String setNoProviderEmailBody(Map<String, Object> emailData, Locale locale) {
+        String p1 = messageSource.getMessage("email.family-confirmation.hi", new Object[]{emailData.get("parentFirstName")},
+            locale);
+        String p2 = messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale);
+        String p3 = messageSource.getMessage("email.family-confirmation.sent-for-review",
+            new Object[]{emailData.get("confirmationCode"), emailData.get("submittedDate")},
+            locale);
+        String p4 = messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale);
+        String p5 = messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale);
+        String p6 = messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale);
+        String p7 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
+        String p8 = messageSource.getMessage("email.general.footer.cfa", null, locale);
+        return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8;
     }
 
     protected void sendEmail(ILGCCEmail email, Submission submission) {

--- a/src/main/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmail.java
@@ -116,7 +116,7 @@ public class SendFamilyConfirmationEmail implements Action {
             new Object[]{emailData.get("confirmationCode"), emailData.get("submittedDate")},
             locale);
         String p4 = messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale);
-        String p5 = messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale);
+        String p5 = messageSource.getMessage("email.family-confirmation.a-staff-member", new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
         String p6 = messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale);
         String p7 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
         String p8 = messageSource.getMessage("email.general.footer.cfa", null, locale);

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -29,6 +29,6 @@ org:
     jobs:
       retry-back-off-time-seed: 1
 il-gcc:
-  enable-emails: ${ENABLE_EMAILS_FLAG:false}
+  enable-emails: ${ENABLE_EMAILS_FLAG:true}
   dts:
     processing-org: '4c-ccap-apps-testing'

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -29,6 +29,6 @@ org:
     jobs:
       retry-back-off-time-seed: 1
 il-gcc:
-  enable-emails: ${ENABLE_EMAILS_FLAG:true}
+  enable-emails: ${ENABLE_EMAILS_FLAG:false}
   dts:
     processing-org: '4c-ccap-apps-testing'

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -450,6 +450,7 @@ flow:
     nextScreens:
       - name: complete-submit-confirmation
   no-provider-intro:
+    beforeDisplayAction: SendFamilyConfirmationEmail
     nextScreens:
       - name: no-provider-notice
   no-provider-notice:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -120,13 +120,17 @@ email.general.footer.cfa=<p>Sent by Code for America on behalf of the Illinois D
 
 #email.family-confirmation
 email.family-confirmation.subject=Your CCAP confirmation code: {0}
-email.family-confirmation.p1=<p>Hi {0},</p>
-email.family-confirmation.p2=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
-email.family-confirmation.p3=<p><strong>You need to email or text your child care provider so they can complete their part.</strong> They have 3 business days to complete the application using this unique link: {0}
-email.family-confirmation.p4=<p>You will receive mail or email about the status of your application within <strong>13-15 business days.</strong> If you don''t receive a notice within that time or need more information, reach out to your Child Care Resource and Referral (CCR&R) Agency, {0} by phone: <a href="tel:{1}">{1}</a>.</p>
-email.family-confirmation.p5=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Pending review<br/>Date of submission: {1}</p>
-email.family-confirmation.p6=<p><strong>What happens if my provider doesn't respond?</strong><br/>If your provider doesn't complete their part of the application in 3 business days, your application will automatically be forwarded to your CCR&R for processing. A worker will reach out to you and help you find an available child care provider.</p>
-email.family-confirmation.p7=<p><strong>What are the next steps in the process?</strong><br/>Your application will be reviewed by a worker at your CCR&R who will approve or deny the application based on CCAP program requirements. If they don't have enough information to make a decision, they will reach out to you by phone, email, or mail.</p>
+email.family-confirmation.hi=<p>Hi {0},</p>
+email.family-confirmation.you-completed-the-online-application=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
+email.family-confirmation.you-need-to-email-or-text=<p><strong>You need to email or text your child care provider so they can complete their part.</strong> They have 3 business days to complete the application using this unique link: {0}
+email.family-confirmation.you-will-recieve-mail=<p>You will receive mail or email about the status of your application within <strong>13-15 business days.</strong> If you don''t receive a notice within that time or need more information, reach out to your Child Care Resource and Referral (CCR&R) Agency, {0} by phone: <a href="tel:{1}">{1}</a>.</p>
+email.family-confirmation.pending-review=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Pending review<br/>Date of submission: {1}</p>
+email.family-confirmation.sent-for-review=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Sent for review<br/>Date of submission: {1}</p>
+email.family-confirmation.what-happens=<p><strong>What happens if my provider doesn't respond?</strong><br/>If your provider doesn't complete their part of the application in 3 business days, your application will automatically be forwarded to your CCR&R for processing. A worker will reach out to you and help you find an available child care provider.</p>
+email.family-confirmation.what-are-the-next=<p><strong>What are the next steps in the process?</strong><br/>Your application will be reviewed by a worker at your CCR&R who will approve or deny the application based on CCAP program requirements. If they don't have enough information to make a decision, they will reach out to you by phone, email, or mail.</p>
+email.family-confirmation.review-without-a-child-care-provider=<p><strong>Your application has been sent for review without a child care provider listed.</strong></p>
+email.family-confirmation.a-staff-member=<p>A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact your CCR&R, {0}: {1}</p>
+email.family-confirmation.you-will-receive=<p>You will receive a letter or email about the status of your case within 10-12 business days.</p>
 
 #email.response-email-for-family.provider-agrees
 email.response-email-for-family.provider-agrees.subject=[CCAP update] Application submitted

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -120,13 +120,13 @@ email.general.footer.cfa=<p>Enviado por Code for America en nombre del Departame
 
 #email.family-confirmation
 email.family-confirmation.subject=Su código de confirmación de CCAP: {0}
-email.family-confirmation.p1=<p>Hola {0},</p>
-email.family-confirmation.p2=<p>¡Ha completado la solicitud en línea del Programa de Asistencia para el Cuidado de Niños (CCAP)!</p>
-email.family-confirmation.p3=<p><strong>Necesita enviar un correo electrónico o un mensaje de texto a su proveedor de cuidado infantil para que complete la parte que le corresponde.</strong> Esta persona tiene  3 días hábiles para completar la solicitud utilizando este enlace único:  {0}
-email.family-confirmation.p4=<p>Recibirá una carta en el correo postal o un correo electrónico sobre el estatus de su caso dentro de los próximos <strong>13 a 15 días hábiles</strong>. Si no recibe un aviso dentro de ese tiempo o necesita más información, comuníquese con su Agencia de Recursos y Referencias para el Cuidado de Niños (CCR&R), {0} por teléfono <a href="tel:{1}">{1}</a>.</p>
-email.family-confirmation.p5=<p><strong>Detalles de su solicitud:</strong><br/>Código de confirmación: {0}<br/>Estatus:  Pendiente de revisión<br/>Fecha de envio: {1}</p>
-email.family-confirmation.p6=<p><strong>¿Qué sucede si mi proveedor no responde?</strong><br/>Si su proveedor no completa su parte de la solicitud en 3 días hábiles, su solicitud se enviará automáticamente a su CCR&R para su procesamiento. Alguien del personal se comunicará con usted y le ayudará a encontrar un proveedor de cuidado infantil disponible.</p>
-email.family-confirmation.p7=<p><strong>¿Cuáles son los próximos pasos en el proceso?</strong><br/>Su solicitud será revisada por alguien del personal de su CCR&R, quien aprobará o denegará la solicitud según los requisitos del programa CCAP. Si esta persona no tiene suficiente información para tomar una decisión, se comunicará con usted por teléfono, correo electrónico o correo postal.</p>
+email.family-confirmation.hi=<p>Hola {0},</p>
+email.family-confirmation.you-completed-the-online-application=<p>¡Ha completado la solicitud en línea del Programa de Asistencia para el Cuidado de Niños (CCAP)!</p>
+email.family-confirmation.you-need-to-email-or-text=<p><strong>Necesita enviar un correo electrónico o un mensaje de texto a su proveedor de cuidado infantil para que complete la parte que le corresponde.</strong> Esta persona tiene  3 días hábiles para completar la solicitud utilizando este enlace único:  {0}
+email.family-confirmation.you-will-recieve-mail=<p>Recibirá una carta en el correo postal o un correo electrónico sobre el estatus de su caso dentro de los próximos <strong>13 a 15 días hábiles</strong>. Si no recibe un aviso dentro de ese tiempo o necesita más información, comuníquese con su Agencia de Recursos y Referencias para el Cuidado de Niños (CCR&R), {0} por teléfono <a href="tel:{1}">{1}</a>.</p>
+email.family-confirmation.pending-review=<p><strong>Detalles de su solicitud:</strong><br/>Código de confirmación: {0}<br/>Estatus:  Pendiente de revisión<br/>Fecha de envio: {1}</p>
+email.family-confirmation.what-happens=<p><strong>¿Qué sucede si mi proveedor no responde?</strong><br/>Si su proveedor no completa su parte de la solicitud en 3 días hábiles, su solicitud se enviará automáticamente a su CCR&R para su procesamiento. Alguien del personal se comunicará con usted y le ayudará a encontrar un proveedor de cuidado infantil disponible.</p>
+email.family-confirmation.what-are-the-next=<p><strong>¿Cuáles son los próximos pasos en el proceso?</strong><br/>Su solicitud será revisada por alguien del personal de su CCR&R, quien aprobará o denegará la solicitud según los requisitos del programa CCAP. Si esta persona no tiene suficiente información para tomar una decisión, se comunicará con usted por teléfono, correo electrónico o correo postal.</p>
 
 #email.response-email-for-family.provider-agrees
 email.response-email-for-family.provider-agrees.subject=[CCAP update] Su aplicación ha sido enviada

--- a/src/test/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmailTest.java
@@ -103,17 +103,36 @@ public class SendFamilyConfirmationEmailTest {
         String emailCopy = action.setBodyCopy(emailData, locale);
 
         assertThat(emailCopy).contains(
-                messageSource.getMessage("email.family-confirmation.p1", new Object[]{"FirstName"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p2", null, locale));
+                messageSource.getMessage("email.family-confirmation.hi", new Object[]{"FirstName"}, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale));
         assertThat(emailCopy).contains(
-                messageSource.getMessage("email.family-confirmation.p3", new Object[]{"tempEmailLink"},
+                messageSource.getMessage("email.family-confirmation.you-need-to-email-or-text", new Object[]{"tempEmailLink"},
                         locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p4",
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-recieve-mail",
                 new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p5",
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.pending-review",
                 new Object[]{"ABC123", "October 10, 2022"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.what-happens", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.what-are-the-next", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+    }
+
+    @Test
+    void correctlySetsNoProviderEmailBody() {
+        Optional<Map<String, Object>> emailDataOptional = action.getEmailData(familySubmission);
+        Map<String, Object> emailData = emailDataOptional.get();
+
+        String emailCopy = action.setNoProviderEmailBody(emailData, locale);
+
+        assertThat(emailCopy).contains(
+            messageSource.getMessage("email.family-confirmation.hi", new Object[]{"FirstName"}, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.sent-for-review",
+            new Object[]{"ABC123", "October 10, 2022"}, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale));        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
     }

--- a/src/test/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmailTest.java
@@ -131,10 +131,9 @@ public class SendFamilyConfirmationEmailTest {
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.sent-for-review",
             new Object[]{"ABC123", "October 10, 2022"}, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
     }
 

--- a/src/test/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SendFamilyConfirmationEmailTest.java
@@ -132,8 +132,9 @@ public class SendFamilyConfirmationEmailTest {
             new Object[]{"ABC123", "October 10, 2022"}, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale));        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
     }
 


### PR DESCRIPTION
#### 🔗 Jira ticket[
[CCAP-495]
#### ✍️ Description
- [ ] The confirmation email is triggered when a family submits an application and the family decided to apply for CCAP without a provider 
   - [ ] SendFamilyConfirmationEmail modified to include no providers
- [ ] The `reply to` and `sender address` address for the email should be `noreply@getchildcareil.org` 
- [ ] The content should match the content manager


#### 📷 Design reference
[Content Manager](https://docs.google.com/document/d/1vwtwI1-GcqrGDGf3l1UEk161ahoGqVlCAX0BhmoYnlY/edit?tab=t.0#bookmark=id.douf4myo1zo8)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] translations should be added to transifex
- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-495]: https://codeforamerica.atlassian.net/browse/CCAP-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ