### PR TITLE
[CCAP-740] create new submit-contact-provider-text-confirmation screen

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -123,8 +123,6 @@ org:
     background-job-server:
       enabled: ${JOBRUNR_SERVER_ENABLED:true}
     dashboard:
-      enabled: ${JOBRUNR_DASHBOARD_ENABLED:false}
-#TODO: REMOVE THIS TODO WHEN UAT TESTING CAN BE DONE
 il-gcc:
   app-version: ${APTIBLE_GIT_REF:no-version-set}
   enable-emails: ${ENABLE_EMAILS_FLAG:true}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -123,6 +123,7 @@ org:
     background-job-server:
       enabled: ${JOBRUNR_SERVER_ENABLED:true}
     dashboard:
+      enabled: ${JOBRUNR_DASHBOARD_ENABLED:false}
 il-gcc:
   app-version: ${APTIBLE_GIT_REF:no-version-set}
   enable-emails: ${ENABLE_EMAILS_FLAG:true}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -124,6 +124,7 @@ org:
       enabled: ${JOBRUNR_SERVER_ENABLED:true}
     dashboard:
       enabled: ${JOBRUNR_DASHBOARD_ENABLED:false}
+#TODO: REMOVE THIS TODO WHEN UAT TESTING CAN BE DONE
 il-gcc:
   app-version: ${APTIBLE_GIT_REF:no-version-set}
   enable-emails: ${ENABLE_EMAILS_FLAG:true}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1724,6 +1724,14 @@ submit-contact-provider-email-confirmation.email-preview.body.pt3=<strong>Click 
 submit-contact-provider-email-confirmation.email-preview.body.pt4=The sooner you respond, the sooner you can get paid.
 submit-contact-provider-email-confirmation.email-preview.body.pt5=If you don't respond, the application will be submitted to the CCR&R after 3 business days.
 
+#submit-contact-provider-text-confirmation
+submit-contact-provider-text-confirmation.title=Text provider
+submit-contact-provider-text-confirmation.header=Send a text to your child care provider
+submit-contact-provider-text-confirmation.body.pt1=Text a <strong>secure link</strong> to your provider with your confirmation code and application details.
+submit-contact-provider-text-confirmation.body.pt2=They have <strong>3 business days</strong> to complete their part.
+submit-contact-provider-text-confirmation.text-action=Open text app
+submit-contact-provider-text-confirmation.message=Hi! I applied for CCAP with you as my provider.\n\nConfirmation code: {0}\n\nPlease complete your part within 3 business days {1}
+
 #parent-confirm-provider-number
 parent-confirm-provider-number.title=Confirm provider phone
 parent-confirm-provider-number.header=Is this the correct cell phone number for your child care provider?

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -446,7 +446,13 @@ p.normal {
   align-items: flex-start;
   gap: 20px;
 }
+.open-text-app header{
+  margin-bottom: 0;
+}
 
+.open-text-app-paragraph{
+  margin-bottom: 5rem;
+}
 .steps-box svg {
   flex-shrink: 0;
 }

--- a/src/main/resources/templates/gcc/submit-contact-provider-text-confirmation.html
+++ b/src/main/resources/templates/gcc/submit-contact-provider-text-confirmation.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{submit-contact-provider-text-confirmation.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,17 +8,28 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
+        <th:block th:replace="~{fragments/gcc-icons :: text-bubble}"></th:block>
+        <div class="open-text-app">
+          <th:block
+              th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-contact-provider-text-confirmation.header})}"/>
+        </div>
+        <div class="form-card__content">
+          <div>
+            <p th:utext="#{submit-contact-provider-text-confirmation.body.pt1}"></p>
+            <p class="open-text-app-paragraph" th:utext="#{submit-contact-provider-text-confirmation.body.pt2}"></p>
+          </div>
+          <div class="center"
+               th:with="textMessageContent=${T(org.ilgcc.app.utils.TextUtilities).generateTextMessage(inputData.get('familyIntendedProviderPhoneNumber'), #messages.msg('submit-contact-provider-text-confirmation.message', shortCode, shareableLink))}">
+            <a target="_blank" th:id="contact-provider-by-text-confirmation" th:href="${textMessageContent}"
+               class="button button--wide">
+              <i aria-hidden="true"  class="icon-insert_comment"></i>
+              <span th:text="#{submit-contact-provider-text-confirmation.text-action}"></span>
+            </a>
+          </div>
+        </div>
+        <div class="form-card__footer">
+          <th:block th:replace="~{fragments/continueButton :: continue}"/>
+        </div>
       </main>
     </div>
   </section>

--- a/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
@@ -1,11 +1,9 @@
 package org.ilgcc.app.journeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import org.ilgcc.app.utils.AbstractBasePageTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
-
 @TestPropertySource(properties = {"il-gcc.enable-provider-messaging=true"})
 public class GccProviderMessagingFlowJourneyTest extends AbstractBasePageTest {
 
@@ -87,13 +85,17 @@ public class GccProviderMessagingFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-contact-provider-email-confirmation.title"));
         testPage.clickContinue();
 
-        // parent-confirm-provider-number
-        testPage.navigateToFlowScreen("gcc/parent-confirm-provider-number");
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("parent-confirm-provider-number.title"));
-        testPage.clickYes();
+      testPage.navigateToFlowScreen("gcc/submit-contact-provider-text-confirmation");
+      assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-contact-provider-text-confirmation.title"));
+      testPage.clickContinue();
 
-        // submit-share-confirmation-code
-        testPage.navigateToFlowScreen("gcc/submit-share-confirmation-code");
+      // parent-confirm-provider-number
+      testPage.navigateToFlowScreen("gcc/parent-confirm-provider-number");
+      assertThat(testPage.getTitle()).isEqualTo(getEnMessage("parent-confirm-provider-number.title"));
+      testPage.clickYes();
+
+      // submit-share-confirmation-code
+      testPage.navigateToFlowScreen("gcc/submit-share-confirmation-code");
 
         // skips screen and goes to doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-740]

#### ✍️ Description
- [x] The submit-contact-provider-text-confirmation screen exists
- [x] The content on the submit-contact-provider-text-confirmation screen matches the designs
    - [x] Add icon
    - [x] Add title
    - [x] Add header
    - [x] add 2 paragraphs
    - [x] Add open text app button 
      - [x] add icon
      - [x] add text
- [x] Clicking the “Open text app” button on the submit-contact-provider-text-confirmation should trigger the default messaging app on the client’s device and create a message with the family’s intended provider phone number as the to number and a pre-filled message.

```
Message content:
Hi! I applied for CCAP with you as my provider.
Confirmation code: KOSGEB
Please complete your part within 3 business days https://getchildcareil.org/s/KOSGEB 
```

#### 📷 Design reference
[Figma](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=17162-40959&m=dev)

Design
![image](https://github.com/user-attachments/assets/6060ed40-0737-4d80-9686-eeb69472b91d)

PR
![image](https://github.com/user-attachments/assets/e5a0826e-b0de-4a3e-a63f-e99e9b67ed0b)


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-740]: https://codeforamerica.atlassian.net/browse/CCAP-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ