### PR TITLE
[CCAP-823] - direct families to next steps when enable provider flag …

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -433,6 +433,8 @@ flow:
   doc-upload-submit-confirmation:
     afterSaveAction: SendUploadedFileToDocumentTransferService
     nextScreens:
+      - name: submit-next-steps
+        condition: EnableProviderMessagingFlagOn
       - name: no-provider-intro
         condition: NoProviderChosen
       - name: contact-provider-intro

--- a/src/main/resources/templates/gcc/doc-upload-recommended-docs.html
+++ b/src/main/resources/templates/gcc/doc-upload-recommended-docs.html
@@ -64,16 +64,23 @@
                         <div class="form-card__footer">
                             <th:block
                                     th:replace="~{fragments/continueButton :: continue(text=#{doc-upload-recommended-docs.submit})}"/>
-                            <div th:with="hasChosenNoProvider=${submission.getInputData().getOrDefault('hasChosenProvider', 'true')}">
-                                <th:block th:unless="${hasChosenNoProvider == 'true'}">
-                                    <a th:href="'/flow/' + ${flow} + '/no-provider-intro'"
+                            <div th:with="hasChosenNoProvider=${submission.getInputData().getOrDefault('hasChosenProvider', 'true')}, enableProviderMessaging=${@environment.getProperty('il-gcc.enable-provider-messaging') == 'true'}">
+                                <th:block th:if="${enableProviderMessaging}">
+                                    <a th:href="'/flow/' + ${flow} + '/submit-next-steps'"
                                        th:text="#{doc-upload-recommended-docs.skip}"
                                        class='button'></a>
                                 </th:block>
-                                <th:block th:if="${hasChosenNoProvider == 'true'}">
-                                 <a th:href="'/flow/' + ${flow} + '/contact-provider-intro'"
-                                   th:text="#{doc-upload-recommended-docs.skip}"
-                                   class='button'></a>
+                                <th:block th:unless="${enableProviderMessaging}">
+                                    <th:block th:unless="${hasChosenNoProvider == 'true'}">
+                                        <a th:href="'/flow/' + ${flow} + '/no-provider-intro'"
+                                           th:text="#{doc-upload-recommended-docs.skip}"
+                                           class='button'></a>
+                                    </th:block>
+                                    <th:block th:if="${hasChosenNoProvider == 'true'}">
+                                        <a th:href="'/flow/' + ${flow} + '/contact-provider-intro'"
+                                           th:text="#{doc-upload-recommended-docs.skip}"
+                                           class='button'></a>
+                                    </th:block>
                                 </th:block>
                             </div>
                         </div>

--- a/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccProviderMessagingFlowJourneyTest.java
@@ -121,7 +121,12 @@ public class GccProviderMessagingFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-share-confirmation-code.title"));
         testPage.clickButton(getEnMessage("general.button.next.submit-documents"));
 
+        // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.skip"));
+
+        // submit-next-steps
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-next-steps.title"));
     }
 
 
@@ -160,6 +165,11 @@ public class GccProviderMessagingFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("after-submit-contact-provider.no-provider.title"));
         testPage.clickContinue();
 
+        // doc-upload-recommended-docs
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("doc-upload-recommended-docs.title"));
+        testPage.clickButton(getEnMessage("doc-upload-recommended-docs.skip"));
+
+        // submit-next-steps
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("submit-next-steps.title"));
     }
 }


### PR DESCRIPTION
…is on

#### 🔗 Jira ticket
[CCAP-823](https://codeforamerica.atlassian.net/browse/CCAP-823)

#### ✍️ Description
- route in provider messaging flow to submit-next-steps. screen

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-823]: https://codeforamerica.atlassian.net/browse/CCAP-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ