### PR TITLE
[CCAP-732] - update submit intro screen to include contactProvider co…

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -783,9 +783,9 @@ unearned-income-referral-services.disability-support=Services for people living 
 
 # submit-intro
 submit-intro.title=Sign and Submit
-submit-intro.box.next-steps=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Agreeing to terms</li><li>Verification documents</li><li>Next steps</li></ol>
+submit-intro.box.next-steps=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Verification documents</li><li>Agreeing to terms</li><li>Next steps</li></ol>
 submit-intro.header.contact-provider=Submit Application & Contact Provider
-submit-intro.box.next-steps.contact-provider=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Contacting your provider</li><li>Verification documents</li><li>Submitting documents</li></ol>
+submit-intro.box.next-steps.contact-provider=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Agreeing to terms</li><li>Contacting your provider</li><li>Submitting documents</li></ol>
 
 submit-ccap-terms.title=Parent Agreement and Terms
 submit-ccap-terms.subtext=Please expand the boxes below to read the terms and requirements. You will sign on the next page.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -781,13 +781,12 @@ unearned-income-referral-services.safe-support=Safe support for people experienc
 unearned-income-referral-services.housing-support=Housing support and homelessness prevention for people with unstable housing
 unearned-income-referral-services.disability-support=Services for people living with a physical or mental disability
 
-#
-submit-intro.step=Step 5 of {0}
+# submit-intro
 submit-intro.title=Sign and Submit
-submit-intro.box.header=We'll ask about
-submit-intro.box.one=Agreeing to terms
-submit-intro.box.two=Verification documents
-submit-intro.box.three=Next steps
+submit-intro.box.next-steps=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Agreeing to terms</li><li>Verification documents</li><li>Next steps</li></ol>
+submit-intro.header.contact-provider=Submit Application & Contact Provider
+submit-intro.box.next-steps.contact-provider=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Contacting your provider</li><li>Verification documents</li><li>Submitting documents</li></ol>
+
 submit-ccap-terms.title=Parent Agreement and Terms
 submit-ccap-terms.subtext=Please expand the boxes below to read the terms and requirements. You will sign on the next page.
 submit-ccap-terms.accordion-1.title=Benefit Application Terms

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -783,9 +783,14 @@ unearned-income-referral-services.disability-support=Services for people living 
 
 # submit-intro
 submit-intro.title=Sign and Submit
-submit-intro.box.next-steps=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Verification documents</li><li>Agreeing to terms</li><li>Next steps</li></ol>
+submit-intro.box.header=We'll ask about
+submit-intro.box.one=Verification documents
+submit-intro.box.two=Agreeing to terms
+submit-intro.box.three=Next steps
 submit-intro.header.contact-provider=Submit Application & Contact Provider
-submit-intro.box.next-steps.contact-provider=<p class="text--centered"><strong>We'll ask about</strong></p><ol class="list--numbered"><li>Agreeing to terms</li><li>Contacting your provider</li><li>Submitting documents</li></ol>
+submit-intro.box.one.contact-provider=Agreeing to terms
+submit-intro.box.two.contact-provider=Contacting your provider
+submit-intro.box.three.contact-provider=Submitting documents
 
 submit-ccap-terms.title=Parent Agreement and Terms
 submit-ccap-terms.subtext=Please expand the boxes below to read the terms and requirements. You will sign on the next page.

--- a/src/main/resources/templates/gcc/submit-intro.html
+++ b/src/main/resources/templates/gcc/submit-intro.html
@@ -8,25 +8,40 @@
         <div class="grid">
             <div th:replace="~{fragments/goBack :: goBackLink}"></div>
             <main id="content" role="main" class="form-card spacing-above-35">
-                <div class="text--centered">
-                    <th:block th:replace="~{fragments/gcc-icons :: application-mail}"></th:block>
-                    <p class="text--grey-dark" th:id="submit-intro-step" th:text="${#messages.msg('submit-intro.step', '6')}"></p>
-                    <th:block
-                            th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-intro.title})}"/>
-                </div>
-                <div class="form-card__content">
-                    <div class="boxed-content">
-                        <p class="text--centered"><strong th:text="#{submit-intro.box.header}"></strong></p>
-                        <ol class="list--numbered">
-                            <li th:text="#{submit-intro.box.one}"></li>
-                            <li th:text="#{submit-intro.box.two}"></li>
-                            <li th:text="#{submit-intro.box.three}"></li>
-                        </ol>
+                <th:block
+                        th:unless="${@environment.getProperty('il-gcc.enable-provider-messaging') == 'true'}">
+                    <div class="text--centered">
+                        <th:block
+                                th:replace="~{fragments/gcc-icons :: application-mail}"></th:block>
+                        <p class="text--grey-dark" th:id="submit-intro-step"
+                           th:text="#{general.step-header('5','6')}"></p>
+                        <th:block
+                                th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-intro.title})}"/>
                     </div>
-                </div>
-                <div class="form-card__footer text--centered">
-                    <th:block th:replace="~{fragments/continueButton :: continue}"/>
-                </div>
+                    <div class="form-card__content">
+                        <div class="boxed-content" th:utext="#{submit-intro.box.next-steps}"></div>
+                    </div>
+                    <div class="form-card__footer text--centered">
+                        <th:block th:replace="~{fragments/continueButton :: continue}"/>
+                    </div>
+                </th:block>
+                <th:block
+                        th:if="${@environment.getProperty('il-gcc.enable-provider-messaging') == 'true'}">
+                    <div class="text--centered">
+                        <th:block
+                                th:replace="~{fragments/gcc-icons :: application-mail}"></th:block>
+                        <p class="text--grey-dark" th:id="submit-intro-step"
+                           th:text="#{general.step-header('5','5')}"></p>
+                        <th:block
+                                th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-intro.header.contact-provider})}"/>
+                    </div>
+                    <div class="form-card__content">
+                        <div class="boxed-content" th:utext="#{submit-intro.box.next-steps.contact-provider}"></div>
+                    </div>
+                    <div class="form-card__footer text--centered">
+                        <th:block th:replace="~{fragments/continueButton :: continue}"/>
+                    </div>
+                </th:block>
             </main>
         </div>
     </section>

--- a/src/main/resources/templates/gcc/submit-intro.html
+++ b/src/main/resources/templates/gcc/submit-intro.html
@@ -19,7 +19,14 @@
                                 th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-intro.title})}"/>
                     </div>
                     <div class="form-card__content">
-                        <div class="boxed-content" th:utext="#{submit-intro.box.next-steps}"></div>
+                        <div class="boxed-content">
+                            <p class="text--centered"><strong th:text="#{submit-intro.box.header}"></strong></p>
+                            <ol class="list--numbered">
+                                <li th:text="#{submit-intro.box.one}"></li>
+                                <li th:text="#{submit-intro.box.two}"></li>
+                                <li th:text="#{submit-intro.box.three}"></li>
+                            </ol>
+                        </div>
                     </div>
                     <div class="form-card__footer text--centered">
                         <th:block th:replace="~{fragments/continueButton :: continue}"/>
@@ -36,7 +43,14 @@
                                 th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-intro.header.contact-provider})}"/>
                     </div>
                     <div class="form-card__content">
-                        <div class="boxed-content" th:utext="#{submit-intro.box.next-steps.contact-provider}"></div>
+                        <div class="boxed-content">
+                            <p class="text--centered"><strong th:text="#{submit-intro.box.header}"></strong></p>
+                            <ol class="list--numbered">
+                                <li th:text="#{submit-intro.box.one.contact-provider}"></li>
+                                <li th:text="#{submit-intro.box.two.contact-provider}"></li>
+                                <li th:text="#{submit-intro.box.three.contact-provider}"></li>
+                            </ol>
+                        </div>
                     </div>
                     <div class="form-card__footer text--centered">
                         <th:block th:replace="~{fragments/continueButton :: continue}"/>

--- a/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
@@ -1,0 +1,29 @@
+package org.ilgcc.app.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+@TestPropertySource(properties = {"il-gcc.enable-provider-messaging=true"})
+public class GccProviderMessagingFlowJourneyTest extends AbstractBasePageTest {
+
+    @Test
+    void ProviderMessagingSteps() {
+        testPage.navigateToFlowScreen("gcc/parent-info-disability");
+
+        saveSubmission(getSessionSubmissionTestBuilder()
+                .withParentBasicInfo()
+                .with("familyIntendedProviderName", "ACME Daycare")
+                .with("applicationCounty", "LEE")
+                .build());
+
+        testPage.clickYes();
+
+        testPage.navigateToFlowScreen("gcc/submit-intro");
+
+        // submit-intro
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-intro.title"));
+        assertThat(testPage.getHeader()).isEqualTo(getEnMessage("submit-intro.header.contact-provider"));
+        testPage.clickContinue();
+    }
+}


### PR DESCRIPTION
[CCAP-732](https://codeforamerica.atlassian.net/browse/CCAP-732)

#### 🔗 Jira ticket
The submit-intro screen matches the designs

#### ✍️ Description
![Screenshot 2025-03-25 at 2 09 14 PM](https://github.com/user-attachments/assets/d477ca47-22f4-4cbc-9bfc-1f0965c8d47e)



With the feature flag off:  Step 5 of 6 was already there and I don't want to override it.
![Screenshot 2025-03-25 at 2 09 14 PM](https://github.com/user-attachments/assets/f20680ef-9655-4241-aaa1-ed1d9013cd30)



#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-732]: https://codeforamerica.atlassian.net/browse/CCAP-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ