### PR TITLE
[CCAP-807] - Update mapping when existing provider declines care

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
@@ -181,8 +181,8 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
 
 
     private String providerResponse(Map<String, Object> providerInputData) {
-        Boolean hasEIN = providerInputData.containsKey("providerTaxIdEIN");
-        Boolean hasProviderNumber = providerInputData.containsKey("providerResponseProviderNumber");
+        boolean hasEIN = providerInputData.containsKey("providerTaxIdEIN");
+        boolean hasProviderNumber = providerInputData.containsKey("providerResponseProviderNumber");
         if (!hasEIN && !hasProviderNumber) {
             return "Unable to identify provider - no response to care arrangement";
         }

--- a/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
@@ -3,7 +3,6 @@ package org.ilgcc.app.pdf;
 import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getProviderApplicationResponseStatus;
 import static org.ilgcc.app.utils.SubmissionUtilities.formatToStringFromLocalDate;
 import static org.ilgcc.app.utils.SubmissionUtilities.hasNotChosenProvider;
-import static org.ilgcc.app.utils.SubmissionUtilities.hasProviderResponse;
 
 import formflow.library.data.Submission;
 import formflow.library.pdf.PdfMap;
@@ -17,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.enums.SubmissionStatus;
 import org.springframework.stereotype.Component;
@@ -29,15 +27,20 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
     Submission providerSubmission;
 
     @Override
-    public Map<String, SubmissionField> prepareSubmissionFields(Submission submission, PdfMap pdfMap) {
-        if (hasNotChosenProvider(submission)) {
-            return prepareNoProviderData(submission.getShortCode());
+    public Map<String, SubmissionField> prepareSubmissionFields(Submission familySubmission, PdfMap pdfMap) {
+        if (hasNotChosenProvider(familySubmission)) {
+            return prepareNoProviderData(familySubmission.getShortCode());
         }
 
-        if (useProviderResponse(submission)) {
+        Optional<Submission> providerSubmissionOptional = getProviderSubmission(familySubmission);
+
+        if (providerSubmissionOptional.isPresent()) {
+            providerSubmission = providerSubmissionOptional.get();
             return prepareProviderResponse();
         } else {
-            return prepareFamilyIntendedProviderData(submission);
+            Optional<SubmissionStatus> submissionStatus = getProviderApplicationResponseStatus(familySubmission);
+            Boolean hasExpired = submissionStatus.isPresent() && submissionStatus.get().equals(SubmissionStatus.EXPIRED);
+            return prepareFamilyIntendedProviderData(familySubmission, hasExpired);
         }
     }
 
@@ -48,7 +51,6 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
         Map<String, Object> providerInputData = providerSubmission.getInputData();
 
         List<String> providerFields = new ArrayList<>(Arrays.asList(
-                "providerResponseProviderNumber",
                 "providerResponseFirstName",
                 "providerResponseLastName",
                 "providerResponseBusinessName",
@@ -57,6 +59,7 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
                 "providerConviction",
                 "providerConvictionExplanation",
                 "providerIdentityCheckDateOfBirthDate",
+                "providerResponseProviderNumber",
                 "providerTaxIdEIN",
                 "providerResponseServiceStreetAddress1",
                 "providerResponseServiceStreetAddress2",
@@ -70,7 +73,8 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
                 "providerMailingZipCode"
         ));
 
-        for (String fieldName : providerFields) {
+        for (
+                String fieldName : providerFields) {
             results.put(fieldName,
                     new SingleField(fieldName, providerInputData.getOrDefault(fieldName, "").toString(), null));
         }
@@ -78,21 +82,22 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
         Map<String, String> client = (Map<String, String>) providerInputData.getOrDefault("clientResponse",
                 new HashMap<String, String>());
         results.put("clientResponseConfirmationCode", new SingleField("clientResponseConfirmationCode",
-                (String) client.getOrDefault("clientResponseConfirmationCode", ""), null));
+                client.getOrDefault("clientResponseConfirmationCode", ""), null));
 
         results.put("providerLicenseNumber",
                 new SingleField("providerLicenseNumber", providerLicense(providerInputData), null));
-
         results.put("providerSignature",
                 new SingleField("providerSignature", providerSignature(providerInputData), null));
         results.put("providerSignatureDate",
                 new SingleField("providerSignatureDate", providerSignatureDate(providerSubmission.getSubmittedAt()),
                         null));
+        results.put("providerResponse", new SingleField("providerResponse", providerResponse(providerInputData), null));
 
         return results;
     }
 
-    private Map<String, SubmissionField> prepareFamilyIntendedProviderData(Submission submission) {
+    private Map<String, SubmissionField> prepareFamilyIntendedProviderData(Submission submission,
+            Boolean providerApplicationExpired) {
         var results = new HashMap<String, SubmissionField>();
         Map<String, Object> inputData = submission.getInputData();
 
@@ -104,11 +109,14 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
                         inputData.getOrDefault("familyIntendedProviderPhoneNumber", "").toString(), null));
         results.put("providerEmail",
                 new SingleField("providerEmail", inputData.getOrDefault("familyIntendedProviderEmail", "").toString(), null));
-        results.put("providerResponse",
-                new SingleField("providerResponse", providerResponse(submission), null));
 
         results.put("clientResponseConfirmationCode", new SingleField("clientResponseConfirmationCode",
                 submission.getShortCode(), null));
+
+        if (providerApplicationExpired) {
+            results.put("providerResponse",
+                    new SingleField("providerResponse", "No response from provider", null));
+        }
 
         return results;
     }
@@ -171,36 +179,13 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
 
     }
 
-    private boolean useProviderResponse(Submission familySubmission) {
-        Optional<Submission> providerSubmissionOptional = getProviderSubmission(familySubmission);
-        if (providerSubmissionOptional.isPresent()) {
-            providerSubmission = providerSubmissionOptional.get();
-            Map<String, Object> providerInputData = providerSubmission.getInputData();
-            if (providerInputData.containsKey("providerResponseAgreeToCare")) {
-                return providerInputData.get("providerResponseAgreeToCare").equals("true");
-            }
 
-            return true;
-        }
-        return false;
-    }
-
-    private String providerResponse(Submission familySubmission) {
-        if (hasProviderResponse(familySubmission)) {
-            Map<String, Object> providerInputData = providerSubmission.getInputData();
-            if (providerInputData.containsKey("providerResponseAgreeToCare")) {
-                if (providerInputData.get("providerResponseAgreeToCare").equals("false")) {
-                    return "Provider declined";
-                } else {
-                    return "true";
-                }
-            }
+    private String providerResponse(Map<String, Object> providerInputData) {
+        if (providerInputData.get("providerResponseAgreeToCare").equals("false")) {
+            return "Provider declined";
+        } else {
+            return "";
         }
 
-        Optional<SubmissionStatus> submissionStatus = getProviderApplicationResponseStatus(familySubmission);
-        if (submissionStatus.isPresent() && submissionStatus.get().equals(SubmissionStatus.EXPIRED) || ProviderSubmissionUtilities.providerApplicationHasExpired(familySubmission)) {
-            return "No response from provider";
-        }
-        return "";
     }
 }

--- a/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
@@ -181,6 +181,11 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
 
 
     private String providerResponse(Map<String, Object> providerInputData) {
+        Boolean hasEIN = providerInputData.containsKey("providerTaxIdEIN");
+        Boolean hasProviderNumber = providerInputData.containsKey("providerResponseProviderNumber");
+        if (!hasEIN && !hasProviderNumber) {
+            return "Unable to identify provider - no response to care arrangement";
+        }
         if (providerInputData.get("providerResponseAgreeToCare").equals("false")) {
             return "Provider declined";
         } else {

--- a/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import org.ilgcc.app.IlGCCApplication;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.ilgcc.app.utils.enums.SubmissionStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,6 +41,7 @@ public class ProviderApplicationPreparerTest {
                 .with("familyIntendedProviderName", "ProviderName")
                 .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
                 .with("familyIntendedProviderEmail", "mail@test.com")
+                .with("providerApplicationResponseStatus", SubmissionStatus.EXPIRED)
                 .build();
 
         Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
@@ -57,7 +59,7 @@ public class ProviderApplicationPreparerTest {
         assertThat(result.get("dayCareAddressState")).isEqualTo(null);
         assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
     }
-    
+
     @Test
     public void shouldNotMapNoProviderResponseIfSubmissionHasNotExpired() {
         familySubmission = new SubmissionTestBuilder()
@@ -67,11 +69,12 @@ public class ProviderApplicationPreparerTest {
                 .with("familyIntendedProviderName", "ProviderName")
                 .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
                 .with("familyIntendedProviderEmail", "mail@test.com")
+                .with("providerApplicationResponseStatus", SubmissionStatus.ACTIVE)
+
                 .build();
 
         Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
-        assertThat(result.get("providerResponse")).isEqualTo(
-                new SingleField("providerResponse", "", null));
+        assertThat(result.get("providerResponse")).isNull();
     }
 
     @Test
@@ -151,8 +154,8 @@ public class ProviderApplicationPreparerTest {
                 .with("providerResponseServiceStreetAddress1", "123 Main Street")
                 .with("providerResponseServiceCity", "De Kalb")
                 .with("providerResponseServiceState", "IL")
-                .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
                 .with("providerResponseServiceZipCode", "60112")
+                .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
                 .with("providerMailingStreetAddress1", "123 Main Street")
                 .with("providerMailingCity", "De Kalb")
                 .with("providerMailingState", "IL")
@@ -210,11 +213,19 @@ public class ProviderApplicationPreparerTest {
     }
 
     @Test
-    public void mapsFamilyIntendedProviderInfoIfProviderDoesNotAgreeToCare() {
+    public void correctlyMapsDataWhenProviderDoesNotAgreeToCareAndHasValidProviderId() {
         providerSubmission = new SubmissionTestBuilder()
                 .withFlow("providerresponse")
                 .withProviderSubmissionData()
+                .withProviderStateLicense()
+                .with("providerResponseProviderNumber", "12345678901")
+                .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
+                .with("providerMailingStreetAddress1", "123 Main Street")
+                .with("providerMailingCity", "De Kalb")
+                .with("providerMailingState", "IL")
+                .with("providerMailingZipCode", "60112")
                 .with("providerResponseAgreeToCare", "false")
+                .withClientResponseConfirmationCode("testConfirmationCode")
                 .build();
 
         submissionRepositoryService.save(providerSubmission);
@@ -230,24 +241,68 @@ public class ProviderApplicationPreparerTest {
                 .build();
 
         Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
-        assertThat(result.get("providerNameCorporate")).isEqualTo(new SingleField("providerNameCorporate", "ProviderName", null));
-        assertThat(result.get("providerPhoneNumber")).isEqualTo(new SingleField("providerPhoneNumber", "(125) 785-67896", null));
-        assertThat(result.get("providerEmail")).isEqualTo(new SingleField("providerEmail", "mail@test.com", null));
+        assertThat(result.get("providerResponseFirstName")).isEqualTo(
+                new SingleField("providerResponseFirstName", "Provider", null));
+        assertThat(result.get("providerResponseLastName")).isEqualTo(
+                new SingleField("providerResponseLastName", "LastName", null));
+        assertThat(result.get("providerResponseBusinessName")).isEqualTo(
+                new SingleField("providerResponseBusinessName", "DayCare Place", null));
+        assertThat(result.get("providerResponseProviderNumber")).isEqualTo(
+                new SingleField("providerResponseProviderNumber", "12345678901", null));
+
+        assertThat(result.get("providerMailingStreetAddress1")).isEqualTo(
+                new SingleField("providerMailingStreetAddress1", "123 Main Street", null));
+        assertThat(result.get("providerMailingCity")).isEqualTo(
+                new SingleField("providerMailingCity", "De Kalb", null));
+        assertThat(result.get("providerMailingState")).isEqualTo(
+                new SingleField("providerMailingState", "IL", null));
+        assertThat(result.get("providerMailingZipCode")).isEqualTo(
+                new SingleField("providerMailingZipCode", "60112", null));
+
+        assertThat(result.get("providerResponseServiceStreetAddress1")).isEqualTo(
+                new SingleField("providerResponseServiceStreetAddress1", "123 Main St", null));
+        assertThat(result.get("providerResponseServiceStreetAddress2")).isEqualTo(
+                new SingleField("providerResponseServiceStreetAddress2", "Unit 10", null));
+        assertThat(result.get("providerResponseServiceCity")).isEqualTo(
+                new SingleField("providerResponseServiceCity", "DeKalb", null));
+        assertThat(result.get("providerResponseServiceState")).isEqualTo(
+                new SingleField("providerResponseServiceState", "IL", null));
+        assertThat(result.get("providerResponseServiceZipCode")).isEqualTo(
+                new SingleField("providerResponseServiceZipCode", "60112", null));
+
+        assertThat(result.get("providerResponseContactEmail")).isEqualTo(
+                new SingleField("providerResponseContactEmail", "mail@daycareplace.org", null));
+        assertThat(result.get("providerResponseContactPhoneNumber")).isEqualTo(
+                new SingleField("providerResponseContactPhoneNumber", "(111) 222-3333", null));
+
+        assertThat(result.get("providerLicenseNumber")).isEqualTo(
+                new SingleField("providerLicenseNumber", "123453646 (IL)", null));
         assertThat(result.get("providerResponse")).isEqualTo(
                 new SingleField("providerResponse", "Provider declined", null));
 
-        assertThat(result.get("providerResponseFirstName")).isEqualTo(null);
-        assertThat(result.get("providerResponseLastName")).isEqualTo(null);
-        assertThat(result.get("providerResponseBusinessName")).isEqualTo(null);
+        assertThat(result.get("clientResponseConfirmationCode")).isEqualTo(
+                new SingleField("clientResponseConfirmationCode", "testConfirmationCode", null));
+
+        assertThat(result.get("dayCareName")).isEqualTo(null);
+        assertThat(result.get("dayCareIdNumber")).isEqualTo(null);
+        assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
+        assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
     }
 
     @Test
-    public void mapsProviderResponseIfProviderAgreesToCare() {
+    public void correctlyMapsDataProviderAgreesToCareAndHasValidProviderId() {
         providerSubmission = new SubmissionTestBuilder()
                 .withFlow("providerresponse")
                 .withProviderSubmissionData()
                 .withProviderStateLicense()
+                .with("providerResponseProviderNumber", "12345678901")
+                .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
+                .with("providerMailingStreetAddress1", "123 Main Street")
+                .with("providerMailingCity", "De Kalb")
+                .with("providerMailingState", "IL")
+                .with("providerMailingZipCode", "60112")
                 .with("providerResponseAgreeToCare", "true")
+                .withClientResponseConfirmationCode("testConfirmationCode")
                 .build();
 
         submissionRepositoryService.save(providerSubmission);
@@ -270,6 +325,18 @@ public class ProviderApplicationPreparerTest {
                 new SingleField("providerResponseLastName", "LastName", null));
         assertThat(result.get("providerResponseBusinessName")).isEqualTo(
                 new SingleField("providerResponseBusinessName", "DayCare Place", null));
+        assertThat(result.get("providerResponseProviderNumber")).isEqualTo(
+                new SingleField("providerResponseProviderNumber", "12345678901", null));
+
+        assertThat(result.get("providerMailingStreetAddress1")).isEqualTo(
+                new SingleField("providerMailingStreetAddress1", "123 Main Street", null));
+        assertThat(result.get("providerMailingCity")).isEqualTo(
+                new SingleField("providerMailingCity", "De Kalb", null));
+        assertThat(result.get("providerMailingState")).isEqualTo(
+                new SingleField("providerMailingState", "IL", null));
+        assertThat(result.get("providerMailingZipCode")).isEqualTo(
+                new SingleField("providerMailingZipCode", "60112", null));
+
         assertThat(result.get("providerResponseServiceStreetAddress1")).isEqualTo(
                 new SingleField("providerResponseServiceStreetAddress1", "123 Main St", null));
         assertThat(result.get("providerResponseServiceStreetAddress2")).isEqualTo(
@@ -280,44 +347,24 @@ public class ProviderApplicationPreparerTest {
                 new SingleField("providerResponseServiceState", "IL", null));
         assertThat(result.get("providerResponseServiceZipCode")).isEqualTo(
                 new SingleField("providerResponseServiceZipCode", "60112", null));
-        assertThat(result.get("providerResponseContactPhoneNumber")).isEqualTo(
-                new SingleField("providerResponseContactPhoneNumber", "(111) 222-3333", null));
+
         assertThat(result.get("providerResponseContactEmail")).isEqualTo(
                 new SingleField("providerResponseContactEmail", "mail@daycareplace.org", null));
+        assertThat(result.get("providerResponseContactPhoneNumber")).isEqualTo(
+                new SingleField("providerResponseContactPhoneNumber", "(111) 222-3333", null));
+
         assertThat(result.get("providerLicenseNumber")).isEqualTo(
                 new SingleField("providerLicenseNumber", "123453646 (IL)", null));
+
+        assertThat(result.get("clientResponseConfirmationCode")).isEqualTo(
+                new SingleField("clientResponseConfirmationCode", "testConfirmationCode", null));
+
+        assertThat(result.get("providerResponse")).isEqualTo(
+                new SingleField("providerResponse", "", null));
 
         assertThat(result.get("dayCareName")).isEqualTo(null);
         assertThat(result.get("dayCareIdNumber")).isEqualTo(null);
         assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
         assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
     }
-
-    @Test
-    public void mapsApplicantConfirmationCodeToPdf(){
-        providerSubmission = new SubmissionTestBuilder()
-            .withFlow("providerresponse")
-            .withProviderSubmissionData()
-            .withProviderStateLicense()
-            .with("providerResponseAgreeToCare", "true")
-            .withClientResponseConfirmationCode("testConfirmationCode")
-            .build();
-
-        submissionRepositoryService.save(providerSubmission);
-        familySubmission = new SubmissionTestBuilder()
-            .withFlow("gcc")
-            .withDayCareProvider()
-            .withSubmittedAtDate(OffsetDateTime.now())
-            .with("familyIntendedProviderName", "ProviderName")
-            .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
-            .with("familyIntendedProviderEmail", "mail@test.com")
-            .with("providerResponseSubmissionId", providerSubmission.getId())
-
-            .build();
-
-        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
-        assertThat(result.get("clientResponseConfirmationCode")).isEqualTo(new SingleField("clientResponseConfirmationCode", "testConfirmationCode", null));
-
-    }
-
 }

--- a/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
@@ -367,4 +367,81 @@ public class ProviderApplicationPreparerTest {
         assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
         assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
     }
+
+    @Test
+    public void correctlyMapsDataWhenProviderDoesNotHaveValidProviderId() {
+        providerSubmission = new SubmissionTestBuilder()
+                .withFlow("providerresponse")
+                .withProviderSubmissionData()
+                .withProviderStateLicense()
+                .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
+                .with("providerMailingStreetAddress1", "123 Main Street")
+                .with("providerMailingCity", "De Kalb")
+                .with("providerMailingState", "IL")
+                .with("providerMailingZipCode", "60112")
+                .withClientResponseConfirmationCode("testConfirmationCode")
+                .build();
+
+        submissionRepositoryService.save(providerSubmission);
+
+        familySubmission = new SubmissionTestBuilder()
+                .withFlow("gcc")
+                .withDayCareProvider()
+                .withSubmittedAtDate(OffsetDateTime.now())
+                .with("familyIntendedProviderName", "ProviderName")
+                .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
+                .with("familyIntendedProviderEmail", "mail@test.com")
+                .with("providerResponseSubmissionId", providerSubmission.getId())
+
+                .build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
+        assertThat(result.get("providerResponseFirstName")).isEqualTo(
+                new SingleField("providerResponseFirstName", "Provider", null));
+        assertThat(result.get("providerResponseLastName")).isEqualTo(
+                new SingleField("providerResponseLastName", "LastName", null));
+        assertThat(result.get("providerResponseBusinessName")).isEqualTo(
+                new SingleField("providerResponseBusinessName", "DayCare Place", null));
+
+        assertThat(result.get("providerMailingStreetAddress1")).isEqualTo(
+                new SingleField("providerMailingStreetAddress1", "123 Main Street", null));
+        assertThat(result.get("providerMailingCity")).isEqualTo(
+                new SingleField("providerMailingCity", "De Kalb", null));
+        assertThat(result.get("providerMailingState")).isEqualTo(
+                new SingleField("providerMailingState", "IL", null));
+        assertThat(result.get("providerMailingZipCode")).isEqualTo(
+                new SingleField("providerMailingZipCode", "60112", null));
+
+        assertThat(result.get("providerResponseServiceStreetAddress1")).isEqualTo(
+                new SingleField("providerResponseServiceStreetAddress1", "123 Main St", null));
+        assertThat(result.get("providerResponseServiceStreetAddress2")).isEqualTo(
+                new SingleField("providerResponseServiceStreetAddress2", "Unit 10", null));
+        assertThat(result.get("providerResponseServiceCity")).isEqualTo(
+                new SingleField("providerResponseServiceCity", "DeKalb", null));
+        assertThat(result.get("providerResponseServiceState")).isEqualTo(
+                new SingleField("providerResponseServiceState", "IL", null));
+        assertThat(result.get("providerResponseServiceZipCode")).isEqualTo(
+                new SingleField("providerResponseServiceZipCode", "60112", null));
+
+        assertThat(result.get("providerResponseContactEmail")).isEqualTo(
+                new SingleField("providerResponseContactEmail", "mail@daycareplace.org", null));
+        assertThat(result.get("providerResponseContactPhoneNumber")).isEqualTo(
+                new SingleField("providerResponseContactPhoneNumber", "(111) 222-3333", null));
+
+        assertThat(result.get("providerLicenseNumber")).isEqualTo(
+                new SingleField("providerLicenseNumber", "123453646 (IL)", null));
+
+        assertThat(result.get("clientResponseConfirmationCode")).isEqualTo(
+                new SingleField("clientResponseConfirmationCode", "testConfirmationCode", null));
+
+        assertThat(result.get("providerResponse")).isEqualTo(
+                new SingleField("providerResponse", "Unable to identify provider - no response to care arrangement", null));
+
+        assertThat(result.get("dayCareName")).isEqualTo(null);
+        assertThat(result.get("dayCareIdNumber")).isEqualTo(null);
+        assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
+        assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
+    }
+
+
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-807](https://codeforamerica.atlassian.net/browse/CCAP-807)

#### ✍️ Description
- Updates provider logic to set providerResponse as "Provider declined"
- Maps:
providerResponseFirstName
providerResponseLastName
providerResponseBusinessName
providerResponseServiceStreetAddress1
providerResponseServiceStreetAddress2
providerResponseServiceCity
providerResponseServiceState
providerResponseServiceZipCode
providerMailingStreetAddress1
providerMailingStreetAddress2
providerMailingCity
providerMailingState
providerMailingZipCode
providerResponseContactEmail
providerResponseContactPhoneNumber

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [X] Added relevant tests
- [X] Meets acceptance criteria


[CCAP-807]: https://codeforamerica.atlassian.net/browse/CCAP-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ