### PR TITLE
[CCAP-839] Update Error Prevention for ITIN Fields

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -162,7 +162,7 @@ public class Providerresponse extends FlowInputs {
     private String homeProviderTaxIDselection;
     
     //registration-home-provider-itin
-    @Pattern(regexp = "^$|\\d{9}", message = "{registration-home-provider-itin.error-invalid}")
+    @Pattern(regexp = "^9\\d{2}-\\d{2}-\\d{4}$", message = "{registration-tax-id-itin.error}")
     private String providerITIN;
 
     // registration-signature

--- a/src/main/resources/templates/fragments/inputs/itin.html
+++ b/src/main/resources/templates/fragments/inputs/itin.html
@@ -1,0 +1,38 @@
+<th:block
+    th:fragment="itin"
+    th:with="
+      hasHelpText=${!#strings.isEmpty(helpText)},
+      hasLabel=${!#strings.isEmpty(label)},
+      hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
+      requiredInputsForFlow=${requiredInputs.get(flow)},
+      isRequiredInput=${(requiredInputsForFlow != null && inputName != null && requiredInputsForFlow.getOrDefault(inputName, false)) || (required != null && required)},
+      hasError=${
+        errorMessages != null &&
+        errorMessages.get(inputName) != null &&
+        (#arrays.length(errorMessages.get(inputName)) > 0) }"
+    th:assert="${!#strings.isEmpty(inputName)}, ${hasLabel || hasAriaLabel}">
+  <div th:class="'form-group' + ${(hasError ? ' form-group--error' : '')}">
+    <label th:if="${hasLabel}" th:for="${inputName}" class="form-question">
+      <span th:text="${label}"></span>
+      <span th:if="${isRequiredInput  && !hasAriaLabel}" class="required-input"
+            th:text="#{general.required-field}"></span>
+    </label>
+    <p class="text--help"
+       th:if="${hasHelpText}"
+       th:id="${inputName + '-help-text'}"
+       th:text="${helpText}"></p>
+    <th:block
+        th:if="${hasError}"
+        th:replace="~{fragments/inputError :: validationError(inputName=${inputName})}"></th:block>
+    <input type="text" class="text-input form-width--med ssn-input"
+           th:id="${inputName}"
+           th:name="${inputName}"
+           th:placeholder="${placeholder}"
+           th:attr="
+            aria-describedby=${hasHelpText ? inputName + '-help-text' : ''},
+            aria-labelledby=${hasAriaLabel ? ariaLabel : ''},
+            aria-invalid=${hasError}"
+           th:value="${fieldData.getOrDefault(inputName, '')}"
+           inputmode="numeric">
+  </div>
+</th:block>

--- a/src/main/resources/templates/providerresponse/registration-home-provider-itin.html
+++ b/src/main/resources/templates/providerresponse/registration-home-provider-itin.html
@@ -3,40 +3,42 @@
 <head th:replace="~{fragments/head :: head(title=#{registration-home-provider-itin.title})}"></head>
 <body>
 <div class="page-wrapper">
-    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-    <section class="slab">
-        <div class="grid">
-            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
-                <th:block th:replace="~{fragments/gcc-icons :: social-security}"></th:block>
-                <th:block
-                        th:replace="~{fragments/cardHeaderForSingleInputScreen ::
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/gcc-icons :: social-security}"></th:block>
+        <th:block
+            th:replace="~{fragments/cardHeaderForSingleInputScreen ::
               cardHeaderForSingleInputScreen(header=#{registration-home-provider-itin.header}, required='true')}"/>
+        <th:block
+            th:replace="~{fragments/form :: form(action=${formAction}, content=~{::itinContent})}">
+          <th:block th:ref="itinContent">
+            <th:block th:ref="inputContent">
+              <div class="form-card__content">
                 <th:block
-                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::itinContent})}">
-                    <th:block th:ref="itinContent">
-                        <th:block th:ref="inputContent">
-                            <div class="form-card__content">
-                                <th:block th:replace="~{fragments/inputs/text ::
-                                  text(inputName='providerITIN',
-                                  ariaLabel='header')}" />
-                                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                    th:replace="~{fragments/inputs/itin :: itin(
+                                  inputName='providerITIN',
+                                  ariaLabel='header',
+                                  placeholder='XXX-XX-XXXX')}"/>
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
                                   text=#{general.button.continue})}"/>
-                                <div class="display-flex">
-                                    <div class="spacing-right-10">
-                                        <th:block
-                                                th:replace="~{fragments/icons :: filledLock}"></th:block>
-                                    </div>
-                                    <p class="text--small"
-                                       th:utext="#{registration-home-provider-ssn.secure-footer}"></p>
-                                </div>
-                            </div>
-                        </th:block>
-                    </th:block>
-                </th:block>
-            </main>
-        </div>
-    </section>
+                <div class="display-flex">
+                  <div class="spacing-right-10">
+                    <th:block
+                        th:replace="~{fragments/icons :: filledLock}"></th:block>
+                  </div>
+                  <p class="text--small"
+                     th:utext="#{registration-home-provider-ssn.secure-footer}"></p>
+                </div>
+              </div>
+            </th:block>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
 </body>

--- a/src/main/resources/templates/providerresponse/registration-tax-id-itin.html
+++ b/src/main/resources/templates/providerresponse/registration-tax-id-itin.html
@@ -3,42 +3,44 @@
 <head th:replace="~{fragments/head :: head(title=#{registration-tax-id-itin.title})}"></head>
 <body>
 <div class="page-wrapper">
-    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-    <section class="slab">
-        <div class="grid">
-            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
-                <th:block th:replace="~{fragments/gcc-icons :: social-security}"></th:block>
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/gcc-icons :: social-security}"></th:block>
 
-                <th:block
-                        th:replace="~{fragments/cardHeaderForSingleInputScreen ::
+        <th:block
+            th:replace="~{fragments/cardHeaderForSingleInputScreen ::
               cardHeaderForSingleInputScreen(header=#{registration-tax-id-itin.header}, subtext=#{registration-tax-id-itin.subtext})}"/>
 
+        <th:block
+            th:replace="~{fragments/form :: form(action=${formAction}, content=~{::itinContent})}">
+          <th:block th:ref="itinContent">
+            <th:block th:ref="inputContent">
+              <div class="form-card__content">
                 <th:block
-                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::itinContent})}">
-                    <th:block th:ref="itinContent">
-                        <th:block th:ref="inputContent">
-                            <div class="form-card__content">
-                                <th:block th:replace="~{fragments/inputs/text ::
-                                  text(inputName='providerITIN',
-                                  ariaLabel='header')}" />
-                                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                    th:replace="~{fragments/inputs/itin :: itin(
+                                  inputName='providerITIN',
+                                  ariaLabel='header',
+                                  placeholder='XXX-XX-XXXX')}"/>
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
                                   text=#{general.button.continue})}"/>
-                                <div class="display-flex">
-                                    <div class="spacing-right-10">
-                                        <th:block
-                                                th:replace="~{fragments/icons :: filledLock}"></th:block>
-                                    </div>
-                                    <p class="text--small"
-                                       th:utext="#{registration-home-provider-ssn.secure-footer}"></p>
-                                </div>
-                            </div>
-                        </th:block>
-                    </th:block>
-                </th:block>
-            </main>
-        </div>
-    </section>
+                <div class="display-flex">
+                  <div class="spacing-right-10">
+                    <th:block
+                        th:replace="~{fragments/icons :: filledLock}"></th:block>
+                  </div>
+                  <p class="text--small"
+                     th:utext="#{registration-home-provider-ssn.secure-footer}"></p>
+                </div>
+              </div>
+            </th:block>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
 </body>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderRegistrationWithITINJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderRegistrationWithITINJourneyTest.java
@@ -106,7 +106,11 @@ public class ProviderresponseProviderRegistrationWithITINJourneyTest extends Abs
         testPage.clickContinue();
 
         assertThat(testPage.hasErrorText(getEnMessage("registration-home-provider-itin.error-invalid"))).isTrue();
-        testPage.enter("providerITIN", "123456789");
+        testPage.enter("providerITIN", "123-45-6789");
+        testPage.clickContinue();
+
+        assertThat(testPage.hasErrorText(getEnMessage("registration-tax-id-itin.error"))).isTrue();
+        testPage.enter("providerITIN", "923-45-6781");
         testPage.clickContinue();
 
         // registration-home-provider-dob
@@ -338,8 +342,8 @@ public class ProviderresponseProviderRegistrationWithITINJourneyTest extends Abs
         testPage.enter("providerITIN", "1231425");
         testPage.clickContinue();
 
-        assertThat(testPage.hasErrorText(getEnMessage("registration-home-provider-itin.error-invalid"))).isTrue();
-        testPage.enter("providerITIN", "123456789");
+        assertThat(testPage.hasErrorText(getEnMessage("registration-tax-id-itin.error"))).isTrue();
+        testPage.enter("providerITIN", "923-45-6781");
         testPage.clickContinue();
 
         //registration-service-languages


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-839]

#### ✍️ Description
# CCAP-839

## Acceptance criteria

### Implement error prevention on the ITIN fields on both:
 - [ ] the providerresponse/registration-home-provider-itin screen
 - [ ] the providerresponse/registration-tax-id-itin screen

### The ITIN field will only accept numbers as input, 
- [ ] not letters or special characters
- [ ] The ITIN field will accept a maximum of 9 digits
- [ ] The ITIN field displays a placeholder and input mask with the format XXX-XX-XXXX
- [ ] An ITIN must start with a “9”. If the entered ITIN does not start with a “9”, the application should return an error:
Make sure the ITIN is valid and 9 digits
- [ ] key: registration-tax-id-itin.error

Steps to completion
1. Analyze the itin story and figure out implementation plan
2. We will generate an input fragment similar to the ssn input fragment
3. We will generate a itin pattern that matches the rules for itin numbers 
4. Add fragment to screens getting itin inputs

#### 📷 Design reference

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-839]: https://codeforamerica.atlassian.net/browse/CCAP-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ