### PR TITLE
[CCAP-739] - submit-edit-provider-email screen

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -488,6 +488,10 @@ flow:
     condition: EnableProviderMessagingFlagOn
     nextScreens:
       - name: submit-contact-provider-email-confirmation
+  submit-edit-provider-email:
+    condition: EnableProviderMessagingFlagOn
+    nextScreens:
+      - name: submit-confirm-provider-email
   submit-contact-provider-email-confirmation:
     condition: EnableProviderMessagingFlagOn
     nextScreens:
@@ -560,6 +564,7 @@ landmarks:
     - submit-contact-method
     - submit-contact-provider-email
     - submit-confirm-provider-email
+    - submit-edit-provider-email
     - submit-provider-info-edit
     - submit-contact-provider-email-confirmation
     - submit-contact-provider-text

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -293,12 +293,14 @@ onboarding-no-provider-intro.subtext=Need help finding a child care provider?<ol
 #onboarding-provider-info
 onboarding-provider-info.title=Provider Info
 onboarding-provider-info.header=Tell us about your child care provider
-onboarding-provider-info.name=Provider name
-onboarding-provider-info.name-help=Enter their first and last name or the name of the child care center.
-onboarding-provider-info.email=Provider email address
-onboarding-provider-info.email-help=We recommend adding their email if you have it.
-onboarding-provider-info.phone=Provider mobile phone number
-onboarding-provider-info.phone-help=We recommend adding their cell phone number if you have it.
+
+# child-care-provider-info
+child-care-provider-info.name=Provider name
+child-care-provider-info.name-help=Enter their first and last name or the name of the child care center.
+child-care-provider-info.email=Provider email address
+child-care-provider-info.email-help=We recommend adding their email if you have it.
+child-care-provider-info.phone=Provider mobile phone number
+child-care-provider-info.phone-help=We recommend adding their cell phone number if you have it.
 
 #onboarding-provider-info-review
 onboarding-provider-info-review.title=Review provider info
@@ -831,6 +833,10 @@ submit-contact-method.notice=<strong>Email:</strong> We will automatically email
 submit-contact-method.email=Email
 submit-contact-method.text=Text
 submit-contact-method.other=Another way
+
+# submit-edit-provider-email
+submit-edit-provider-email.title=Edit provider email
+submit-edit-provider-email.header=Update your child care provider's information
 
 submit-complete.title=Your application has been submitted!
 submit-complete.header=Do you want to add any verification documents to your application?

--- a/src/main/resources/templates/fragments/screens/child-care-provider-info.html
+++ b/src/main/resources/templates/fragments/screens/child-care-provider-info.html
@@ -1,0 +1,49 @@
+<th:block th:fragment="screen" th:with="
+    hasTitle=${!#strings.isEmpty(title)},
+    hasHeader=${!#strings.isEmpty(header)}
+">
+    <!DOCTYPE html>
+    <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+    <head th:replace="~{fragments/head :: head(title=${title})}"></head>
+    <body>
+    <div class="page-wrapper">
+        <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+        <section class="slab">
+            <div class="grid">
+                <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+                <main id="content" role="main" class="form-card spacing-above-35">
+                    <th:block th:replace="~{fragments/gcc-icons :: care}"></th:block>
+                    <th:block
+                            th:replace="~{fragments/cardHeader :: cardHeader(header=${header})}"/>
+                    <th:block
+                            th:replace="~{fragments/form :: form(action=${formAction}, content=~{:: content})}">
+                        <th:block th:ref="content">
+                            <div class="form-card__content">
+                                <th:block th:replace="~{fragments/inputs/text ::
+                                  text(inputName='familyIntendedProviderName',
+                                  label=#{child-care-provider-info.name},
+                                  helpText=#{child-care-provider-info.name-help})}"/>
+                                <th:block th:replace="~{fragments/inputs/text ::
+                                  text(inputName='familyIntendedProviderEmail',
+                                  label=#{child-care-provider-info.email},
+                                  helpText=#{child-care-provider-info.email-help})}"/>
+                                <th:block th:replace="~{fragments/inputs/phone :: phone(
+                                  inputName='familyIntendedProviderPhoneNumber',
+                                  label=#{child-care-provider-info.phone},
+                                  helpText=#{child-care-provider-info.phone-help})}"/>
+                                <input type="hidden" id="providerApplicationResponseStatusHidden" name="providerApplicationResponseStatus" th:value="${T(org.ilgcc.app.utils.enums.SubmissionStatus).ACTIVE.name()}">
+                            </div>
+                            <div class="form-card__footer">
+                                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{general.inputs.continue})}"/>
+                            </div>
+                        </th:block>
+                    </th:block>
+                </main>
+            </div>
+        </section>
+    </div>
+    <th:block th:replace="~{fragments/footer :: footer}"/>
+    </body>
+    </html>
+</th:block>

--- a/src/main/resources/templates/gcc/onboarding-provider-info.html
+++ b/src/main/resources/templates/gcc/onboarding-provider-info.html
@@ -1,43 +1,6 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{onboarding-provider-info.title})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/gcc-icons :: care}"></th:block>
-        <th:block
-            th:replace="~{fragments/cardHeader :: cardHeader(header=#{onboarding-provider-info.header})}"/>
-          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{:: content})}">
-            <th:block th:ref="content">
-              <div class="form-card__content">
-                <th:block th:replace="~{fragments/inputs/text ::
-                  text(inputName='familyIntendedProviderName',
-                  label=#{onboarding-provider-info.name},
-                  helpText=#{onboarding-provider-info.name-help})}" />
-                <th:block th:replace="~{fragments/inputs/text ::
-                  text(inputName='familyIntendedProviderEmail',
-                  label=#{onboarding-provider-info.email},
-                  helpText=#{onboarding-provider-info.email-help})}" />
-                <th:block th:replace="~{fragments/inputs/phone :: phone(
-                  inputName='familyIntendedProviderPhoneNumber',
-                  label=#{onboarding-provider-info.phone},
-                  helpText=#{onboarding-provider-info.phone-help})}"/>
-                <input type="hidden" id="providerApplicationResponseStatusHidden" name="providerApplicationResponseStatus" th:value="${T(org.ilgcc.app.utils.enums.SubmissionStatus).ACTIVE.name()}">
-              </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
-                  text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}" />
-</body>
-</html>
+<th:block th:replace="~{fragments/screens/child-care-provider-info ::
+      screen(
+        title=#{onboarding-provider-info.title},
+        header=#{onboarding-provider-info.header}
+      )}">
+</th:block>

--- a/src/main/resources/templates/gcc/submit-edit-provider-email.html
+++ b/src/main/resources/templates/gcc/submit-edit-provider-email.html
@@ -1,0 +1,13 @@
+<th:block th:replace="~{fragments/screens/child-care-provider-info ::
+      screen(
+        title=#{submit-edit-provider-email.title},
+        header=#{submit-edit-provider-email.header}
+      )}">
+</th:block>
+
+<script th:inline="javascript">
+  $(document).ready(function () {
+    $('#familyIntendedProviderName').prop('disabled', true);
+    $('#familyIntendedProviderPhoneNumber').prop('disabled', true);
+  });
+</script>

--- a/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
@@ -45,5 +45,22 @@ public class GccProviderMessagingFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
 
         // submit-contact-provider-email
+        // submit-edit-provider-email
+        testPage.navigateToFlowScreen("gcc/submit-edit-provider-email");
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-edit-provider-email.title"));
+        assertThat(testPage.getInputValue("familyIntendedProviderName")).isEqualTo("ACME Daycare");
+        assertThat(testPage.findElementById("familyIntendedProviderName").isEnabled()).isFalse();
+        assertThat(testPage.findElementById("familyIntendedProviderEmail").isEnabled()).isTrue();
+        assertThat(testPage.findElementById("familyIntendedProviderPhoneNumber").isEnabled()).isFalse();
+
+        testPage.enter("familyIntendedProviderEmail", "test");
+        testPage.clickContinue();
+
+        assertThat(testPage.hasErrorText(getEnMessage("errors.invalid-email"))).isTrue();
+
+        testPage.enter("familyIntendedProviderEmail", "test@mail.com");
+        testPage.clickContinue();
+
+        // submit-confirm-provider-email
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
<!-- Add link to the issue -->

#### ✍️ Description
Since we are basically editing the data from the onboarding-provider-info, I moved the main content into a screen fragment to be reused by onboarding-provider-info and submit-edit-provider-email screen
- submit-edit-provider-email screen loads name, email, phone number if they exist
- submit-edit-provider-email updates only email if it is updated
- submit-edit-provider-email name and phone number fields are disabled

#### 📷 Design reference
![Screenshot 2025-03-25 at 2 51 39 PM](https://github.com/user-attachments/assets/e0f1c5ff-ee0c-47b6-8ff7-4c47def76b5e)


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ x] Added relevant tests
- [ x] Meets acceptance criteria
