### PR TITLE
[CCAP-727] - Send automatic email notification to provider

### DIFF
--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -39,7 +39,8 @@ public class ILGCCEmail implements Serializable {
         PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL("Provider Agrees to Care Family Email"),
         PROVIDER_CONFIRMATION_EMAIL("Provider Confirmation Email"),
         PROVIDER_DECLINES_CARE_FAMILY_EMAIL("Provider Declines Care Family Email"),
-        PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL("Provider Did Not Respond Family Email");
+        PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL("Provider Did Not Respond Family Email"),
+        AUTOMATED_PROVIDER_OUTREACH_EMAIL("Automated Provider Outreach Email");
 
         private final String description;
 

--- a/src/main/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmail.java
@@ -28,7 +28,7 @@ public class SendAutomatedProviderOutreachEmail extends SendEmail {
     protected ILGCCEmailTemplate emailTemplate(Map<String, Object> emailData) {
         return new AutomatedProviderOutreachEmailTemplate(emailData,
                 messageSource,
-                locale).createTemplate();
+                locale.ENGLISH).createTemplate();
     }
 
     @Override

--- a/src/main/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmail.java
@@ -1,0 +1,39 @@
+package org.ilgcc.app.email;
+
+import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getFamilySubmissionDataForEmails;
+
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.email.templates.AutomatedProviderOutreachEmailTemplate;
+import org.ilgcc.jobs.SendEmailJob;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SendAutomatedProviderOutreachEmail extends SendEmail {
+
+    @Autowired
+    public SendAutomatedProviderOutreachEmail(SendEmailJob sendEmailJob,
+            MessageSource messageSource,
+            SubmissionRepositoryService submissionRepositoryService) {
+        super(sendEmailJob, messageSource, submissionRepositoryService, "providerOutreachEmailSent", "familyIntendedProviderEmail");
+    }
+
+    @Override
+    protected ILGCCEmailTemplate emailTemplate(Map<String, Object> emailData) {
+        return new AutomatedProviderOutreachEmailTemplate(emailData,
+                messageSource,
+                locale).createTemplate();
+    }
+
+    @Override
+    protected Optional<Map<String, Object>> getEmailData(Submission familySubmission) {
+        return Optional.of(getFamilySubmissionDataForEmails(familySubmission));
+    }
+
+}

--- a/src/main/java/org/ilgcc/app/email/SendProviderConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendProviderConfirmationEmail.java
@@ -31,7 +31,7 @@ public class SendProviderConfirmationEmail extends SendEmail {
     protected ILGCCEmailTemplate emailTemplate(Map<String, Object> emailData) {
         return new ProviderConfirmationEmailTemplate(emailData,
                 messageSource,
-                locale).createTemplate();
+                locale.ENGLISH).createTemplate();
     }
 
     @Override

--- a/src/main/java/org/ilgcc/app/email/templates/AutomatedProviderOutreachEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/AutomatedProviderOutreachEmailTemplate.java
@@ -1,0 +1,59 @@
+package org.ilgcc.app.email.templates;
+
+import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import java.util.Locale;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.ilgcc.app.email.ILGCCEmail;
+import org.ilgcc.app.email.ILGCCEmail.EmailType;
+import org.ilgcc.app.email.ILGCCEmailTemplate;
+import org.springframework.context.MessageSource;
+
+@Getter
+@Setter
+public class AutomatedProviderOutreachEmailTemplate {
+
+    private Map<String, Object> emailData;
+    private MessageSource messageSource;
+    private Locale locale;
+
+    public AutomatedProviderOutreachEmailTemplate(Map<String, Object> emailData, MessageSource messageSource, Locale locale) {
+       this.emailData = emailData;
+       this.messageSource = messageSource;
+       this.locale = locale;
+
+   }
+   public ILGCCEmailTemplate createTemplate(){
+       return new ILGCCEmailTemplate(senderEmail(), setSubject(), new Content("text/html", setBodyCopy(emailData)), EmailType.AUTOMATED_PROVIDER_OUTREACH_EMAIL);
+   }
+
+    private Email senderEmail() {
+        return  new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale));
+    }
+
+    private String setSubject() {
+        return messageSource.getMessage("email.automated-provider-outreach.subject", null,
+                locale);
+    }
+
+    private String setBodyCopy(Map<String, Object> emailData) {
+        String p1 = messageSource.getMessage("email.automated-provider-outreach.p1", null,
+                locale);
+        String p2 = messageSource.getMessage("email.automated-provider-outreach.p2", new Object[]{emailData.get("confirmationCode")}, locale);
+        String p3 = messageSource.getMessage("email.automated-provider-outreach.p3", new Object[]{emailData.get("shareableLink")}, locale);
+        String p4 = messageSource.getMessage("email.automated-provider-outreach.p4",
+                null, locale);
+        String p5 = messageSource.getMessage("email.automated-provider-outreach.p5",
+                new Object[]{emailData.get("ccrrName")},
+                locale);
+        String p6 = messageSource.getMessage("email.automated-provider-outreach.p6", null, locale);
+        String p7 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
+        String p8 = messageSource.getMessage("email.general.footer.cfa", null, locale);
+        return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8;
+    }
+
+}

--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -645,6 +645,8 @@ public class Gcc extends FlowInputs {
     @NotEmpty(message = "{errors.submit-contact-method}")
     private List<String> contactProviderMethod;
 
+    private String hasConfirmedIntendedProviderEmail;
+
     // complete-submit-confirmation
     private String surveyDifficulty;
     private String surveyAdditionalComments;

--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -652,6 +652,8 @@ public class Gcc extends FlowInputs {
 
     private String familyConfirmationEmailSent;
 
+    private String providerOutreachEmailSent;
+
     // Stores the Response status (Active, Expired, Responded) of the provider application
     private String providerApplicationResponseStatus;
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmail.java
@@ -9,14 +9,15 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class SendAutomatedProviderEmailAndFormatSubmittedAtDate implements Action {
+public class SendAutomatedProviderEmail implements Action {
 
     @Autowired
     SendAutomatedProviderOutreachEmail sendAutomatedProviderOutreachEmail;
 
     @Override
     public void run(Submission familySubmission) {
-        new FormatSubmittedAtDate().run(familySubmission);
-        sendAutomatedProviderOutreachEmail.send(familySubmission);
+        if (familySubmission.getInputData().get("hasConfirmedIntendedProviderEmail").equals("true")) {
+            sendAutomatedProviderOutreachEmail.send(familySubmission);
+        }
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmailAndFormatSubmittedAtDate.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmailAndFormatSubmittedAtDate.java
@@ -1,0 +1,22 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.email.SendAutomatedProviderOutreachEmail;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SendAutomatedProviderEmailAndFormatSubmittedAtDate implements Action {
+
+    @Autowired
+    SendAutomatedProviderOutreachEmail sendAutomatedProviderOutreachEmail;
+
+    @Override
+    public void run(Submission familySubmission) {
+        new FormatSubmittedAtDate().run(familySubmission);
+        sendAutomatedProviderOutreachEmail.send(familySubmission);
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/hasConfirmedProviderEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/hasConfirmedProviderEmail.java
@@ -1,0 +1,13 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+@Component
+public class hasConfirmedProviderEmail extends BasicCondition {
+
+    @Override
+    public Boolean run(Submission submission) {
+        return run(submission, "hasConfirmedIntendedProviderEmail", "true");
+    }
+}

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -118,6 +118,8 @@ public class ProviderSubmissionUtilities {
         applicationData.put("shareableLink", familySubmission.getInputData().getOrDefault("shareableLink", ""));
         applicationData.put("familyIntendedProviderName",
                 familySubmission.getInputData().getOrDefault("familyIntendedProviderName", ""));
+        applicationData.put("familyIntendedProviderEmail",
+                familySubmission.getInputData().getOrDefault("familyIntendedProviderEmail", ""));
         applicationData.put("submittedDate", SubmissionUtilities.getFormattedSubmittedAtDate(familySubmission));
         applicationData.put("ccapStartDate", ProviderSubmissionUtilities.getCCAPStartDateFromProviderOrFamilyChildcareStartDate(familySubmission,
                 Optional.empty()));

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -489,7 +489,7 @@ flow:
     nextScreens:
       - name: submit-confirm-provider-email
   submit-contact-provider-email-confirmation:
-    beforeDisplayAction: SendAutomatedProviderEmailAndFormatSubmittedAtDate
+    beforeDisplayAction: FormatSubmittedAtDate
     condition: EnableProviderMessagingFlagOn
     nextScreens:
       - name: submit-contact-provider-text

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -489,7 +489,7 @@ flow:
     nextScreens:
       - name: submit-confirm-provider-email
   submit-contact-provider-email-confirmation:
-    beforeDisplayAction: FormatSubmittedAtDate
+    beforeDisplayAction: SendAutomatedProviderEmailAndFormatSubmittedAtDate
     condition: EnableProviderMessagingFlagOn
     nextScreens:
       - name: submit-contact-provider-text

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -482,8 +482,11 @@ flow:
       - name: submit-confirm-provider-email
   submit-confirm-provider-email:
     condition: ContactProviderViaEmail
+    afterSaveAction: SendAutomatedProviderEmail
     nextScreens:
       - name: submit-contact-provider-email-confirmation
+        condition: hasConfirmedProviderEmail
+      - name: submit-edit-provider-email
   submit-edit-provider-email:
     condition: EnableProviderMessagingFlagOn
     nextScreens:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -133,6 +133,15 @@ email.family-confirmation.review-without-a-child-care-provider=<p><strong>Your a
 email.family-confirmation.a-staff-member=<p>A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact <strong>{0}: <a href="tel:{1}">{1}</a></strong></p>
 email.family-confirmation.you-will-receive=<p>You will receive a letter or email about the status of your case within 13-15 business days.</p>
 
+# AUTOMATED_PROVIDER_OUTREACH_EMAIL
+email.automated-provider-outreach.subject=[Action Required] New CCAP application
+email.automated-provider-outreach.p1=<p>Hello,</p>
+email.automated-provider-outreach.p2=<p>A family just submitted a Child Care Assistance Program (CCAP) application online and listed you as their child care provider. The confirmation code is: {0}</p>
+email.automated-provider-outreach.p3=<p><strong>Click this secure link to view child care details and complete your part of the application within 3 business days: <a href="{0}" target="_blank">{0}</a></p></strong>
+email.automated-provider-outreach.p4=<p>The sooner you respond, the sooner you can get paid.</p>
+email.automated-provider-outreach.p5=<p>If you don''t respond, the application will be submitted to {0} after 3 business days.</p>
+email.automated-provider-outreach.p6=<p>Thank you!</p>
+
 # PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
 email.response-email-for-family.provider-agrees.subject=[CCAP update] Application submitted
 email.response-email-for-family.provider-agrees.p1=<p>Hello,</p>
@@ -1718,11 +1727,7 @@ submit-contact-provider-email-confirmation.subheader=We sent your provider the e
 submit-contact-provider-email-confirmation.email-preview.sent=<strong>Sent:</strong> {0} at {1}
 submit-contact-provider-email-confirmation.email-preview.from=<strong>From:</strong> noreply@getchildcareil.org
 submit-contact-provider-email-confirmation.email-preview.subject=<strong>Subject:</strong> [Action Required] New CCAP application
-submit-contact-provider-email-confirmation.email-preview.body.pt1=Hello,
-submit-contact-provider-email-confirmation.email-preview.body.pt2=A family just submitted a Child Care Assistance Program (CCAP) application online and listed you as their child care provider. The confirmation code is: {0}
 submit-contact-provider-email-confirmation.email-preview.body.pt3=<strong>Click this secure link to view child care details and complete your part of the application within 3 business days: <u>{0}</u></strong>
-submit-contact-provider-email-confirmation.email-preview.body.pt4=The sooner you respond, the sooner you can get paid.
-submit-contact-provider-email-confirmation.email-preview.body.pt5=If you don't respond, the application will be submitted to the CCR&R after 3 business days.
 
 #parent-confirm-provider-number
 parent-confirm-provider-number.title=Confirm provider phone

--- a/src/main/resources/templates/gcc/submit-confirm-provider-email.html
+++ b/src/main/resources/templates/gcc/submit-confirm-provider-email.html
@@ -1,44 +1,22 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}">
-<head th:replace="~{fragments/head :: head(title=#{submit-confirm-provider-email.title})}"></head>
-<body>
-<div class="page-wrapper">
-    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-    <section class="slab">
-        <div class="grid">
-            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
-                <th:block th:replace="~{fragments/gcc-icons :: application-search}"></th:block>
-                <th:block
-                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-confirm-provider-email.header})}"/>
-                <div class="form-card__content">
-                    <div class="grid__item address-validation spacing-below-60">
-                        <div class="display-box-green "
-                             id="email-entered-label">
-                            <p><strong th:text="#{submit-confirm-provider-email.body}"></strong></p>
-                            <div th:text="${submission.getInputData().get('familyIntendedProviderEmail')}"></div>
-                        </div>
-
-                    </div>
-                </div>
-                <div class="form-card__footer">
-                    <a aria-describedby="header"
-                       th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'"
-                       class="button button--secondary" id="confirmed-provider-email">
-                        <span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>
-                        <span th:text="#{general.inputs.yes}"></span>
-                    </a>
-                    <a aria-describedby="header"
-                       th:href="'/flow/' + ${flow} + '/submit-edit-provider-email'"
-                       class="button button--secondary" id="edit-provider-email">
-                        <span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>
-                        <span th:text="#{general.inputs.no}"></span>
-                    </a>
-                </div>
-            </main>
-        </div>
-    </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block
+  th:replace="~{fragments/screens/screenWithOneInput ::
+  screenWithOneInput(
+    title=#{submit-confirm-provider-email.title},
+    header=#{submit-confirm-provider-email.header},
+    iconFragment=~{fragments/gcc-icons :: application-search},
+    formAction=${formAction},
+    inputContent=~{::inputContent})}">
+  <th:block th:ref="inputContent">
+      <label th:for="email-entered"
+             class="radio-button is-selected"
+             style="padding-left: 2.5rem; word-break: break-word;"
+             id="email-entered-label">
+          <p th:text="#{submit-confirm-provider-email.body}"></p>
+          <div th:text="${submission.getInputData().get('familyIntendedProviderEmail')}"></div>
+      </label>
+      <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+        inputName='hasConfirmedIntendedProviderEmail',
+        ariaDescribe='header'
+       )}"/>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/gcc/submit-confirm-provider-email.html
+++ b/src/main/resources/templates/gcc/submit-confirm-provider-email.html
@@ -1,22 +1,36 @@
-<th:block
-  th:replace="~{fragments/screens/screenWithOneInput ::
-  screenWithOneInput(
-    title=#{submit-confirm-provider-email.title},
-    header=#{submit-confirm-provider-email.header},
-    iconFragment=~{fragments/gcc-icons :: application-search},
-    formAction=${formAction},
-    inputContent=~{::inputContent})}">
-  <th:block th:ref="inputContent">
-      <label th:for="email-entered"
-             class="radio-button is-selected"
-             style="padding-left: 2.5rem; word-break: break-word;"
-             id="email-entered-label">
-          <p th:text="#{submit-confirm-provider-email.body}"></p>
-          <div th:text="${submission.getInputData().get('familyIntendedProviderEmail')}"></div>
-      </label>
-      <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
-        inputName='hasConfirmedIntendedProviderEmail',
-        ariaDescribe='header'
-       )}"/>
-  </th:block>
-</th:block>
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{submit-confirm-provider-email.title})}"></head>
+<body>
+<div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/gcc-icons :: application-search}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{submit-confirm-provider-email.header})}"/>
+                <th:block
+                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+                    <th:block th:ref="formContent">
+                        <div class="grid__item address-validation spacing-below-60">
+                            <div class="display-box-green "
+                                 id="email-entered-label">
+                                <p><strong th:text="#{submit-confirm-provider-email.body}"></strong>
+                                </p>
+                                <div th:text="${submission.getInputData().get('familyIntendedProviderEmail')}"></div>
+                            </div>
+                        </div>
+                        <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+              inputName='hasConfirmedIntendedProviderEmail',
+              ariaDescribe='header')}"/>
+                    </th:block>
+                </th:block>
+            </main>
+        </div>
+    </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/gcc/submit-contact-provider-email-confirmation.html
+++ b/src/main/resources/templates/gcc/submit-contact-provider-email-confirmation.html
@@ -24,11 +24,11 @@
                 </div>
                 <hr>
                 <div>
-                  <p th:utext="#{submit-contact-provider-email-confirmation.email-preview.body.pt1}"></p>
-                  <p th:utext="#{submit-contact-provider-email-confirmation.email-preview.body.pt2(${submission.getShortCode()})}"></p>
+                  <p th:utext="#{email.automated-provider-outreach.p1}"></p>
+                  <p th:utext="#{email.automated-provider-outreach.p2(${submission.getShortCode()})}"></p>
                   <p th:utext="#{submit-contact-provider-email-confirmation.email-preview.body.pt3(${submission.getInputData().getOrDefault('shareableLink', '')})}"></p>
-                  <p th:utext="#{submit-contact-provider-email-confirmation.email-preview.body.pt4}"></p>
-                  <p th:utext="#{submit-contact-provider-email-confirmation.email-preview.body.pt5}"></p>
+                  <p th:utext="#{email.automated-provider-outreach.p4}"></p>
+                  <p th:utext="#{email.automated-provider-outreach.p5('the CCR&R')}"></p>
                 </div>
               </div>
             </div>

--- a/src/test/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmailTest.java
@@ -1,0 +1,147 @@
+package org.ilgcc.app.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+
+import com.sendgrid.helpers.mail.objects.Email;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.MessageSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class SendAutomatedProviderOutreachEmailTest {
+
+    @MockitoSpyBean
+    SendEmailJob sendEmailJob;
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+
+    @Autowired
+    MessageSource messageSource;
+
+    private Submission familySubmission;
+
+    private SendAutomatedProviderOutreachEmail sendEmailClass;
+
+    private Locale locale = Locale.ENGLISH;
+
+
+    @BeforeEach
+    void setUp() {
+        familySubmission = new SubmissionTestBuilder()
+                .withFlow("gcc")
+                .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
+                .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
+                .withCCRR()
+                .with("parentContactEmail", "familyemail@test.com")
+                .with("familyIntendedProviderEmail", "provideremail@test.com")
+                .with("shareableLink", "tempEmailLink")
+                .withShortCode("ABC123")
+                .build();
+
+        submissionRepositoryService.save(familySubmission);
+
+        sendEmailClass = new SendAutomatedProviderOutreachEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @Test
+    void correctlySetsEmailRecipient() {
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+        Map<String, Object> emailData = emailDataOptional.get();
+
+        assertThat(sendEmailClass.getRecipientEmail(emailData)).isEqualTo("provideremail@test.com");
+    }
+
+    @Test
+    void correctlySetsEmailData() {
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+
+        assertThat(emailDataOptional.isPresent()).isTrue();
+
+        Map<String, Object> emailData = emailDataOptional.get();
+
+        assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+        assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+        assertThat(emailData.get("familyIntendedProviderEmail")).isEqualTo("provideremail@test.com");
+        assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+        assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+        assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+        assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+        assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+    }
+
+    @Test
+    void correctlySetsEmailTemplateData() {
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+        ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailDataOptional.get());
+
+        assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+        assertThat(emailTemplate.getSubject()).isEqualTo(
+                messageSource.getMessage("email.automated-provider-outreach.subject", null, locale));
+
+        String emailCopy = emailTemplate.getBody().getValue();
+
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p1", null, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p2", new Object[]{"ABC123"}, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p3", new Object[]{"tempEmailLink"},
+                        locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p4", null,
+                        locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.automated-provider-outreach.p5",
+                new Object[]{"Sample Test CCRR"}, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p6", null,
+                        locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+    }
+
+    @Test
+    void correctlyUpdatesEmailSendStatus() {
+        assertThat(familySubmission.getInputData().containsKey("providerOutreachEmailSent")).isFalse();
+        sendEmailClass.send(familySubmission);
+
+        assertThat(familySubmission.getInputData().containsKey("providerOutreachEmailSent")).isTrue();
+        assertThat(familySubmission.getInputData().get("providerOutreachEmailSent")).isEqualTo("true");
+    }
+
+    @Test
+    void correctlySkipsEmailSendWhenEmailStatusIsTrue() {
+        assertThat(sendEmailClass.skipEmailSend(familySubmission)).isFalse();
+
+        familySubmission.getInputData().put("providerOutreachEmailSent", "true");
+        assertThat(sendEmailClass.skipEmailSend(familySubmission)).isTrue();
+    }
+
+    @Test
+    void correctlyEnqueuesSendEmailJob() {
+        sendEmailClass.send(familySubmission);
+        verify(sendEmailJob).enqueueSendEmailJob(any(ILGCCEmail.class));
+    }
+
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-727](https://codeforamerica.atlassian.net/browse/CCAP-727)

#### ✍️ Description
<!-- Brief summary of changes  -->

#### 📷 Design reference
<img width="1176" alt="Screenshot 2025-04-01 at 11 25 39 AM" src="https://github.com/user-attachments/assets/1aadfedb-76ab-4d99-b4a2-6f692c18fdeb" />
<img width="439" alt="Screenshot 2025-04-01 at 11 25 52 AM" src="https://github.com/user-attachments/assets/5e599aba-6a3c-441e-8c28-32a3d7deb375" />


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] The confirmation email is triggered when an applicant clicks “Yes” on the submit-confirm-provider-email screen
The provider notification email should be sent immediately

- [ ] Email Reply and Sender
- The reply to address for the email should be [noreply@getchildcareil.org](mailto:contact@getchildcareil.org)
- The sender address for the email should be [noreply@getchildcareil.org](mailto:noreply@getchildcareil.org)
- The sender name for the email should be Child Care Assistance Program Applications - Code for America on behalf of Illinois Department of Human Services
- The footer of the email must clearly identify Code for America as the sender and the address


[CCAP-727]: https://codeforamerica.atlassian.net/browse/CCAP-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ