### PR TITLE
[CCAP-887][CCAP-888][CCAP-889] Alerting and retry logic for CCMS jobs

### DIFF
--- a/src/main/java/org/ilgcc/jobs/JobRetriesFailedFilter.java
+++ b/src/main/java/org/ilgcc/jobs/JobRetriesFailedFilter.java
@@ -1,8 +1,10 @@
 package org.ilgcc.jobs;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.data.Transaction;
+import org.jetbrains.annotations.NotNull;
 import org.jobrunr.jobs.Job;
 import org.jobrunr.jobs.JobParameter;
 import org.jobrunr.jobs.filters.JobServerFilter;
@@ -14,12 +16,10 @@ import org.springframework.stereotype.Component;
 public class JobRetriesFailedFilter implements JobServerFilter {
     @Override
     public void onFailedAfterRetries(Job job) {
-        if ("Lookup Work Item ID for Transaction".equals(job.getJobName())) {
-            String exceptionMessage = job.getLastJobStateOfType(FailedState.class)
-                    .map(FailedState::getExceptionMessage)
-                    .orElse("Unknown exception occurred");
+        String exceptionMessage = getExceptionMessage(job);
+        List<JobParameter> jobParameters = job.getJobDetails().getJobParameters();
 
-            List<JobParameter> jobParameters = job.getJobDetails().getJobParameters();
+        if ("Lookup Work Item ID for Transaction".equals(job.getJobName())) {
 
             if (jobParameters.isEmpty() || !jobParameters.getFirst().getClassName().equals(Transaction.class.getName())) {
                 log.error("Work item lookup job with ID {} failed and was unable to recover the Transaction parameter. Exception: {}",
@@ -30,6 +30,24 @@ public class JobRetriesFailedFilter implements JobServerFilter {
             Transaction transaction = (Transaction) jobParameters.getFirst().getObject();
             log.error("Work item lookup job with ID {} failed for Transaction ID {} after all retries exhausted. Exception: {}",
                     job.getId(), transaction.getTransactionId(), exceptionMessage);
+        } else if ("Send CCMS Submission Payload".equals(job.getJobName())) {
+
+            if (jobParameters.isEmpty() || !jobParameters.getFirst().getClassName().equals(UUID.class.getName())) {
+                log.error("CCMS Submission job with ID {} failed and was unable to recover the UUID parameter. Exception: {}",
+                        job.getId(), exceptionMessage);
+                return;
+            }
+
+            UUID submissionId = (UUID) jobParameters.getFirst().getObject();
+            log.error("CCMS Submission job with ID {} failed for Submission {} after all retries exhausted. Exception: {}",
+                    job.getId(), submissionId, exceptionMessage);
         }
+    }
+
+    private static @NotNull String getExceptionMessage(Job job) {
+        String exceptionMessage = job.getLastJobStateOfType(FailedState.class)
+                .map(FailedState::getExceptionMessage)
+                .orElse("Unknown exception occurred");
+        return exceptionMessage;
     }
 }

--- a/src/main/java/org/ilgcc/jobs/ProviderResponseRecurringJob.java
+++ b/src/main/java/org/ilgcc/jobs/ProviderResponseRecurringJob.java
@@ -200,7 +200,7 @@ public class ProviderResponseRecurringJob {
                 } else {
                     log.warn(
                             String.format(
-                                    "TransmissionsRecurringJob: The Family and Provider Applications were submitted but they do not have a corresponding transmission or transaction. Check familySubmission: %s",
+                                    "ProviderResponseRecurringJob: The Family and Provider Applications were submitted but they do not have a corresponding transmission or transaction. Check familySubmission: %s",
                                     expiredFamilySubmission.getId()));
                 }
             }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-887
https://codeforamerica.atlassian.net/browse/CCAP-888
https://codeforamerica.atlassian.net/browse/CCAP-889

#### ✍️ Description
This should handle any/all exceptions that occur within the CCMS job, and surface them with the new `log.error` by enhancing the Datadog monitor:

<img width="1108" alt="Screenshot 2025-05-06 at 2 59 33 PM" src="https://github.com/user-attachments/assets/b9460a54-b479-4b66-a7d4-b8bdf7b1c232" />

I also fixed the logging for the No Provider Response job, and adjusted the Datadog monitor there too.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
