### PR TITLE
[CCAP-806] - looks for missing ProviderID and FEIN when existing prov…

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderApplicationPreparer.java
@@ -181,16 +181,17 @@ public class ProviderApplicationPreparer extends ProviderSubmissionFieldPreparer
 
 
     private String providerResponse(Map<String, Object> providerInputData) {
+        boolean returningProvider = providerInputData.getOrDefault("providerPaidCcap", "true").toString().equals("true");
         boolean hasEIN = providerInputData.containsKey("providerTaxIdEIN");
         boolean hasProviderNumber = providerInputData.containsKey("providerResponseProviderNumber");
-        if (!hasEIN && !hasProviderNumber) {
-            return "Unable to identify provider - no response to care arrangement";
-        }
         if ("false".equals(providerInputData.get("providerResponseAgreeToCare"))) {
             return "Provider declined";
-        } else {
-            return "";
         }
 
+        if (returningProvider && !hasEIN && !hasProviderNumber) {
+            return "Unable to identify provider - no response to care arrangement";
+        }
+
+        return "";
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsRegistering.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsRegistering.java
@@ -12,7 +12,8 @@ public class ProviderIsRegistering extends BasicCondition {
 
     @Override
     public Boolean run(Submission submission) {
-        boolean providerNotPaidByCCAP = submission.getInputData().getOrDefault("providerPaidCcap", "false").toString().equals("false");
+        // providerPaidCcap doesn't exist when enable provider registration flag is turned off.
+        boolean providerNotPaidByCCAP = submission.getInputData().getOrDefault("providerPaidCcap", "true").toString().equals("false");
 
         return enableProviderRegistration && providerNotPaidByCCAP;
     }

--- a/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderApplicationPreparerTest.java
@@ -375,11 +375,12 @@ public class ProviderApplicationPreparerTest {
     }
 
     @Test
-    public void correctlyMapsDataWhenProviderDoesNotHaveValidProviderId() {
+    public void correctlyMapsDataWhenExistingProviderDoesNotHaveValidProviderId() {
         providerSubmission = new SubmissionTestBuilder()
                 .withFlow("providerresponse")
                 .withProviderSubmissionData()
                 .withProviderStateLicense()
+                .with("providerPaidCcap", "true")
                 .with("providerMailingAddressSameAsServiceAddress[]", List.of("yes"))
                 .with("providerMailingStreetAddress1", "123 Main Street")
                 .with("providerMailingCity", "De Kalb")


### PR DESCRIPTION
…ider

#### 🔗 Jira ticket
[CCAP-806](https://codeforamerica.atlassian.net/browse/CCAP-806)

#### ✍️ Description
- Only maps "Unable to identify provider - no response to care arrangement" when an existing provider cannot provide a valid form of identification

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-806]: https://codeforamerica.atlassian.net/browse/CCAP-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ