### PR TITLE
[CCAP-817][CCAP-818] New emails for family and provider when provider is unidentified

### DIFF
--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -53,6 +53,7 @@ public class ILGCCEmail implements Serializable {
         FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER("No Provider Family Confirmation Email"),
         PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL("Provider Agrees to Care Family Email"),
         PROVIDER_CONFIRMATION_EMAIL("Provider Confirmation Email"),
+        UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL("Unidentified Provider Confirmation Email"),
         PROVIDER_DECLINES_CARE_FAMILY_EMAIL("Provider Declines Care Family Email"),
         PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL("Provider Did Not Respond Family Email"),
         NEW_PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL("New Provider Agrees to Care Family Email"),

--- a/src/main/java/org/ilgcc/app/email/SendUnidentifiedProviderConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendUnidentifiedProviderConfirmationEmail.java
@@ -1,0 +1,53 @@
+package org.ilgcc.app.email;
+
+import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getCombinedDataForEmails;
+
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.email.ILGCCEmail.EmailType;
+import org.ilgcc.app.email.templates.UnidentifiedProviderConfirmationEmailTemplate;
+import org.ilgcc.jobs.SendEmailJob;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SendUnidentifiedProviderConfirmationEmail extends SendEmail {
+
+    @Autowired
+    public SendUnidentifiedProviderConfirmationEmail(SendEmailJob sendEmailJob, MessageSource messageSource,
+            SubmissionRepositoryService submissionRepositoryService) {
+        super(sendEmailJob, messageSource, submissionRepositoryService, "providerConfirmationEmailSent",
+                "providerResponseContactEmail");
+    }
+
+    @Override
+    protected ILGCCEmailTemplate emailTemplate(Map<String, Object> emailData) {
+        return new UnidentifiedProviderConfirmationEmailTemplate(emailData, messageSource, Locale.ENGLISH).createTemplate();
+    }
+
+    @Override
+    protected Optional<Map<String, Object>> getEmailData(Submission providerSubmission) {
+        Optional<Submission> familySubmission = getFamilyApplication(providerSubmission);
+        if (familySubmission.isPresent()) {
+            return Optional.of(getCombinedDataForEmails(providerSubmission, familySubmission.get()));
+        } else {
+            log.warn(
+                    "{}: Skipping email send because there is no family submission associated with the provider submission with ID : {}",
+                    EmailType.UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL.getDescription(), providerSubmission.getId());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    protected Boolean skipEmailSend(Submission submission) {
+        return submission.getInputData().getOrDefault("providerConfirmationEmailSent", "false").equals("true");
+    }
+}
+
+

--- a/src/main/java/org/ilgcc/app/email/templates/UnidentifiedProviderConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/UnidentifiedProviderConfirmationEmailTemplate.java
@@ -1,0 +1,56 @@
+package org.ilgcc.app.email.templates;
+
+import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import java.util.Locale;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.ilgcc.app.email.ILGCCEmail;
+import org.ilgcc.app.email.ILGCCEmail.EmailType;
+import org.ilgcc.app.email.ILGCCEmailTemplate;
+import org.springframework.context.MessageSource;
+
+@Getter
+@Setter
+public class UnidentifiedProviderConfirmationEmailTemplate {
+
+    private Map<String, Object> emailData;
+    private MessageSource messageSource;
+    private Locale locale;
+
+   public UnidentifiedProviderConfirmationEmailTemplate(Map<String, Object> emailData, MessageSource messageSource, Locale locale) {
+       this.emailData = emailData;
+       this.messageSource = messageSource;
+       this.locale = locale;
+
+   }
+   public ILGCCEmailTemplate createTemplate(){
+       return new ILGCCEmailTemplate(senderEmail(), setSubject(emailData), new Content("text/html", setBodyCopy(emailData)), EmailType.UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL);
+   }
+
+    private Email senderEmail() {
+        return  new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale));
+    }
+
+    private String setSubject(Map<String, Object> emailData) {
+        return messageSource.getMessage("email.unidentified-provider-confirmation.subject", null, locale);
+    }
+
+    private String setBodyCopy(Map<String, Object> emailData) {
+        String p1 = messageSource.getMessage("email.unidentified-provider-confirmation.p1", null, locale);
+        String p2 = messageSource.getMessage("email.unidentified-provider-confirmation.p2",
+                new Object[]{emailData.get("ccrrName")}, locale);
+        String p3 = messageSource.getMessage("email.unidentified-provider-confirmation.p3",
+                new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
+        String p4 = messageSource.getMessage("email.unidentified-provider-confirmation.p4", new Object[]{emailData.get("confirmationCode")},
+                locale);
+        String p5 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
+        String p6 = messageSource.getMessage("email.general.footer.cfa", null, locale);
+
+        return p1 + p2 + p3 + p4 + p5 + p6 ;
+    }
+
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SendUnidentifiedProviderAndFamilyConfirmationEmails.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendUnidentifiedProviderAndFamilyConfirmationEmails.java
@@ -1,0 +1,48 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.email.SendProviderDidNotRespondToFamilyEmail;
+import org.ilgcc.app.email.SendUnidentifiedProviderConfirmationEmail;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SendUnidentifiedProviderAndFamilyConfirmationEmails implements Action {
+
+    @Autowired
+    SendProviderDidNotRespondToFamilyEmail sendProviderDidNotRespondToFamilyEmail;
+
+    @Autowired
+    SendUnidentifiedProviderConfirmationEmail sendUnidentifiedProviderConfirmationEmail;
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+
+    @Override
+    public void run(Submission submission) {
+        Optional<UUID> familySubmissionId = ProviderSubmissionUtilities.getFamilySubmissionId(submission);
+        if (familySubmissionId.isPresent()) {
+            Optional<Submission> familySubmission = submissionRepositoryService.findById(familySubmissionId.get());
+            if (familySubmission.isPresent()) {
+                sendProviderDidNotRespondToFamilyEmail.send(familySubmission.get());
+            } else {
+                log.warn(
+                        "Could not find family submission for family submission id {} and provider submission {}. Not sending an unidentified provider email to the family.",
+                        familySubmissionId.get(), submission.getId());
+            }
+        } else {
+            log.warn(
+                    "Could not find family submission id for provider submission {}. Not sending an unidentified provider email to the family.",
+                    submission.getId());
+        }
+
+        sendUnidentifiedProviderConfirmationEmail.send(submission);
+    }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -672,6 +672,7 @@ flow:
     nextScreens: null
   confirm-application-submission-no-response:
     condition: EnableProviderResponseFEIN
+    afterSaveAction: SendUnidentifiedProviderAndFamilyConfirmationEmails
     nextScreens: null
   #New Provider Flow
   registration-start:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -176,6 +176,13 @@ email.provider-confirmation.p4=<p><strong>Confirmation code:</strong> {0}</p>
 email.provider-confirmation.p5=<p><strong>Next steps:</strong> You will receive a letter or email about the status of the family''s application within 13-15 business days. If you want an update on the application, call <strong>{0} at <a href="tel:{1}">{1}</a></strong>.</p>
 email.new-provider-confirmation.note=<p><strong>Note about provider registration:</strong> Since this is your first time getting child care assistance payments, {0} may need:<ul class="list--bulleted"><li>You and others in your household to complete background checks or trainings</li><li>Extra papers to prove your information</li></ul></p>
 
+# UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL
+email.unidentified-provider-confirmation.subject=[Action Required] Call to respond to child care request
+email.unidentified-provider-confirmation.p1=<p>Hello,</p>
+email.unidentified-provider-confirmation.p2=<p>The family application you''ve been listed on was submitted for processing without your complete information. You need to call your CCR&R, <strong>{0}</strong>, to get more details about the family''s child care request in order to respond.</p>
+email.unidentified-provider-confirmation.p3=<p><strong>Next steps:</strong> Call <strong>{0}</strong>: <a href="tel:{1}">{1}</a></strong> to complete your part of the application.</p>
+email.unidentified-provider-confirmation.p4=<p><strong>Confirmation code:</strong> {0}</p>
+
 # AUTOMATED_NEW_APPLICATIONS_EMAIL
 email.automated-new-applications.subject= ({1}) CCAP Applications - {0} - Online Summary
 email.automated-new-applications.header1=<h2>Child Care Assistance Program Online Application Summary - {0}</h2>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -180,7 +180,7 @@ email.new-provider-confirmation.note=<p><strong>Note about provider registration
 email.unidentified-provider-confirmation.subject=[Action Required] Call to respond to child care request
 email.unidentified-provider-confirmation.p1=<p>Hello,</p>
 email.unidentified-provider-confirmation.p2=<p>The family application you''ve been listed on was submitted for processing without your complete information. You need to call your CCR&R, <strong>{0}</strong>, to get more details about the family''s child care request in order to respond.</p>
-email.unidentified-provider-confirmation.p3=<p><strong>Next steps:</strong> Call <strong>{0}</strong>: <a href="tel:{1}">{1}</a></strong> to complete your part of the application.</p>
+email.unidentified-provider-confirmation.p3=<p><strong>Next steps:</strong> Call <strong>{0}</strong>: <strong><a href="tel:{1}">{1}</a></strong> to complete your part of the application.</p>
 email.unidentified-provider-confirmation.p4=<p><strong>Confirmation code:</strong> {0}</p>
 
 # AUTOMATED_NEW_APPLICATIONS_EMAIL

--- a/src/test/java/org/ilgcc/app/email/DailyNewApplicationsProviderEmailTemplateTest.java
+++ b/src/test/java/org/ilgcc/app/email/DailyNewApplicationsProviderEmailTemplateTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,18 +38,20 @@ public class DailyNewApplicationsProviderEmailTemplateTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission familySubmission;
 
     private SendAutomatedProviderOutreachEmail sendEmailClass;
 
-    private Locale locale = Locale.ENGLISH;
-
+    private final Locale locale = Locale.ENGLISH;
 
     @BeforeEach
     void setUp() {
-        familySubmission = new SubmissionTestBuilder()
+        familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
@@ -56,11 +60,14 @@ public class DailyNewApplicationsProviderEmailTemplateTest {
                 .with("familyIntendedProviderEmail", "provideremail@test.com")
                 .with("shareableLink", "tempEmailLink")
                 .withShortCode("ABC123")
-                .build();
-
-        submissionRepositoryService.save(familySubmission);
+                .build());
 
         sendEmailClass = new SendAutomatedProviderOutreachEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationEmailTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,18 +38,21 @@ public class SendFamilyConfirmationEmailTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission familySubmission;
 
     private SendFamilyConfirmationEmail sendEmailClass;
 
-    private Locale locale = Locale.ENGLISH;
+    private final Locale locale = Locale.ENGLISH;
 
 
     @BeforeEach
     void setUp() {
-        familySubmission = new SubmissionTestBuilder()
+        familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
@@ -55,11 +60,14 @@ public class SendFamilyConfirmationEmailTest {
                 .with("parentContactEmail", "familyemail@test.com")
                 .with("shareableLink", "tempEmailLink")
                 .withShortCode("ABC123")
-                .build();
-
-        submissionRepositoryService.save(familySubmission);
+                .build());
 
         sendEmailClass = new SendFamilyConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationNoProviderEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationNoProviderEmailTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,18 +38,21 @@ public class SendFamilyConfirmationNoProviderEmailTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission familySubmission;
 
     private SendFamilyConfirmationNoProviderEmail sendEmailClass;
 
-    private Locale locale = Locale.ENGLISH;
+    private final Locale locale = Locale.ENGLISH;
 
 
     @BeforeEach
     void setUp() {
-        familySubmission = new SubmissionTestBuilder()
+        familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
@@ -55,11 +60,14 @@ public class SendFamilyConfirmationNoProviderEmailTest {
                 .with("parentContactEmail", "familyemail@test.com")
                 .with("shareableLink", "tempEmailLink")
                 .withShortCode("ABC123")
-                .build();
-
-        submissionRepositoryService.save(familySubmission);
+                .build());
 
         sendEmailClass = new SendFamilyConfirmationNoProviderEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/ilgcc/app/email/SendNewProviderAgreesToCareFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendNewProviderAgreesToCareFamilyConfirmationEmailTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +37,9 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission providerSubmission;
@@ -46,7 +51,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
 
     @BeforeEach
     void setUp() {
-        Submission familySubmission = new SubmissionTestBuilder()
+        Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .with("parentContactEmail", "familyemail@test.com")
@@ -54,11 +59,9 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
                 .withSubmittedAtDate(OffsetDateTime.now())
                 .withCCRR()
                 .withShortCode("ABC123")
-                .build();
+                .build());
 
-        submissionRepositoryService.save(familySubmission);
-
-        providerSubmission = new SubmissionTestBuilder()
+        providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("providerresponse")
                 .with("familySubmissionId", familySubmission.getId().toString())
                 .with("providerResponseContactEmail", "provideremail@test.com")
@@ -67,12 +70,15 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
                 .with("providerResponseBusinessName", "BusinessName")
                 .with("providerCareStartDate", "01/10/2025")
                 .with("providerResponseAgreeToCare", "true")
-                .build();
-
-        submissionRepositoryService.save(providerSubmission);
+                .build());
 
         sendEmailClass = new SendNewProviderAgreesToCareFamilyConfirmationEmail(sendEmailJob, messageSource,
                 submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/ilgcc/app/email/SendProviderAgreesToCareFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendProviderAgreesToCareFamilyConfirmationEmailTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,20 +37,21 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission providerSubmission;
 
-    private Submission familySubmission;
-
     private SendProviderAgreesToCareFamilyConfirmationEmail sendEmailClass;
 
-    private Locale locale = Locale.ENGLISH;
+    private final Locale locale = Locale.ENGLISH;
 
 
     @BeforeEach
     void setUp() {
-        familySubmission = new SubmissionTestBuilder()
+        Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .with("parentContactEmail", "familyemail@test.com")
@@ -56,11 +59,9 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
                 .withSubmittedAtDate(OffsetDateTime.now())
                 .withCCRR()
                 .withShortCode("ABC123")
-                .build();
+                .build());
 
-        submissionRepositoryService.save(familySubmission);
-
-        providerSubmission = new SubmissionTestBuilder()
+        providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("providerresponse")
                 .with("familySubmissionId", familySubmission.getId().toString())
                 .with("providerResponseContactEmail", "provideremail@test.com")
@@ -69,13 +70,17 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
                 .with("providerResponseBusinessName", "BusinessName")
                 .with("providerCareStartDate", "01/10/2025")
                 .with("providerResponseAgreeToCare", "true")
-                .build();
-
-        submissionRepositoryService.save(providerSubmission);
+                .build());
 
         sendEmailClass = new SendProviderAgreesToCareFamilyConfirmationEmail(sendEmailJob, messageSource,
                 submissionRepositoryService);
     }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
+    }
+
 
     @Test
     void correctlySetsEmailRecipient() {

--- a/src/test/java/org/ilgcc/app/email/SendProviderConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendProviderConfirmationEmailTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,30 +37,29 @@ public class SendProviderConfirmationEmailTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission providerSubmission;
 
-    private Submission familySubmission;
-
     private SendProviderConfirmationEmail sendEmailClass;
 
-    private Locale locale = Locale.ENGLISH;
+    private final Locale locale = Locale.ENGLISH;
 
 
     @BeforeEach
     void setUp() {
-        familySubmission = new SubmissionTestBuilder()
+        Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentPreferredName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .withSubmittedAtDate(OffsetDateTime.now())
                 .withCCRR()
                 .withShortCode("ABC123")
-                .build();
+                .build());
 
-        submissionRepositoryService.save(familySubmission);
-
-        providerSubmission = new SubmissionTestBuilder()
+        providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("providerresponse")
                 .with("familySubmissionId", familySubmission.getId().toString())
                 .with("providerResponseContactEmail", "provideremail@test.com")
@@ -67,11 +68,14 @@ public class SendProviderConfirmationEmailTest {
                 .with("providerResponseBusinessName", "BusinessName")
                 .with("providerCareStartDate", "01/10/2025")
                 .with("providerResponseAgreeToCare", "true")
-                .build();
-
-        submissionRepositoryService.save(providerSubmission);
+                .build());
 
         sendEmailClass = new SendProviderConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/ilgcc/app/email/SendProviderDidNotRespondToFamilyEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendProviderDidNotRespondToFamilyEmailTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sendgrid.helpers.mail.objects.Email;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.util.Locale;
@@ -14,6 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,18 +36,20 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
     SubmissionRepositoryService submissionRepositoryService;
 
     @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
     MessageSource messageSource;
 
     private Submission familySubmission;
 
     private SendProviderDidNotRespondToFamilyEmail sendEmailClass;
 
-    private Locale locale = Locale.ENGLISH;
-
+    private final Locale locale = Locale.ENGLISH;
 
     @BeforeEach
     void setUp() {
-        familySubmission = new SubmissionTestBuilder()
+        familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
                 .withFlow("gcc")
                 .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
                 .with("parentContactEmail", "familyemail@test.com")
@@ -54,11 +58,14 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                 .withSubmittedAtDate(OffsetDateTime.now())
                 .withCCRR()
                 .withShortCode("ABC123")
-                .build();
-
-        submissionRepositoryService.save(familySubmission);
+                .build());
 
         sendEmailClass = new SendProviderDidNotRespondToFamilyEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/ilgcc/app/email/SendUnidentifiedProviderConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendUnidentifiedProviderConfirmationEmailTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @ActiveProfiles("test")
 @SpringBootTest
-public class SendNewProviderConfirmationEmailTest {
+public class SendUnidentifiedProviderConfirmationEmailTest {
 
     @MockitoSpyBean
     SendEmailJob sendEmailJob;
@@ -44,33 +44,24 @@ public class SendNewProviderConfirmationEmailTest {
 
     private Submission providerSubmission;
 
-    private SendNewProviderConfirmationEmail sendEmailClass;
+    private SendUnidentifiedProviderConfirmationEmail sendEmailClass;
 
     private final Locale locale = Locale.ENGLISH;
 
 
     @BeforeEach
     void setUp() {
-        Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
-                .withFlow("gcc")
-                .with("parentPreferredName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
-                .withSubmittedAtDate(OffsetDateTime.now())
-                .withCCRR()
-                .withShortCode("ABC123")
-                .build());
+        Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder().withFlow("gcc").with("parentPreferredName", "FirstName")
+                .withChild("First", "Child", "true").withChild("Second", "Child", "true")
+                .withSubmittedAtDate(OffsetDateTime.now()).withCCRR().withShortCode("ABC123").build());
 
-        providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
-                .withFlow("providerresponse")
+        providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder().withFlow("providerresponse")
                 .with("familySubmissionId", familySubmission.getId().toString())
-                .with("providerResponseContactEmail", "provideremail@test.com")
-                .with("providerResponseFirstName", "ProviderFirst")
-                .with("providerResponseLastName", "ProviderLast")
-                .with("providerResponseBusinessName", "BusinessName")
-                .with("providerCareStartDate", "01/10/2025")
-                .with("providerResponseAgreeToCare", "true")
-                .build());
+                .with("providerResponseContactEmail", "provideremail@test.com").with("providerResponseFirstName", "ProviderFirst")
+                .with("providerResponseLastName", "ProviderLast").with("providerResponseBusinessName", "BusinessName")
+                .with("providerCareStartDate", "01/10/2025").with("providerResponseAgreeToCare", "true").build());
 
-        sendEmailClass = new SendNewProviderConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
+        sendEmailClass = new SendUnidentifiedProviderConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
     }
 
     @AfterEach
@@ -111,24 +102,19 @@ public class SendNewProviderConfirmationEmailTest {
         assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                 new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
         assertThat(emailTemplate.getSubject()).isEqualTo(
-                messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+                messageSource.getMessage("email.unidentified-provider-confirmation.subject", null, locale));
 
         String emailCopy = emailTemplate.getBody().getValue();
 
-        assertThat(emailCopy).contains(messageSource.getMessage("email.provider-confirmation.p1", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.unidentified-provider-confirmation.p1", null, locale));
         assertThat(emailCopy).contains(
-                messageSource.getMessage("email.provider-confirmation.p2", new Object[]{"Sample Test CCRR"},
+                messageSource.getMessage("email.unidentified-provider-confirmation.p2", new Object[]{"Sample Test CCRR"},
                         locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.provider-confirmation.p3",
-                new Object[]{"F.C. and S.C.", "January 10, 2025"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.provider-confirmation.p4",
-                new Object[]{"ABC123"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.provider-confirmation.p5",
-                new Object[]{"Sample Test CCRR", "(603) 555-1244"},
-                locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.new-provider-confirmation.note",
-                new Object[]{"Sample Test CCRR"},
-                locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.unidentified-provider-confirmation.p3",
+                new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.unidentified-provider-confirmation.p4", new Object[]{"ABC123"}, locale));
+
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
     }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-817
https://codeforamerica.atlassian.net/browse/CCAP-818

#### ✍️ Description
Family email is actually the same email as the No Provider Response email per the ticket/talking with Carl. Because this email is traditionally sent from the No Provider Response job, we need to explicitly load the Family submission object based on the provider submission.

Provider email is a new email itself.

PR contains tests, plus refactoring/cleanup of all the other email tests!

#### 📷 Design reference

<img width="864" alt="Screenshot 2025-04-25 at 9 27 18 AM" src="https://github.com/user-attachments/assets/d66ac479-f307-43be-bb9c-544ded8d28a5" />


<img width="856" alt="Screenshot 2025-04-25 at 9 32 00 AM" src="https://github.com/user-attachments/assets/66c8f883-71f5-42cd-83db-952185afe153" />



#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
