### PR TITLE
[CCAP-746] Redact Data from non-business license-exempt providers table on import

### DIFF
--- a/src/main/java/org/ilgcc/app/data/importer/ProviderImporter.java
+++ b/src/main/java/org/ilgcc/app/data/importer/ProviderImporter.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.assertj.core.util.diff.Delta.TYPE;
 
 public class ProviderImporter {
 

--- a/src/main/java/org/ilgcc/app/data/importer/ProviderImporter.java
+++ b/src/main/java/org/ilgcc/app/data/importer/ProviderImporter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.assertj.core.util.diff.Delta.TYPE;
 
 public class ProviderImporter {
 
@@ -44,13 +45,22 @@ public class ProviderImporter {
             "\tstatus = excluded.status,\n" +
             "\tsite_provider_org_id = excluded.site_provider_org_id;\n";
 
-    private static final List<String> COLUMN_HEADERS = List.of("RSRCE_ID", "Provider Type", "RSRCE_NAME", "DO_BUSN_AS_NAME",
+    private static final String TYPE_HEADER = "Provider Type";
+    private static final List<String> COLUMN_HEADERS = List.of("RSRCE_ID", TYPE_HEADER, "RSRCE_NAME", "DO_BUSN_AS_NAME",
             "STR_ADR", "CITY", "ST", "ZIP", "Date of Last Approval", "Maintaining R&R", "Provider Status");
 
     private static final List<String> EXCLUDED_COLUMN_HEADERS = List.of();
     private static final List<String> DATE_COLUMN_HEADERS = List.of("Date of Last Approval");
+    private static final List<String> REDACTED_COLUMN_HEADERS = List.of("RSRCE_NAME", "STR_ADR");
 
     private static final List<String> EXCLUDED_IDS = List.of("460328258720008");
+
+    private static final Set<String> REDACTABLE_TYPES = Set.of(
+        "764 - Day Care Home Exempt from Licensing",
+        "765 - Relative Exempt care in the home of the provider",
+        "766 - Non-Relative Exempt care in the home of the child",
+        "767 - Relative Exempt care in the home of the child"
+    );
 
     public static void main(String[] args) {
         String fileNameAndPath = args[0];
@@ -101,6 +111,16 @@ public class ProviderImporter {
                     excludedColumnsIndices.add(index);
                 }
             }
+
+            Set<Integer> redactedColumnsIndices = new HashSet<>();
+            for (String redactedColumnHeader : REDACTED_COLUMN_HEADERS) {
+                int index = COLUMN_HEADERS.indexOf(redactedColumnHeader);
+                if (index != -1) {
+                    redactedColumnsIndices.add(index);
+                }
+            }
+
+            int typeColumnIndex = COLUMN_HEADERS.indexOf(TYPE_HEADER);
 
             Set<Integer> dateColumnsIndices = new HashSet<>();
             for (String dateColumnHeader : DATE_COLUMN_HEADERS) {
@@ -186,14 +206,20 @@ public class ProviderImporter {
 
                 StringBuilder sb = new StringBuilder("\t(");
                 BigInteger siteAdminId = null;
+                boolean isLineRedactable = false;
                 for (int i = 0; i < values.length; i++) {
+
+                    if (typeColumnIndex == i) {
+                        isLineRedactable = REDACTABLE_TYPES.contains(values[i]);
+                    }
+
                     if (excludedColumnsIndices.contains(i)) {
                         // Skip values in the excluded columns
                         continue;
                     }
 
                     StringBuilder valueToInsert = new StringBuilder();
-                    if (values[i] == null || values[i].isBlank()) {
+                    if (values[i] == null || values[i].isBlank() || (isLineRedactable && redactedColumnsIndices.contains(i))) {
                         valueToInsert.append("NULL");
                     } else {
                         String cleanedValue = ImporterUtils.getCleanedValue(values[i]);


### PR DESCRIPTION


#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-746

#### ✍️ Description
After running the new code, executing the generated SQL, and connecting to the dev database, I see no rows that are not-redacted for these provider types:

```
il-gcc=# select provider_id, type, name, street_address from providers where type like '764%' and (name is NOT NULL or street_address is NOT NULL);
 provider_id | type | name | street_address 
-------------+------+------+----------------
(0 rows)

il-gcc=# select provider_id, type, name, street_address from providers where type like '765%' and (name is NOT NULL or street_address is NOT NULL);
 provider_id | type | name | street_address 
-------------+------+------+----------------
(0 rows)

il-gcc=# select provider_id, type, name, street_address from providers where type like '766%' and (name is NOT NULL or street_address is NOT NULL);
 provider_id | type | name | street_address 
-------------+------+------+----------------
(0 rows)

il-gcc=# select provider_id, type, name, street_address from providers where type like '767%' and (name is NOT NULL or street_address is NOT NULL);
 provider_id | type | name | street_address 
-------------+------+------+----------------
(0 rows)
```

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
