### PR TITLE
[CCAP-893] Navigation change for acceptance testing

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -544,7 +544,7 @@ flow:
   providers-intro:
     condition: EnableMultipleProviders
     nextScreens:
-      -  name: providers-chosen
+      - name: providers-chosen
         condition: EnableProviderMessagingFlagOn
       - name: submit-complete
   providers-chosen:

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -545,8 +545,6 @@ flow:
     condition: EnableMultipleProviders
     nextScreens:
       - name: providers-chosen
-        condition: EnableProviderMessagingFlagOn
-      - name: submit-complete
   providers-chosen:
     condition: EnableMultipleProviders
     nextScreens: null

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -544,7 +544,7 @@ flow:
   providers-intro:
     condition: EnableMultipleProviders
     nextScreens:
-      - name: after-submit-contact-provider
+      -  name: providers-chosen
         condition: EnableProviderMessagingFlagOn
       - name: submit-complete
   providers-chosen:

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -130,6 +130,8 @@ flow:
   children-add:
     beforeDisplayAction: RemoveIncompleteChildIterations
     nextScreens:
+      - name: providers-intro
+        condition: EnableMultipleProviders
       - name: activities-parent-intro
   children-info-basic:
     crossFieldValidationAction: ValidateChildBirth
@@ -541,7 +543,10 @@ flow:
       - name: doc-upload-recommended-docs
   providers-intro:
     condition: EnableMultipleProviders
-    nextScreens: null
+    nextScreens:
+      - name: after-submit-contact-provider
+        condition: EnableProviderMessagingFlagOn
+      - name: submit-complete
   providers-chosen:
     condition: EnableMultipleProviders
     nextScreens: null

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -6,7 +6,7 @@ import org.ilgcc.app.utils.AbstractBasePageTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = {"il-gcc.enable-multiple-providers=true"})
+@TestPropertySource(properties = {"il-gcc.enable-multiple-providers=true", "il-gcc.enable-provider-messaging=true"})
 public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
 
     @Test
@@ -16,12 +16,16 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         saveSubmission(getSessionSubmissionTestBuilder()
                 .withParentBasicInfo()
                 .with("familyIntendedProviderName", "ACME Daycare")
+                .withChild("test", "tested", "true")
                 .with("applicationCounty", "LEE")
                 .with("hasChosenProvider", "true")
                 .withShortCode("familyShortCode")
                 .build());
 
-        testPage.navigateToFlowScreen("gcc/providers-intro");
+        testPage.navigateToFlowScreen("gcc/children-add");
+        testPage.clickButton(getEnMessage("children-add.thats-all"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-intro.title-header"));
+        testPage.clickContinue();
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("after-submit-contact-provider.title"));
     }
 }

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -26,6 +26,5 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickButton(getEnMessage("children-add.thats-all"));
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-intro.title-header"));
         testPage.clickContinue();
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("after-submit-contact-provider.title"));
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-892 / CCAP-893

#### ✍️ Description
##### This code changes screen navigation:
-  when the `ENABLE_MULTIPLE_PROVIDERS` feature flag is on the client can reach the `providers-intro` screen from the `chldren-add` screen.  [figma](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=18967-47623&m=dev)  
-  When `ENABLE_MULTIPLE_PROVIDERS` is off you are routed to the `activities-parent-intro` screen.  
##### Once the `providers-intro` screen is reached
-  clicking continue sends you to the `after-submit-contact-provider` if EnableProviderMessaging is on, 
-  if EnableProviderMessaging is off you are routed to the `submit-complete` screen


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
