### PR TITLE
[CCAP-806] - missing provider id and fein for provider response

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
@@ -181,6 +181,11 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
 
 
     private String providerResponse(Map<String, Object> providerInputData) {
+        Boolean hasEIN = providerInputData.containsKey("providerTaxIdEIN");
+        Boolean hasProviderNumber = providerInputData.containsKey("providerResponseProviderNumber");
+        if (!hasEIN && !hasProviderNumber) {
+            return "Unable to identify provider - no response to care arrangement";
+        }
         if (providerInputData.get("providerResponseAgreeToCare").equals("false")) {
             return "Provider declined";
         } else {

--- a/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
@@ -367,4 +367,81 @@ public class ProviderApplicationPreparerTest {
         assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
         assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
     }
+
+    @Test
+    public void correctlyMapsDataWhenProviderDoesNotHaveValidProviderId() {
+        providerSubmission = new SubmissionTestBuilder()
+                .withFlow("providerresponse")
+                .withProviderSubmissionData()
+                .withProviderStateLicense()
+                .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
+                .with("providerMailingStreetAddress1", "123 Main Street")
+                .with("providerMailingCity", "De Kalb")
+                .with("providerMailingState", "IL")
+                .with("providerMailingZipCode", "60112")
+                .withClientResponseConfirmationCode("testConfirmationCode")
+                .build();
+
+        submissionRepositoryService.save(providerSubmission);
+
+        familySubmission = new SubmissionTestBuilder()
+                .withFlow("gcc")
+                .withDayCareProvider()
+                .withSubmittedAtDate(OffsetDateTime.now())
+                .with("familyIntendedProviderName", "ProviderName")
+                .with("familyIntendedProviderPhoneNumber", "(125) 785-67896")
+                .with("familyIntendedProviderEmail", "mail@test.com")
+                .with("providerResponseSubmissionId", providerSubmission.getId())
+
+                .build();
+
+        Map<String, SubmissionField> result = preparer.prepareSubmissionFields(familySubmission, null);
+        assertThat(result.get("providerResponseFirstName")).isEqualTo(
+                new SingleField("providerResponseFirstName", "Provider", null));
+        assertThat(result.get("providerResponseLastName")).isEqualTo(
+                new SingleField("providerResponseLastName", "LastName", null));
+        assertThat(result.get("providerResponseBusinessName")).isEqualTo(
+                new SingleField("providerResponseBusinessName", "DayCare Place", null));
+
+        assertThat(result.get("providerMailingStreetAddress1")).isEqualTo(
+                new SingleField("providerMailingStreetAddress1", "123 Main Street", null));
+        assertThat(result.get("providerMailingCity")).isEqualTo(
+                new SingleField("providerMailingCity", "De Kalb", null));
+        assertThat(result.get("providerMailingState")).isEqualTo(
+                new SingleField("providerMailingState", "IL", null));
+        assertThat(result.get("providerMailingZipCode")).isEqualTo(
+                new SingleField("providerMailingZipCode", "60112", null));
+
+        assertThat(result.get("providerResponseServiceStreetAddress1")).isEqualTo(
+                new SingleField("providerResponseServiceStreetAddress1", "123 Main St", null));
+        assertThat(result.get("providerResponseServiceStreetAddress2")).isEqualTo(
+                new SingleField("providerResponseServiceStreetAddress2", "Unit 10", null));
+        assertThat(result.get("providerResponseServiceCity")).isEqualTo(
+                new SingleField("providerResponseServiceCity", "DeKalb", null));
+        assertThat(result.get("providerResponseServiceState")).isEqualTo(
+                new SingleField("providerResponseServiceState", "IL", null));
+        assertThat(result.get("providerResponseServiceZipCode")).isEqualTo(
+                new SingleField("providerResponseServiceZipCode", "60112", null));
+
+        assertThat(result.get("providerResponseContactEmail")).isEqualTo(
+                new SingleField("providerResponseContactEmail", "mail@daycareplace.org", null));
+        assertThat(result.get("providerResponseContactPhoneNumber")).isEqualTo(
+                new SingleField("providerResponseContactPhoneNumber", "(111) 222-3333", null));
+
+        assertThat(result.get("providerLicenseNumber")).isEqualTo(
+                new SingleField("providerLicenseNumber", "123453646 (IL)", null));
+
+        assertThat(result.get("clientResponseConfirmationCode")).isEqualTo(
+                new SingleField("clientResponseConfirmationCode", "testConfirmationCode", null));
+
+        assertThat(result.get("providerResponse")).isEqualTo(
+                new SingleField("providerResponse", "Unable to identify provider - no response to care arrangement", null));
+
+        assertThat(result.get("dayCareName")).isEqualTo(null);
+        assertThat(result.get("dayCareIdNumber")).isEqualTo(null);
+        assertThat(result.get("dayCareAddressStreet")).isEqualTo(null);
+        assertThat(result.get("dayCareAddressZip")).isEqualTo(null);
+    }
+
+
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-806](https://codeforamerica.atlassian.net/browse/CCAP-806)

#### ✍️ Description
- This work doesn’t need to be protected by enableProviderResponseFein feature flag created in https://codeforamerica.atlassian.net/browse/CCAP-809, but that flag should not be enabled on production until this work is deployed.

- When a provider submits a response without providing either a valid CCMS id number or FEIN, provider response is mapped as "Unable to identify provider - no response to care arrangement"
-- These fields are also mapped
providerResponseFirstName
providerResponseLastName
providerResponseBusinessName
providerResponseServiceStreetAddress1
providerResponseServiceStreetAddress2
providerResponseServiceCity
providerResponseServiceState
providerResponseServiceZipCode
providerMailingStreetAddress1
providerMailingStreetAddress2
providerMailingCity
providerMailingState
providerMailingZipCode
providerResponseContactEmail
providerResponseContactPhoneNumber


#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [X] Added relevant tests
- [X] Meets acceptance criteria


[CCAP-806]: https://codeforamerica.atlassian.net/browse/CCAP-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ