### PR TITLE
[CCAP-715] - limit site administered site routing to active sdas

### DIFF
--- a/src/main/java/org/ilgcc/app/data/CCMSDataService.java
+++ b/src/main/java/org/ilgcc/app/data/CCMSDataService.java
@@ -15,6 +15,13 @@ public interface CCMSDataService {
     List<String> getActiveCaseLoadCodes();
 
     /**
+     * Retrieves a list of active SDAs based on active caseload codes
+     *
+     * @return a List<Short> of the Active SDAs
+     */
+    List<Short> getActiveSDAsBasedOnActiveCaseLoadCodes();
+
+    /**
      * Retrieves a county based on the given zip code.
      *
      * @param zipCode the zip code to search for
@@ -42,9 +49,11 @@ public interface CCMSDataService {
      * Retrieves a site administered resource organization associated with a given provider ID.
      *
      * @param providerId the unique identifier of the provider
+     * @param activeSDAs the sdas that are currently active
      * @return an Optional containing the matching resource organization if found, or an empty Optional if not found
      */
-    Optional<ResourceOrganization> getSiteAdministeredResourceOrganizationByProviderId(BigInteger providerId);
+    Optional<ResourceOrganization> getSiteAdministeredResourceOrganizationByProviderId(BigInteger providerId,
+            List<Short> activeSDAs);
 
     /**
      * Retrieves a list of resource organizations based on the given caseload code.

--- a/src/main/java/org/ilgcc/app/data/CCMSDataServiceImpl.java
+++ b/src/main/java/org/ilgcc/app/data/CCMSDataServiceImpl.java
@@ -107,12 +107,15 @@ public class CCMSDataServiceImpl implements CCMSDataService {
 
     @Override
     public List<ResourceOrganization> getActiveResourceOrganizations() {
-        List<String> caseLoadCodes = new ArrayList<>();
-        // allows all sites
-        caseLoadCodes.add("SITE");
-        // limits to only active case load codes
-        caseLoadCodes.addAll(activeCaseLoadCodes);
-        return resourceOrganizationRepository.findAll().stream().filter(t -> caseLoadCodes.contains(t.getCaseloadCode()))
+        return resourceOrganizationRepository.findAll().stream()
+                .filter(t -> {
+                    String code = t.getCaseloadCode();
+                    if ("SITE".equals(code)) {
+                        return getActiveSDAsBasedOnActiveCaseLoadCodes().contains(t.getSda());
+                    } else {
+                        return activeCaseLoadCodes.contains(code);
+                    }
+                })
                 .toList();
     }
 

--- a/src/main/java/org/ilgcc/app/data/CCMSDataServiceImpl.java
+++ b/src/main/java/org/ilgcc/app/data/CCMSDataServiceImpl.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,6 +18,25 @@ public class CCMSDataServiceImpl implements CCMSDataService {
     private final CountyRepository countyRepository;
     private final ResourceOrganizationRepository resourceOrganizationRepository;
     private final List<String> activeCaseLoadCodes;
+
+    private final Map<String, Short> caseLoadCodeToSDA = Map.ofEntries(
+            Map.entry("AA", (short) 1),
+            Map.entry("BB", (short) 2),
+            Map.entry("CC", (short) 3),
+            Map.entry("EE", (short) 4),
+            Map.entry("FF", (short) 5),
+            Map.entry("GG", (short) 6),
+            Map.entry("HH", (short) 7),
+            Map.entry("II", (short) 8),
+            Map.entry("JJ", (short) 9),
+            Map.entry("KK", (short) 10),
+            Map.entry("LL", (short) 11),
+            Map.entry("MM", (short) 12),
+            Map.entry("NN", (short) 13),
+            Map.entry("PP", (short) 14),
+            Map.entry("QQ", (short) 15),
+            Map.entry("RR", (short) 16)
+    );
 
     public CCMSDataServiceImpl(ProviderRepository providerRepository, CountyRepository countyRepository,
             ResourceOrganizationRepository resourceOrganizationRepository,
@@ -35,6 +55,16 @@ public class CCMSDataServiceImpl implements CCMSDataService {
     @Override
     public List<String> getActiveCaseLoadCodes() {
         return activeCaseLoadCodes;
+    }
+
+    @Override
+    public List<Short> getActiveSDAsBasedOnActiveCaseLoadCodes() {
+        List<Short> activeSDAs = new ArrayList<>();
+        activeCaseLoadCodes.stream().forEach(c -> {
+            activeSDAs.add(caseLoadCodeToSDA.get(c));
+        });
+
+        return activeSDAs;
     }
 
     @Override
@@ -65,8 +95,9 @@ public class CCMSDataServiceImpl implements CCMSDataService {
     }
 
     @Override
-    public Optional<ResourceOrganization> getSiteAdministeredResourceOrganizationByProviderId(BigInteger providerId) {
-        return resourceOrganizationRepository.findByProvidersProviderId(providerId);
+    public Optional<ResourceOrganization> getSiteAdministeredResourceOrganizationByProviderId(BigInteger providerId,
+            List<Short> activeSDAs) {
+        return resourceOrganizationRepository.findActiveSiteAdministeredOrgByProviderId(providerId, activeSDAs);
     }
 
     @Override

--- a/src/main/java/org/ilgcc/app/data/ResourceOrganizationRepository.java
+++ b/src/main/java/org/ilgcc/app/data/ResourceOrganizationRepository.java
@@ -4,6 +4,8 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +14,16 @@ public interface ResourceOrganizationRepository extends JpaRepository<ResourceOr
     List<ResourceOrganization> findByCaseloadCode(String caseloadCode);
 
     Optional<ResourceOrganization> findByProvidersProviderId(BigInteger providerId);
+
+    @Query("""
+            SELECT r FROM Provider p
+               JOIN ResourceOrganization r
+               ON p.resourceOrganization = r
+               where r.caseloadCode = 'SITE'
+               and p.providerId = :providerId
+               and r.sda in :activeSDAs
+            """)
+    Optional<ResourceOrganization> findActiveSiteAdministeredOrgByProviderId(@Param("providerId") BigInteger providerId,
+            @Param("activeSDAs") List<Short> activeSDAs);
+
 }

--- a/src/main/java/org/ilgcc/app/data/importer/FakeProviderDataImporter.java
+++ b/src/main/java/org/ilgcc/app/data/importer/FakeProviderDataImporter.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.data.importer;
 
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.data.Provider;
 import org.ilgcc.app.data.ProviderRepository;
@@ -26,142 +27,175 @@ public class FakeProviderDataImporter implements InitializingBean {
     @Autowired
     private ResourceOrganizationRepository resourceOrganizationRepository;
 
+    public static Provider CURRENT_APPROVED_PROVIDER;
+    public static Provider CURRENT_STATUS_R_PROVIDER;
+
+    public static Provider CURRENT_DENIED_PROVIDER;
+
+    public static Provider CURRENT_WITHDRAWN_PROVIDER;
+
+    public static Provider CURRENT_STATUS_C_PROVIDER;
+
+    public static Provider OUTDATED_APPROVED_PROVIDER;
+
+    public static Provider OUTDATED_PENDING_PROVIDER;
+
+    public static Provider ACTIVE_SITE_ADMINISTERED_PROVIDER;
+
+    public static ResourceOrganization ACTIVE_SITE_ADMIN_RESOURCE_ORG;
+
     @Override
     public void afterPropertiesSet() {
         log.info("Starting creating fake provider data.");
-
-        if (!providerRepository.existsById(new BigInteger("12345678901"))) {
-            // Valid date, status A
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678901"));
-            provider.setName("Sample Provider #1");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("A");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(1));
-            providerRepository.save(provider);
+        Optional<Provider> approvedProvider = providerRepository.findById(new BigInteger("12345678901"));
+        if (approvedProvider.isPresent()) {
+            CURRENT_APPROVED_PROVIDER = approvedProvider.get();
+        } else {
+            CURRENT_APPROVED_PROVIDER = new Provider();
+            CURRENT_APPROVED_PROVIDER.setProviderId(new BigInteger("12345678901"));
+            CURRENT_APPROVED_PROVIDER.setName("Sample Provider #1");
+            CURRENT_APPROVED_PROVIDER.setCity("Chicago");
+            CURRENT_APPROVED_PROVIDER.setState("IL");
+            CURRENT_APPROVED_PROVIDER.setZipCode("60613");
+            CURRENT_APPROVED_PROVIDER.setStatus("A");
+            CURRENT_APPROVED_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(1));
+            providerRepository.save(CURRENT_APPROVED_PROVIDER);
         }
 
         if (!providerRepository.existsById(new BigInteger("12345678902"))) {
-            // Valid date, status P
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678902"));
-            provider.setName("Sample Provider #2");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("P");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
-            providerRepository.save(provider);
+            Provider CURRENT_PENDING_PROVIDER = new Provider();
+            CURRENT_PENDING_PROVIDER.setProviderId(new BigInteger("12345678902"));
+            CURRENT_PENDING_PROVIDER.setName("Sample Provider #2");
+            CURRENT_PENDING_PROVIDER.setCity("Chicago");
+            CURRENT_PENDING_PROVIDER.setState("IL");
+            CURRENT_PENDING_PROVIDER.setZipCode("60613");
+            CURRENT_PENDING_PROVIDER.setStatus("P");
+            CURRENT_PENDING_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+            providerRepository.save(CURRENT_PENDING_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678903"))) {
-            // Valid date, status R
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678903"));
-            provider.setName("Sample Provider #3");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("R");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
-            providerRepository.save(provider);
+        Optional<Provider> rStatusProvider = providerRepository.findById(new BigInteger("12345678903"));
+        if (rStatusProvider.isPresent()) {
+            CURRENT_STATUS_R_PROVIDER = rStatusProvider.get();
+        } else {
+            CURRENT_STATUS_R_PROVIDER = new Provider();
+            CURRENT_STATUS_R_PROVIDER.setProviderId(new BigInteger("12345678903"));
+            CURRENT_STATUS_R_PROVIDER.setName("Sample Provider #3");
+            CURRENT_STATUS_R_PROVIDER.setCity("Chicago");
+            CURRENT_STATUS_R_PROVIDER.setState("IL");
+            CURRENT_STATUS_R_PROVIDER.setZipCode("60613");
+            CURRENT_STATUS_R_PROVIDER.setStatus("R");
+            CURRENT_STATUS_R_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+            providerRepository.save(CURRENT_STATUS_R_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678904"))) {
-            // Valid date, status D
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678904"));
-            provider.setName("Sample Provider #4");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("D");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
-            providerRepository.save(provider);
+        Optional<Provider> deniedProvider = providerRepository.findById(new BigInteger("12345678904"));
+        if (deniedProvider.isPresent()) {
+            CURRENT_DENIED_PROVIDER = deniedProvider.get();
+        } else {
+            CURRENT_DENIED_PROVIDER = new Provider();
+            CURRENT_DENIED_PROVIDER.setProviderId(new BigInteger("12345678904"));
+            CURRENT_DENIED_PROVIDER.setName("Sample Provider #4");
+            CURRENT_DENIED_PROVIDER.setCity("Chicago");
+            CURRENT_DENIED_PROVIDER.setState("IL");
+            CURRENT_DENIED_PROVIDER.setZipCode("60613");
+            CURRENT_DENIED_PROVIDER.setStatus("D");
+            CURRENT_DENIED_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+            providerRepository.save(CURRENT_DENIED_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678905"))) {
-            // Valid date, status W
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678905"));
-            provider.setName("Sample Provider #5");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("W");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
-            providerRepository.save(provider);
+        Optional<Provider> withdrawnProvider = providerRepository.findById(new BigInteger("12345678905"));
+        if (withdrawnProvider.isPresent()) {
+            CURRENT_WITHDRAWN_PROVIDER = withdrawnProvider.get();
+        } else {
+            CURRENT_WITHDRAWN_PROVIDER = new Provider();
+            CURRENT_WITHDRAWN_PROVIDER.setProviderId(new BigInteger("12345678905"));
+            CURRENT_WITHDRAWN_PROVIDER.setName("Sample Provider #5");
+            CURRENT_WITHDRAWN_PROVIDER.setCity("Chicago");
+            CURRENT_WITHDRAWN_PROVIDER.setState("IL");
+            CURRENT_WITHDRAWN_PROVIDER.setZipCode("60613");
+            CURRENT_WITHDRAWN_PROVIDER.setStatus("W");
+            CURRENT_WITHDRAWN_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+            providerRepository.save(CURRENT_WITHDRAWN_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678906"))) {
-            // Valid date, status C
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678906"));
-            provider.setName("Sample Provider #6");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("C");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
-            providerRepository.save(provider);
+        Optional<Provider> statusCProvider = providerRepository.findById(new BigInteger("12345678906"));
+        if (statusCProvider.isPresent()) {
+            CURRENT_STATUS_C_PROVIDER = statusCProvider.get();
+        } else {
+            CURRENT_STATUS_C_PROVIDER = new Provider();
+            CURRENT_STATUS_C_PROVIDER.setProviderId(new BigInteger("12345678906"));
+            CURRENT_STATUS_C_PROVIDER.setName("Sample Provider #6");
+            CURRENT_STATUS_C_PROVIDER.setCity("Chicago");
+            CURRENT_STATUS_C_PROVIDER.setState("IL");
+            CURRENT_STATUS_C_PROVIDER.setZipCode("60613");
+            CURRENT_STATUS_C_PROVIDER.setStatus("C");
+            CURRENT_STATUS_C_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+            providerRepository.save(CURRENT_STATUS_C_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678907"))) {
-            // Invalid date, status A
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678907"));
-            provider.setName("Sample Provider #7");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("A");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(4));
-            providerRepository.save(provider);
+        Optional<Provider> outdatedApprovedProvider = providerRepository.findById(new BigInteger("12345678907"));
+        if (outdatedApprovedProvider.isPresent()) {
+            OUTDATED_APPROVED_PROVIDER = outdatedApprovedProvider.get();
+        } else {
+            OUTDATED_APPROVED_PROVIDER = new Provider();
+            OUTDATED_APPROVED_PROVIDER.setProviderId(new BigInteger("12345678907"));
+            OUTDATED_APPROVED_PROVIDER.setName("Sample Provider #7");
+            OUTDATED_APPROVED_PROVIDER.setCity("Chicago");
+            OUTDATED_APPROVED_PROVIDER.setState("IL");
+            OUTDATED_APPROVED_PROVIDER.setZipCode("60613");
+            OUTDATED_APPROVED_PROVIDER.setStatus("A");
+            OUTDATED_APPROVED_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(4));
+            providerRepository.save(OUTDATED_APPROVED_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678908"))) {
-            // Invalid date, status P
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678908"));
-            provider.setName("Sample Provider #8");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("P");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(5));
-            providerRepository.save(provider);
+        Optional<Provider> outdatedPendingProvider = providerRepository.findById(new BigInteger("12345678908"));
+        if (outdatedPendingProvider.isPresent()) {
+            OUTDATED_PENDING_PROVIDER = outdatedPendingProvider.get();
+        } else {
+            OUTDATED_PENDING_PROVIDER = new Provider();
+            OUTDATED_PENDING_PROVIDER.setProviderId(new BigInteger("12345678908"));
+            OUTDATED_PENDING_PROVIDER.setName("Sample Provider #8");
+            OUTDATED_PENDING_PROVIDER.setCity("Chicago");
+            OUTDATED_PENDING_PROVIDER.setState("IL");
+            OUTDATED_PENDING_PROVIDER.setZipCode("60613");
+            OUTDATED_PENDING_PROVIDER.setStatus("P");
+            OUTDATED_PENDING_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(5));
+            providerRepository.save(OUTDATED_PENDING_PROVIDER);
         }
 
-        if (!providerRepository.existsById(new BigInteger("12345678909"))) {
+        Optional<ResourceOrganization> activeResourceOrganization = resourceOrganizationRepository.findById(
+                new BigInteger("10101"));
 
-            ResourceOrganization siteAdminResourceOrganization = null;
-            if (!resourceOrganizationRepository.existsById(new BigInteger("10101"))) {
-                siteAdminResourceOrganization = new ResourceOrganization();
-                siteAdminResourceOrganization.setResourceOrgId(new BigInteger("10101"));
-                siteAdminResourceOrganization.setName("Sample Site Admin Resource Organization");
-                siteAdminResourceOrganization.setPhone("(999) 123-1234");
-                siteAdminResourceOrganization.setCity("Chicago");
-                resourceOrganizationRepository.save(siteAdminResourceOrganization);
-            }
-
-            // Valid date, status W
-            Provider provider = new Provider();
-            provider.setProviderId(new BigInteger("12345678909"));
-            provider.setName("Sample Provider #9");
-            provider.setCity("Chicago");
-            provider.setState("IL");
-            provider.setZipCode("60613");
-            provider.setStatus("W");
-            provider.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
-
-            if (siteAdminResourceOrganization != null) {
-                provider.setResourceOrganization(siteAdminResourceOrganization);
-            }
-
-            providerRepository.save(provider);
+        if (activeResourceOrganization.isPresent()) {
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG = activeResourceOrganization.get();
+        } else {
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG = new ResourceOrganization();
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG.setResourceOrgId(new BigInteger("10101"));
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG.setName("Sample Site Admin Resource Organization");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG.setPhone("(999) 123-1234");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG.setCity("Chicago");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG.setSda((short) 2);
+            resourceOrganizationRepository.save(ACTIVE_SITE_ADMIN_RESOURCE_ORG);
         }
+
+        Optional<Provider> activeSiteAdministeredProvider = providerRepository.findById(new BigInteger("12345678909"));
+
+        if (activeSiteAdministeredProvider.isPresent()) {
+            ACTIVE_SITE_ADMINISTERED_PROVIDER = activeSiteAdministeredProvider.get();
+        } else {
+            ACTIVE_SITE_ADMINISTERED_PROVIDER = new Provider();
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setProviderId(new BigInteger("12345678909"));
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setName("Sample Provider #9");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setCity("Chicago");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setState("IL");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setZipCode("60613");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setStatus("A");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+        }
+
+        ACTIVE_SITE_ADMINISTERED_PROVIDER.setResourceOrganization(ACTIVE_SITE_ADMIN_RESOURCE_ORG);
+        providerRepository.save(ACTIVE_SITE_ADMINISTERED_PROVIDER);
 
         log.info("Completed creating fake provider data.");
     }

--- a/src/main/java/org/ilgcc/app/data/importer/FakeProviderDataImporter.java
+++ b/src/main/java/org/ilgcc/app/data/importer/FakeProviderDataImporter.java
@@ -44,6 +44,10 @@ public class FakeProviderDataImporter implements InitializingBean {
 
     public static ResourceOrganization ACTIVE_SITE_ADMIN_RESOURCE_ORG;
 
+    public static Provider ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA;
+
+    public static ResourceOrganization ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA;
+
     @Override
     public void afterPropertiesSet() {
         log.info("Starting creating fake provider data.");
@@ -174,6 +178,7 @@ public class FakeProviderDataImporter implements InitializingBean {
             ACTIVE_SITE_ADMIN_RESOURCE_ORG.setResourceOrgId(new BigInteger("10101"));
             ACTIVE_SITE_ADMIN_RESOURCE_ORG.setName("Sample Site Admin Resource Organization");
             ACTIVE_SITE_ADMIN_RESOURCE_ORG.setPhone("(999) 123-1234");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG.setCaseloadCode("SITE");
             ACTIVE_SITE_ADMIN_RESOURCE_ORG.setCity("Chicago");
             ACTIVE_SITE_ADMIN_RESOURCE_ORG.setSda((short) 2);
             resourceOrganizationRepository.save(ACTIVE_SITE_ADMIN_RESOURCE_ORG);
@@ -196,6 +201,40 @@ public class FakeProviderDataImporter implements InitializingBean {
 
         ACTIVE_SITE_ADMINISTERED_PROVIDER.setResourceOrganization(ACTIVE_SITE_ADMIN_RESOURCE_ORG);
         providerRepository.save(ACTIVE_SITE_ADMINISTERED_PROVIDER);
+
+        Optional<ResourceOrganization> resourceOrganizationOutsideSDA = resourceOrganizationRepository.findById(
+                new BigInteger("10102"));
+
+        if (resourceOrganizationOutsideSDA.isPresent()) {
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA = activeResourceOrganization.get();
+        } else {
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA = new ResourceOrganization();
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA.setResourceOrgId(new BigInteger("10102"));
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA.setName("Sample Site Admin Resource Organization Outside SDA");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA.setPhone("(999) 123-1234");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA.setCaseloadCode("SITE");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA.setCity("Chicago");
+            ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA.setSda((short) 10);
+            resourceOrganizationRepository.save(ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA);
+        }
+
+        Optional<Provider> activeSiteAdministeredProviderOutOfSDA = providerRepository.findById(new BigInteger("12345678910"));
+
+        if (activeSiteAdministeredProviderOutOfSDA.isPresent()) {
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA = activeSiteAdministeredProviderOutOfSDA.get();
+        } else {
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA = new Provider();
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setProviderId(new BigInteger("12345678910"));
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setName("Site Administered Provider");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setCity("Chicago");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setState("IL");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setZipCode("60613");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setStatus("A");
+            ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setDateOfLastApproval(OffsetDateTime.now().minusYears(2));
+        }
+
+        ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.setResourceOrganization(ACTIVE_SITE_ADMIN_RESOURCE_ORG_OUTSIDE_ACTIVE_SDA);
+        providerRepository.save(ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA);
 
         log.info("Completed creating fake provider data.");
     }

--- a/src/main/java/org/ilgcc/app/submission/router/ApplicationRoutingServiceImpl.java
+++ b/src/main/java/org/ilgcc/app/submission/router/ApplicationRoutingServiceImpl.java
@@ -60,7 +60,7 @@ public class ApplicationRoutingServiceImpl implements ApplicationRouterService {
     @Override
     public Optional<ResourceOrganization> getSiteAdministeredOrganizationByProviderId(BigInteger providerId) {
         return ccmsDataService.getSiteAdministeredResourceOrganizationByProviderId(
-                providerId);
+                providerId, ccmsDataService.getActiveSDAsBasedOnActiveCaseLoadCodes());
     }
 
     @Override

--- a/src/test/java/org/ilgcc/app/data/ProviderAndSiteAdministeredResourceOrganizationTest.java
+++ b/src/test/java/org/ilgcc/app/data/ProviderAndSiteAdministeredResourceOrganizationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * This test class uses providers created in the Database by FakeProviderDataImporter to confirm that the relationship between
@@ -24,6 +25,9 @@ import org.springframework.test.context.ActiveProfiles;
  * the columns are set correctly via manual inspection as well as the programmatic tests.
  */
 @SpringBootTest(classes = IlGCCApplication.class)
+@TestPropertySource(properties = {
+        "ACTIVE_CASELOAD_CODES=BB,QQ",
+})
 @ActiveProfiles("test")
 class ProviderAndSiteAdministeredResourceOrganizationTest {
 

--- a/src/test/java/org/ilgcc/app/data/ProviderAndSiteAdministeredResourceOrganizationTest.java
+++ b/src/test/java/org/ilgcc/app/data/ProviderAndSiteAdministeredResourceOrganizationTest.java
@@ -1,6 +1,9 @@
 package org.ilgcc.app.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMINISTERED_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMIN_RESOURCE_ORG;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_APPROVED_PROVIDER;
 
 import java.math.BigInteger;
 import java.util.Optional;
@@ -32,7 +35,7 @@ class ProviderAndSiteAdministeredResourceOrganizationTest {
 
     @Test
     public void testProviderWithoutSiteAdminResourceOrgLookup() {
-        BigInteger providerId = new BigInteger("12345678901");
+        BigInteger providerId = CURRENT_APPROVED_PROVIDER.getProviderId();
 
         assertThat(providerRepository.existsById(providerId)).isTrue();
 
@@ -49,8 +52,8 @@ class ProviderAndSiteAdministeredResourceOrganizationTest {
 
     @Test
     public void testProviderWithSiteAdminResourceOrgLookup() {
-        BigInteger providerId = new BigInteger("12345678909");
-        BigInteger resourceOrgId = new BigInteger("10101");
+        BigInteger providerId = ACTIVE_SITE_ADMINISTERED_PROVIDER.getProviderId();
+        BigInteger resourceOrgId = ACTIVE_SITE_ADMIN_RESOURCE_ORG.getResourceOrgId();
 
         assertThat(providerRepository.existsById(providerId)).isTrue();
 
@@ -60,8 +63,8 @@ class ProviderAndSiteAdministeredResourceOrganizationTest {
         Provider provider = providerOptional.get();
         assertThat(provider.getResourceOrganization()).isNotNull();
         assertThat(provider.getResourceOrganization().getResourceOrgId().equals(resourceOrgId)).isTrue();
-        assertThat(provider.getResourceOrganization().getName().equals("Sample Site Admin Resource Organization")).isTrue();
-        assertThat(provider.getResourceOrganization().getCity().equals("Chicago")).isTrue();
+        assertThat(provider.getResourceOrganization().getName().equals(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getName())).isTrue();
+        assertThat(provider.getResourceOrganization().getCity().equals(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getCity())).isTrue();
 
         Optional<ResourceOrganization> siteAdminOrgOptional = applicationRouterService.getSiteAdministeredOrganizationByProviderId(
                 providerId);

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseFlowJourneyTest.java
@@ -1,6 +1,13 @@
 package org.ilgcc.app.journeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_APPROVED_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_DENIED_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_STATUS_C_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_STATUS_R_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_WITHDRAWN_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.OUTDATED_APPROVED_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.OUTDATED_PENDING_PROVIDER;
 
 import formflow.library.data.Submission;
 import java.time.OffsetDateTime;
@@ -80,7 +87,7 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
         
         // provider-number
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-number.title"));
-        testPage.enter("providerResponseProviderNumber", "12345678901");
+        testPage.enter("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
 
         // response
@@ -165,7 +172,7 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
 
         // provider-number
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-number.title"));
-        testPage.enter("providerResponseProviderNumber", "12345678901");
+        testPage.enter("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
 
         // response
@@ -318,40 +325,39 @@ public class ProviderresponseFlowJourneyTest extends AbstractBasePageTest {
         testPage.navigateToFlowScreen("providerresponse/provider-number");
         // provider-number
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-number.title"));
-        testPage.enter("providerResponseProviderNumber", "12345678903");
+        testPage.enter("providerResponseProviderNumber", CURRENT_STATUS_R_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
 
         // Errors
-        // Status = R
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("errors.general-title"));
         assertThat(testPage.hasErrorText(getEnMessage("provider-response-provider-number.error.invalid-number"))).isTrue();
 
         // Status = D
-        testPage.enter("providerResponseProviderNumber", "12345678904");
+        testPage.enter("providerResponseProviderNumber", CURRENT_DENIED_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("errors.general-title"));
         assertThat(testPage.hasErrorText(getEnMessage("provider-response-provider-number.error.invalid-number"))).isTrue();
 
         // Status = W
-        testPage.enter("providerResponseProviderNumber", "12345678905");
+        testPage.enter("providerResponseProviderNumber", CURRENT_WITHDRAWN_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("errors.general-title"));
         assertThat(testPage.hasErrorText(getEnMessage("provider-response-provider-number.error.invalid-number"))).isTrue();
 
         // Status = C
-        testPage.enter("providerResponseProviderNumber", "12345678906");
+        testPage.enter("providerResponseProviderNumber", CURRENT_STATUS_C_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("errors.general-title"));
         assertThat(testPage.hasErrorText(getEnMessage("provider-response-provider-number.error.invalid-number"))).isTrue();
 
         // Status = A, 4 years old
-        testPage.enter("providerResponseProviderNumber", "12345678907");
+        testPage.enter("providerResponseProviderNumber", OUTDATED_APPROVED_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("errors.general-title"));
         assertThat(testPage.hasErrorText(getEnMessage("provider-response-provider-number.error.invalid-number"))).isTrue();
 
         // Status = P, 5 years old
-        testPage.enter("providerResponseProviderNumber", "12345678908");
+        testPage.enter("providerResponseProviderNumber", OUTDATED_PENDING_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("errors.general-title"));
         assertThat(testPage.hasErrorText(getEnMessage("provider-response-provider-number.error.invalid-number"))).isTrue();

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderRegistrationJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderRegistrationJourneyTest.java
@@ -1,6 +1,7 @@
 package org.ilgcc.app.journeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_APPROVED_PROVIDER;
 
 import formflow.library.data.Submission;
 import java.time.OffsetDateTime;
@@ -539,7 +540,7 @@ public class ProviderresponseProviderRegistrationJourneyTest extends AbstractBas
 
         //provider-number
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-number.title"));
-        testPage.enter("providerResponseProviderNumber", "12345678901");
+        testPage.enter("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
         testPage.clickContinue();
 
         //response

--- a/src/test/java/org/ilgcc/app/submission/actions/SetResourceOrganizationTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SetResourceOrganizationTest.java
@@ -1,6 +1,9 @@
 package org.ilgcc.app.submission.actions;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMINISTERED_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMIN_RESOURCE_ORG;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_APPROVED_PROVIDER;
 
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
@@ -33,7 +36,7 @@ class SetResourceOrganizationTest {
                 .build();
         submissionRepositoryService.save(familySubmission);
         HashMap<String, Object> providerSubmissionData = new HashMap<>();
-        providerSubmissionData.put("providerResponseProviderNumber", "12345678909");
+        providerSubmissionData.put("providerResponseProviderNumber", ACTIVE_SITE_ADMINISTERED_PROVIDER.getProviderId().toString());
         providerSubmissionData.put("familySubmissionId", familySubmission.getId().toString());
         providerSubmission = Submission.builder()
                 .inputData(providerSubmissionData)
@@ -46,14 +49,14 @@ class SetResourceOrganizationTest {
     void shouldChangeFamilyOrgIdWhenProviderIsSiteAdministered() {
         setResourceOrganization.run(providerSubmission);
         familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();
-        assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo(10101);
-        assertThat(familySubmission.getInputData().get("ccrrName")).isEqualTo("Sample Site Admin Resource Organization");
-        assertThat(familySubmission.getInputData().get("ccrrPhoneNumber")).isEqualTo("(999) 123-1234");
+        assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getResourceOrgId().intValue());
+        assertThat(familySubmission.getInputData().get("ccrrName")).isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getName());
+        assertThat(familySubmission.getInputData().get("ccrrPhoneNumber")).isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getPhone());
     }
 
     @Test
     void shouldNotChangeFamilyOrgIdWhenProviderIsNotSiteAdministered() {
-        providerSubmission.getInputData().put("providerResponseProviderNumber", "12345678901");
+        providerSubmission.getInputData().put("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
         submissionRepositoryService.save(providerSubmission);
         setResourceOrganization.run(providerSubmission);
         familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();

--- a/src/test/java/org/ilgcc/app/submission/actions/SetResourceOrganizationTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SetResourceOrganizationTest.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.submission.actions;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMINISTERED_PROVIDER;
+import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA;
 import static org.ilgcc.app.data.importer.FakeProviderDataImporter.ACTIVE_SITE_ADMIN_RESOURCE_ORG;
 import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_APPROVED_PROVIDER;
 
@@ -9,13 +10,18 @@ import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
 import java.util.HashMap;
 import java.util.Map;
+import org.ilgcc.app.data.ProviderRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+        "ACTIVE_CASELOAD_CODES=BB,QQ",
+})
 @ActiveProfiles("test")
 class SetResourceOrganizationTest {
 
@@ -24,6 +30,9 @@ class SetResourceOrganizationTest {
 
     @Autowired
     SetResourceOrganization setResourceOrganization;
+
+    @Autowired
+    ProviderRepository providerRepository;
 
     Submission familySubmission;
     Submission providerSubmission;
@@ -36,7 +45,8 @@ class SetResourceOrganizationTest {
                 .build();
         submissionRepositoryService.save(familySubmission);
         HashMap<String, Object> providerSubmissionData = new HashMap<>();
-        providerSubmissionData.put("providerResponseProviderNumber", ACTIVE_SITE_ADMINISTERED_PROVIDER.getProviderId().toString());
+        providerSubmissionData.put("providerResponseProviderNumber",
+                ACTIVE_SITE_ADMINISTERED_PROVIDER.getProviderId().toString());
         providerSubmissionData.put("familySubmissionId", familySubmission.getId().toString());
         providerSubmission = Submission.builder()
                 .inputData(providerSubmissionData)
@@ -46,17 +56,31 @@ class SetResourceOrganizationTest {
     }
 
     @Test
-    void shouldChangeFamilyOrgIdWhenProviderIsSiteAdministered() {
+    void shouldChangeFamilyOrgIdWhenProviderIsSiteAdministeredAndSDAIsActive() {
         setResourceOrganization.run(providerSubmission);
         familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();
-        assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getResourceOrgId().intValue());
+        assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo(
+                ACTIVE_SITE_ADMIN_RESOURCE_ORG.getResourceOrgId().intValue());
         assertThat(familySubmission.getInputData().get("ccrrName")).isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getName());
         assertThat(familySubmission.getInputData().get("ccrrPhoneNumber")).isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getPhone());
     }
 
     @Test
+    void shouldNotChangeFamilyOrgIdWhenProviderIsSiteAdministeredAndSDAIsInactive() {
+        providerSubmission.getInputData()
+                .put("providerResponseProviderNumber", ACTIVE_SITE_ADMINISTERED_PROVIDER_OUTSIDE_SDA.getProviderId().toString());
+
+        setResourceOrganization.run(providerSubmission);
+        familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();
+        assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo("testValue");
+        assertThat(familySubmission.getInputData().get("ccrrName")).isEqualTo("CCRR Name");
+        assertThat(familySubmission.getInputData().get("ccrrPhoneNumber")).isEqualTo("(123) 123-1234");
+    }
+
+    @Test
     void shouldNotChangeFamilyOrgIdWhenProviderIsNotSiteAdministered() {
-        providerSubmission.getInputData().put("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
+        providerSubmission.getInputData()
+                .put("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
         submissionRepositoryService.save(providerSubmission);
         setResourceOrganization.run(providerSubmission);
         familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-715](https://codeforamerica.atlassian.net/browse/CCAP-715)

#### ✍️ Description
- Creates a new query that looks for site administered providers in a given set of SDAs
- Creates a method that determines active SDAs based on active caseload codes (active + pending if feature flag is on) set in our ENV
- Limits emails to only site administered SDAs that are active (Out of scope but relevant)
- Updates provider faker to be more human readable
- Updates set Resource organization test

#### 📷 Design reference


#### ✅ Completion tasks
* When a provider responds to an application with a provider id number that is associated with a site administered provider as the processing organization in SDA 2, SDA 6. or SDA 15, then that application should be routed to that site administered provider in CCMS for processing
* When a provider responds to an application with a provider number that is either
** Not associated with a site administered provider
** Associated with a site administered provider in an SDA other than SDA 2, SDA 6, or SDA 15
* then that application should be routed to the relevant CCR&R

####To Test locally
Make sure to update your local SDAs:

https://cfastaff.slack.com/archives/C085NRJ60P7/p1745522550096529


[CCAP-715]: https://codeforamerica.atlassian.net/browse/CCAP-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ