### PR TITLE
[CCAP-812] update content of providerresponse provider number screen

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1332,6 +1332,7 @@ provider-response-provider-number.accordion.document1=CCAP Approval Notice (Form
 provider-response-provider-number.accordion.document2=Child Care Certificate/Certificate Report (Form IL444-3492)
 provider-response-provider-number.accordion.document3=Child Care Certificate Report for centers (Form IL444-3492A)
 provider-response-provider-number.accordion.document4=Monthly Enrollment Report for Site Administered Providers
+provider-response-provider-number.skip-text=I don't have my provider number
 
 #confirmation-code
 provider-response-confirmation-code.title=Confirmation code

--- a/src/main/resources/templates/providerresponse/provider-number.html
+++ b/src/main/resources/templates/providerresponse/provider-number.html
@@ -1,5 +1,6 @@
-<th:block
-  th:replace="~{fragments/inputs/screenWithOneInputAndSkip ::
+<th:block th:with="enableProviderResponseWithFEINFlagISOn = ${@environment.getProperty('il-gcc.enable-provider-response-with-fein') == 'true'}">
+    <th:block
+        th:replace="~{fragments/inputs/screenWithOneInputAndSkip ::
   screenWithOneInputAndSkip(
     title=#{'provider-response-provider-number.title'},
     iconFragment=~{fragments/gcc-icons :: registered-provider},
@@ -8,30 +9,33 @@
     subtext=#{provider-response-provider-number.subtext},
     buttonLabel=#{general.button.continue},
     formAction=${formAction},
+    skipLocation=${enableProviderResponseWithFEINFlagISOn ? 'fein' : null},
+    skipText=${enableProviderResponseWithFEINFlagISOn ? #messages.msg('provider-response-provider-number.skip-text') : null},
     inputContent=~{::inputContent})}">
 
-  <th:block th:ref="inputContent">
-      <div class="spacing-below-60 move-40-up">
-          <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
+        <th:block th:ref="inputContent">
+            <div class="spacing-below-60 move-40-up">
+                <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
             controlId='r1',
             linkLabel=~{::revealLabel1},
             content=~{::revealContent1},
             forceShowContent='false')}">
-              <th:block th:ref="revealLabel1">
-                  <th:span th:text="#{provider-response-provider-number.accordion.title}"></th:span>
-              </th:block>
-              <th:block th:ref="revealContent1">
-                  <p th:text="#{provider-response-provider-number.accordion.intro}"></p>
-                  <ul class="list--bulleted">
-                      <li th:utext="#{provider-response-provider-number.accordion.document1}"></li>
-                      <li th:utext="#{provider-response-provider-number.accordion.document2}"></li>
-                      <li th:utext="#{provider-response-provider-number.accordion.document3}"></li>
-                      <li th:utext="#{provider-response-provider-number.accordion.document4}"></li>
-                  </ul>
-              </th:block>
-          </th:block>
-      </div>
-      <th:block
-              th:replace="~{fragments/inputs/overrides/number :: number(inputName='providerResponseProviderNumber', ariaLabel='header', required='true')}"/>
-  </th:block>
+                    <th:block th:ref="revealLabel1">
+                        <th:span th:text="#{provider-response-provider-number.accordion.title}"></th:span>
+                    </th:block>
+                    <th:block th:ref="revealContent1">
+                        <p th:text="#{provider-response-provider-number.accordion.intro}"></p>
+                        <ul class="list--bulleted">
+                            <li th:utext="#{provider-response-provider-number.accordion.document1}"></li>
+                            <li th:utext="#{provider-response-provider-number.accordion.document2}"></li>
+                            <li th:utext="#{provider-response-provider-number.accordion.document3}"></li>
+                            <li th:utext="#{provider-response-provider-number.accordion.document4}"></li>
+                        </ul>
+                    </th:block>
+                </th:block>
+            </div>
+            <th:block
+                th:replace="~{fragments/inputs/overrides/number :: number(inputName='providerResponseProviderNumber', ariaLabel='header', required='true')}"/>
+        </th:block>
+    </th:block>
 </th:block>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
@@ -24,7 +24,7 @@ public class ProviderresponseProviderResponseWithFEINJourneyTest extends Abstrac
     public void existingProviderBasicflow() {
         testPage.navigateToFlowScreen("gcc/activities-parent-intro");
 
-        Submission s = getSessionSubmissionTestBuilder().withDayCareProvider().withParentDetails()
+        Submission s = submissionRepositoryService.save(getSessionSubmissionTestBuilder().withDayCareProvider().withParentDetails()
             .with("parentPreferredName", "FirstName").withChild("First", "Child", "true")
             .withChild("Second", "Child", "false").withChild("NoAssistance", "Child", "No").withConstantChildcareSchedule(0)
             .with("earliestChildcareStartDate", "10/10/2011").withSubmittedAtDate(OffsetDateTime.now()).build();

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
@@ -29,7 +29,6 @@ public class ProviderresponseProviderResponseWithFEINJourneyTest extends Abstrac
             .withChild("Second", "Child", "false").withChild("NoAssistance", "Child", "No").withConstantChildcareSchedule(0)
             .with("earliestChildcareStartDate", "10/10/2011").withSubmittedAtDate(OffsetDateTime.now()).build());
 
-        s = submissionRepositoryService.save(s);
         submissionRepositoryService.generateAndSetUniqueShortCode(s);
 
         testPage.clickContinue();

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
@@ -1,0 +1,103 @@
+package org.ilgcc.app.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import formflow.library.data.Submission;
+import java.time.OffsetDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@Slf4j
+@TestPropertySource(properties = {"il-gcc.allow-provider-registration-flow=true",
+        "il-gcc.enable-provider-response-with-fein=true"})
+public class ProviderresponseProviderResponseWithFEINJourneyTest extends AbstractBasePageTest {
+
+    @AfterEach
+    protected void clearSubmissions() {
+        super.clearSubmissions();
+    }
+
+    @Test
+    public void existingProviderBasicflow() {
+        testPage.navigateToFlowScreen("gcc/activities-parent-intro");
+
+        Submission s = getSessionSubmissionTestBuilder().withDayCareProvider().withParentDetails()
+            .with("parentPreferredName", "FirstName").withChild("First", "Child", "true")
+            .withChild("Second", "Child", "false").withChild("NoAssistance", "Child", "No").withConstantChildcareSchedule(0)
+            .with("earliestChildcareStartDate", "10/10/2011").withSubmittedAtDate(OffsetDateTime.now()).build();
+
+        s = submissionRepositoryService.save(s);
+        submissionRepositoryService.generateAndSetUniqueShortCode(s);
+
+        testPage.clickContinue();
+
+        driver.navigate().to("http://localhost:%s/s/%s".formatted(localServerPort, s.getShortCode()));
+
+        // submit-start
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-submit-start.title"));
+        testPage.clickButton(getEnMessage("provider-response-submit-start.active.button"));
+
+        // confirmation-code
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-confirmation-code.title"));
+        assertThat(testPage.findElementById("providerResponseFamilyShortCode").getAttribute("value")).isEqualTo(s.getShortCode());
+        testPage.clickContinue();
+
+        // paid-by-ccap
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("paid-by-ccap.title"));
+        testPage.clickYes();
+
+        //provider-info
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-info.title"));
+        testPage.enter("providerResponseBusinessName", "Business Name");
+        testPage.enter("providerResponseFirstName", "First Name");
+        testPage.enter("providerResponseLastName", "Last Name");
+        testPage.clickButton("Continue");
+
+        // service-address
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-service-address.title"));
+        testPage.enter("providerResponseServiceStreetAddress1", "123 Main St");
+        testPage.enter("providerResponseServiceCity", "City");
+        testPage.selectFromDropdown("providerResponseServiceState", "IL - Illinois");
+        testPage.enter("providerResponseServiceZipCode", "12345");
+        testPage.clickButton("Continue");
+
+        // confirm-service-address
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("confirm-address.title"));
+        testPage.clickButton("Use this address");
+
+        //mailing-address
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response.mailing-address.title"));
+        testPage.clickElementById("providerMailingAddressSameAsServiceAddress-yes");
+        testPage.clickContinue();
+
+        //confirm-mailing-address
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("confirm-address.title"));
+        testPage.clickButton("Use this address");
+
+        // contact-info
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-contact-info.title"));
+        testPage.enter("providerResponseContactPhoneNumber", "5555555555");
+        testPage.enter("providerResponseContactEmail", "foo@bar.com");
+        testPage.clickButton("Continue");
+
+        // info-review
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-info-review.title"));
+        assertThat(testPage.findElementTextById("business-name")).isEqualTo("Business Name");
+        assertThat(testPage.findElementTextById("full-name")).isEqualTo("First Name Last Name");
+        assertThat(testPage.findElementTextById("provider-service-street-address-1")).isEqualTo("123 Main St");
+        assertThat(testPage.findElementTextById("provider-service-city-state")).isEqualTo("City, IL");
+        assertThat(testPage.findElementTextById("provider-service-zipcode")).isEqualTo("12345");
+        assertThat(testPage.findElementTextById("phone")).isEqualTo("(555) 555-5555");
+        assertThat(testPage.findElementTextById("email")).isEqualTo("foo@bar.com");
+        testPage.clickButton("Continue");
+
+        //provider-number
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-number.title"));
+        testPage.enter("providerResponseProviderNumber", "12345678901");
+        assertThat(testPage.getElementText("skip-to-fein")).isEqualTo(getEnMessage("provider-response-provider-number.skip-text"));
+        testPage.clickContinue();
+    }
+}

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
@@ -27,7 +27,7 @@ public class ProviderresponseProviderResponseWithFEINJourneyTest extends Abstrac
         Submission s = submissionRepositoryService.save(getSessionSubmissionTestBuilder().withDayCareProvider().withParentDetails()
             .with("parentPreferredName", "FirstName").withChild("First", "Child", "true")
             .withChild("Second", "Child", "false").withChild("NoAssistance", "Child", "No").withConstantChildcareSchedule(0)
-            .with("earliestChildcareStartDate", "10/10/2011").withSubmittedAtDate(OffsetDateTime.now()).build();
+            .with("earliestChildcareStartDate", "10/10/2011").withSubmittedAtDate(OffsetDateTime.now()).build());
 
         s = submissionRepositoryService.save(s);
         submissionRepositoryService.generateAndSetUniqueShortCode(s);


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-812]

#### ✍️ Description
# CCAP-812
## Acceptance criteria

- [ ] The content on the providerresponse/provider-number matches the designs
- [ ] Clicking on the “I don’t have my provider number” link triggers a link click event with a unique element id
- [ ] The new content should only be shown when the enableProviderResponseFein feature flag is enabled

Steps
1.  Examine page to see best process for modifying provider number
2.  Add new message-properties values for the screen
3.  Add skip location input triggered by fein flag.  
4.  Add skip text for `singlescreenwithoneinputandaskip`
5.  Add test for screen when fein flag is on.  check of link to fein scerren is displayed. 
6. Check that acceptance criteria have been met

#### 📷 Design reference
[Figma](https://www.figma.com/design/lGFsTvWwHoOOJ9XQGPFNmu/IL-CCAP-Provider-Experiences?node-id=5593-34586&m=dev)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-812]: https://codeforamerica.atlassian.net/browse/CCAP-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ