### PR TITLE
[CCAP-722] - add new provider messaging flag and scaffold screens

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/conditions/EnableProviderMessagingFlagOn.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/EnableProviderMessagingFlagOn.java
@@ -1,0 +1,18 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnableProviderMessagingFlagOn implements Condition {
+
+    @Value("${il-gcc.enable-provider-messaging}")
+    private boolean enableProviderMessaging;
+
+    @Override
+    public Boolean run(Submission submission) {
+        return enableProviderMessaging;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -129,6 +129,7 @@ il-gcc:
   enable-emails: ${ENABLE_EMAILS_FLAG:true}
   allow-provider-registration-flow: ${ALLOW_PROVIDER_REGISTRATION_FLOW:false}
   enable-new-sda-caseload-codes: ${ENABLE_NEW_SDA_CASELOAD_CODES:false}
+  enable-provider-messaging: ${ENABLE_PROVIDER_MESSAGING:false}
   ccms-integration-enabled: ${ENABLE_CCMS_INTEGRATION:false}
   ccms-transaction-delay-minutes: ${CCMS_TRANSACTION_DELAY_MINUTES:60}
   dts-integration-enabled: ${ENABLE_DTS_INTEGRATION:true}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -467,6 +467,42 @@ flow:
     beforeDisplayAction: FormatSubmittedAtDate
     nextScreens:
       - name: complete-submit-confirmation
+  submit-contact-method:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-contact-provider-email
+  submit-contact-provider-email:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-confirm-provider-email
+  submit-confirm-provider-email:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-provider-info-edit
+  submit-provider-info-edit:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-contact-provider-email-confirmation
+  submit-contact-provider-email-confirmation:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-contact-provider-text
+  submit-contact-provider-text:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: parent-confirm-provider-number
+  parent-confirm-provider-number:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-contact-provider-text-confirmation
+  submit-contact-provider-text-confirmation:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-confirmation
+  submit-confirmation:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: null
   doc-upload-confirm:
     nextScreens: null
   children-delete:

--- a/src/main/resources/templates/gcc/parent-confirm-provider-number.html
+++ b/src/main/resources/templates/gcc/parent-confirm-provider-number.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-confirm-provider-email.html
+++ b/src/main/resources/templates/gcc/submit-confirm-provider-email.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-confirmation.html
+++ b/src/main/resources/templates/gcc/submit-confirmation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-contact-method.html
+++ b/src/main/resources/templates/gcc/submit-contact-method.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-contact-provider-email-confirmation.html
+++ b/src/main/resources/templates/gcc/submit-contact-provider-email-confirmation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-contact-provider-email.html
+++ b/src/main/resources/templates/gcc/submit-contact-provider-email.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-contact-provider-text-confirmation.html
+++ b/src/main/resources/templates/gcc/submit-contact-provider-text-confirmation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-contact-provider-text.html
+++ b/src/main/resources/templates/gcc/submit-contact-provider-text.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-provider-info-edit.html
+++ b/src/main/resources/templates/gcc/submit-provider-info-edit.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+          <th:block th:ref="formContent">
+            <div class="form-card__content">
+                <!-- Put inputs here -->
+            </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-722](https://codeforamerica.atlassian.net/browse/CCAP-722)
#### ✍️ Description
- Creates new feature flag and sets it in heroku (true) , aptible - staging (true), production (false)
- scaffolds screens: 
  - submit-contact-method
  - submit-contact-provider-email
  - submit-confirm-provider-email
  - submit-provider-info-edit
  - submit-contact-provider-email-confirmation
  - submit-contact-provider-text
  - parent-confirm-provider-number
  - submit-contact-provider-text-confirmation
  - submit-confirmation
Displays conditions above when feature flag is on.
#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-722]: https://codeforamerica.atlassian.net/browse/CCAP-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ