### PR TITLE
[CCAP-813] create new providerresponse fein screen

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -173,5 +173,5 @@ public class Providerresponse extends FlowInputs {
 
     private String providerConfirmationEmailSent;
 
-    private String providerHasFEINOrEIN;
+    private String providerHasFEIN;
 }

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -172,4 +172,6 @@ public class Providerresponse extends FlowInputs {
     private String providerSurveyAdditionalComments;
 
     private String providerConfirmationEmailSent;
+
+    private String providerHasFEINOrEIN;
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/HasFEIN.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/HasFEIN.java
@@ -4,10 +4,10 @@ import formflow.library.data.Submission;
 import org.springframework.stereotype.Component;
 
 @Component
-public class HasFEINOrEIN extends BasicCondition {
+public class HasFEIN extends BasicCondition {
 
     @Override
     public Boolean run(Submission submission) {
-        return run(submission, "providerHasFEINOrEIN", "true");
+        return run(submission, "providerHasFEIN", "true");
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/HasFEINOrEIN.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/HasFEINOrEIN.java
@@ -1,0 +1,13 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HasFEINOrEIN extends BasicCondition {
+
+    @Override
+    public Boolean run(Submission submission) {
+        return run(submission, "providerHasFEINOrEIN", "true");
+    }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -667,6 +667,8 @@ flow:
     condition: EnableProviderResponseFEIN
     nextScreens:
       - name: provider-id-fein
+        condition: HasFEINOrEIN
+      - name: confirm-application-submission-no-response
   provider-id-fein:
     condition: EnableProviderResponseFEIN
     nextScreens: null

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -667,7 +667,7 @@ flow:
     condition: EnableProviderResponseFEIN
     nextScreens:
       - name: provider-id-fein
-        condition: HasFEINOrEIN
+        condition: HasFEIN
       - name: confirm-application-submission-no-response
   provider-id-fein:
     condition: EnableProviderResponseFEIN

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,6 +4,7 @@ general.illinois.state.seal.text=Seal of the State of Illinois
 general.illinois.department.logo.text=Illinois Department of Human Services logo
 general.skip-to-content=Skip to content
 general.skip=Skip
+general.skip.im-not-sure=I'm not sure
 general.inputs.none-of-the-above=None of the above
 general.inputs.male=Male
 general.inputs.female=Female
@@ -1341,6 +1342,14 @@ provider-response-provider-number.accordion.document3=Child Care Certificate Rep
 provider-response-provider-number.accordion.document4=Monthly Enrollment Report for Site Administered Providers
 provider-response-provider-number.skip-text=I don't have my provider number
 
+#provider-response-fein
+provider-response-fein.title=FEIN
+provider-response-fein.header=Do you have a Federal Employer Identification Number (FEIN or EIN)?
+provider-response-fein.reveal-header1=Where can I find this number?
+provider-response-fein.reveal-content.p1=An Employee Identification Number is a nine-digit number that the IRS assigns you for tax purposes.
+provider-response-fein.reveal-content.p2=Not all child care providers will have an EIN.
+provider-response-fein.reveal-content.p3=If you have one, you can find it on  W-2 form, 1099 form, or your business tax returns.
+
 #confirmation-code
 provider-response-confirmation-code.title=Confirmation code
 provider-response-confirmation-code.header=Respond to a family's application
@@ -1425,7 +1434,7 @@ provider-response-submit-complete-final.respond-to-another-app-button=Respond to
 # paid-by-ccap
 paid-by-ccap.title=Paid By CCAP
 paid-by-ccap.header=Have you been paid by the Child Care Assistance Program (CCAP) in the last 2 years?
-paid-by-ccap.im-not-sure=I'm not sure
+
 
 # registration-getting-started
 registration-getting-started.title=Getting started

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -1417,7 +1417,7 @@ provider-response-submit-complete-final.respond-to-another-app-button=Responder 
 # paid-by-ccap
 paid-by-ccap.title=Pagos for CCAP
 paid-by-ccap.header=¿En los últimos dos años, ha recibido pagos del Programa de Asistencia para el Cuidado de Niños (CCAP, por sus siglas en inglés)?
-paid-by-ccap.im-not-sure=No estoy seguro
+general.skip.im-not-sure=No estoy seguro
 
 # registration-getting-started
 registration-getting-started.title=Cómo empezar

--- a/src/main/resources/templates/providerresponse/fein.html
+++ b/src/main/resources/templates/providerresponse/fein.html
@@ -31,7 +31,7 @@
               </div>
               <div>
                 <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
-                  inputName='providerHasFEINOrEIN',
+                  inputName='providerHasFEIN',
                   ariaDescribe='header')}"/>
               </div>
             </div>

--- a/src/main/resources/templates/providerresponse/fein.html
+++ b/src/main/resources/templates/providerresponse/fein.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{provider-response-fein.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -8,14 +8,37 @@
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+        <th:block th:replace="~{fragments/gcc-icons :: documents-search}"></th:block>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{provider-response-fein.header})}"/>
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
-                <!-- Put inputs here -->
+              <div class="spacing-below-60 move-40-up">
+                <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
+            controlId='r1',
+            linkLabel=~{::revealLabel1},
+            content=~{::revealContent1},
+            forceShowContent='false')}">
+                  <th:block th:ref="revealLabel1">
+                    <span th:text="#{provider-response-fein.reveal-header1}"></span>
+                  </th:block>
+                  <th:block th:ref="revealContent1">
+                    <p th:text="#{provider-response-fein.reveal-content.p1}"></p>
+                    <p th:text="#{provider-response-fein.reveal-content.p2}"></p>
+                    <p th:text="#{provider-response-fein.reveal-content.p3}"></p>
+                  </th:block>
+                </th:block>
+              </div>
+              <div>
+                <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+                  inputName='providerHasFEINOrEIN',
+                  ariaDescribe='header')}"/>
+              </div>
             </div>
             <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+              <a href="/flow/providerresponse/confirm-application-submission-no-response"
+                 th:id="not-sure-hasEINOrFEIN-link"
+                 th:text="#{general.skip.im-not-sure}"></a>
             </div>
           </th:block>
         </th:block>

--- a/src/main/resources/templates/providerresponse/paid-by-ccap.html
+++ b/src/main/resources/templates/providerresponse/paid-by-ccap.html
@@ -21,7 +21,7 @@
             <div class="form-card__footer">
               <a href="/flow/providerresponse/registration-start"
                  th:id="not-sure-providerPaidCcap-link"
-                 th:text="#{paid-by-ccap.im-not-sure}"></a>
+                 th:text="#{general.skip.im-not-sure}"></a>
             </div>
           </th:block>
         </th:block>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderResponseWithFEINJourneyTest.java
@@ -97,6 +97,10 @@ public class ProviderresponseProviderResponseWithFEINJourneyTest extends Abstrac
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-provider-number.title"));
         testPage.enter("providerResponseProviderNumber", "12345678901");
         assertThat(testPage.getElementText("skip-to-fein")).isEqualTo(getEnMessage("provider-response-provider-number.skip-text"));
-        testPage.clickContinue();
+        testPage.clickElementById("skip-to-fein");
+
+        //fein
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-fein.title"));
+        assertThat(testPage.getElementText("not-sure-hasEINOrFEIN-link")).isEqualTo(getEnMessage("general.skip.im-not-sure"));
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-813]

#### ✍️ Description
# CCAP-813
## Acceptance criteria

- [ ] The providerresponse/fein screen exists
- [ ] The providerresponse/fein screen matches the designs
- [ ] The providerresponse/fein screen should only be shown when the enableProviderResponseFein feature flag is enabled
- [ ] Clicking “Yes” loads the providerresponse/provider-id-fein screen
- [ ] Clicking the “No” button or the “I’m not sure” link loads the providerresponse/confirm-application-submission-no-response screen

Steps to Complete:
1. Check Fein Screen against figma designs and the content manager
2. Add Fein text to message properties
3. Add icons to match figma
4. Properly link Yes and I'm not sure links to their proper screens
5. Add Journey test to ensure navigation when user selects yes/no or i'm not sure

#### 📷 Design reference
[Figma](https://www.figma.com/design/lGFsTvWwHoOOJ9XQGPFNmu/IL-CCAP-Provider-Experiences?node-id=5593-34525&t=NLwxxYO4buIgWY3b-4)

#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-813]: https://codeforamerica.atlassian.net/browse/CCAP-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ