### PR TITLE
[CCAP-951][CCAP-952] Create new contact-providers-email-address, contact-providers-confirm-email-address screens

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmail.java
@@ -26,8 +26,8 @@ public class SendAutomatedProviderEmail implements Action {
     }
 
     @Override
-    public void run(Submission familySubmission, String id) {
-        Optional<Map<String, Object>> subflow = Optional.of(familySubmission.getSubflowEntryByUuid("contactProviders", id));
+    public void run(Submission familySubmission, String contactProvidersSubflowUUID) {
+        Optional<Map<String, Object>> subflow = Optional.of(familySubmission.getSubflowEntryByUuid("contactProviders", contactProvidersSubflowUUID));
         if ("true".equals(subflow.get().get("hasConfirmedIntendedProviderEmail"))) {
             sendAutomatedProviderOutreachEmail.send(familySubmission);
         }

--- a/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendAutomatedProviderEmail.java
@@ -1,7 +1,11 @@
 package org.ilgcc.app.submission.actions;
 
 import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
 import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.email.SendAutomatedProviderOutreachEmail;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +20,15 @@ public class SendAutomatedProviderEmail implements Action {
 
     @Override
     public void run(Submission familySubmission) {
-        if (familySubmission.getInputData().get("hasConfirmedIntendedProviderEmail").equals("true")) {
+        if ("true".equals(familySubmission.getInputData().get("hasConfirmedIntendedProviderEmail"))) {
+            sendAutomatedProviderOutreachEmail.send(familySubmission);
+        }
+    }
+
+    @Override
+    public void run(Submission familySubmission, String id) {
+        Optional<Map<String, Object>> subflow = Optional.of(familySubmission.getSubflowEntryByUuid("contactProviders", id));
+        if ("true".equals(subflow.get().get("hasConfirmedIntendedProviderEmail"))) {
             sendAutomatedProviderOutreachEmail.send(familySubmission);
         }
     }

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateProviderEmailWhenInputIsPresent.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateProviderEmailWhenInputIsPresent.java
@@ -1,14 +1,11 @@
 package org.ilgcc.app.submission.actions;
 
-
 import static org.ilgcc.app.submission.actions.ValidateProviderEmail.callSendGridAndValidateEmail;
 
 import formflow.library.config.submission.Action;
 import formflow.library.data.FormSubmission;
 import formflow.library.data.Submission;
-import formflow.library.utils.RegexUtils;
 import jakarta.servlet.http.HttpSession;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -24,30 +21,33 @@ import org.springframework.stereotype.Component;
 @Component
 public class ValidateProviderEmailWhenInputIsPresent implements Action {
 
-  private final HttpSession httpSession;
-  @Autowired
-  MessageSource messageSource;
+    private final HttpSession httpSession;
 
-  @Autowired
-  SendGridEmailValidationService sendGridEmailValidationService;
-  private final String INPUT_NAME = "familyIntendedProviderEmail";
+    @Autowired
+    MessageSource messageSource;
 
-  public ValidateProviderEmailWhenInputIsPresent(HttpSession httpSession) {
-    this.httpSession = httpSession;
-  }
-  @Override
-  public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {
+    @Autowired
+    SendGridEmailValidationService sendGridEmailValidationService;
 
-    Locale locale = LocaleContextHolder.getLocale();
-    Map<String, List<String>> errorMessages = new HashMap<>();
-    Map<String, Object> formData = formSubmission.getFormData();
-    String providerEmail = formData.getOrDefault(INPUT_NAME, "").toString();
+    private final String INPUT_NAME = "familyIntendedProviderEmail";
 
-    if (providerEmail.isBlank()){
-      errorMessages.put(INPUT_NAME, List.of(messageSource.getMessage("errors.invalid-email.blank", null, locale)));
+    public ValidateProviderEmailWhenInputIsPresent(HttpSession httpSession) {
+        this.httpSession = httpSession;
     }
 
-    return callSendGridAndValidateEmail(locale, errorMessages, providerEmail, sendGridEmailValidationService, INPUT_NAME,
-        messageSource, httpSession);
-  }
+    @Override
+    public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {
+
+        Locale locale = LocaleContextHolder.getLocale();
+        Map<String, List<String>> errorMessages = new HashMap<>();
+        Map<String, Object> formData = formSubmission.getFormData();
+        String providerEmail = formData.getOrDefault(INPUT_NAME, "").toString();
+
+        if (providerEmail.isBlank()) {
+            errorMessages.put(INPUT_NAME, List.of(messageSource.getMessage("errors.invalid-email.blank", null, locale)));
+        }
+
+        return callSendGridAndValidateEmail(locale, errorMessages, providerEmail, sendGridEmailValidationService, INPUT_NAME,
+                messageSource, httpSession);
+    }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplayContactProvidersEmailScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplayContactProvidersEmailScreen.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class DisplayContactProvidersEmailScreen extends EnableMultipleProviders implements Condition {
 
     @Override
-    public Boolean run(Submission submission) {
+    public Boolean run(Submission submission, String uuid) {
         Map<String, Object> inputData = submission.getInputData();
         return super.run(submission) && SubmissionUtilities.isSelectedAsProviderContactMethod(inputData, "EMAIL")
                 && isMissingProviderEmail(inputData);

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplayContactProvidersEmailScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplayContactProvidersEmailScreen.java
@@ -2,8 +2,8 @@ package org.ilgcc.app.submission.conditions;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
-import java.util.List;
 import java.util.Map;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,15 +12,12 @@ public class DisplayContactProvidersEmailScreen extends EnableMultipleProviders 
     @Override
     public Boolean run(Submission submission) {
         Map<String, Object> inputData = submission.getInputData();
-        return super.run(submission) && selectedEmailAsProviderContactMethod(inputData) && isMissingProviderEmail(inputData);
+        return super.run(submission) && SubmissionUtilities.isSelectedAsProviderContactMethod(inputData, "EMAIL")
+                && isMissingProviderEmail(inputData);
     }
 
     private Boolean isMissingProviderEmail(Map<String, Object> inputData) {
         return inputData.getOrDefault("familyIntendedProviderEmail", "").toString().isBlank();
     }
 
-    private Boolean selectedEmailAsProviderContactMethod(Map<String, Object> inputData) {
-        List<String> contactProviderMethodList = (List<String>) inputData.getOrDefault("contactProviderMethod[]", List.of());
-        return contactProviderMethodList.contains("EMAIL");
-    }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplayContactProvidersEmailScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplayContactProvidersEmailScreen.java
@@ -1,0 +1,26 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DisplayContactProvidersEmailScreen extends EnableMultipleProviders implements Condition {
+
+    @Override
+    public Boolean run(Submission submission) {
+        Map<String, Object> inputData = submission.getInputData();
+        return super.run(submission) && selectedEmailAsProviderContactMethod(inputData) && isMissingProviderEmail(inputData);
+    }
+
+    private Boolean isMissingProviderEmail(Map<String, Object> inputData) {
+        return inputData.getOrDefault("familyIntendedProviderEmail", "").toString().isBlank();
+    }
+
+    private Boolean selectedEmailAsProviderContactMethod(Map<String, Object> inputData) {
+        List<String> contactProviderMethodList = (List<String>) inputData.getOrDefault("contactProviderMethod[]", List.of());
+        return contactProviderMethodList.contains("EMAIL");
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/HasConfirmedProviderEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/HasConfirmedProviderEmail.java
@@ -1,6 +1,8 @@
 package org.ilgcc.app.submission.conditions;
 
 import formflow.library.data.Submission;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,5 +11,11 @@ public class HasConfirmedProviderEmail extends BasicCondition {
     @Override
     public Boolean run(Submission submission) {
         return run(submission, "hasConfirmedIntendedProviderEmail", "true");
+    }
+
+    @Override
+    public Boolean run(Submission submission, String subflowUuid) {
+        Optional<Map<String, Object>> subflow = Optional.of(submission.getSubflowEntryByUuid("contactProviders", subflowUuid));
+        return "true".equals(subflow.get().get("hasConfirmedIntendedProviderEmail"));
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/HasConfirmedProviderEmail.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/HasConfirmedProviderEmail.java
@@ -4,7 +4,7 @@ import formflow.library.data.Submission;
 import org.springframework.stereotype.Component;
 
 @Component
-public class hasConfirmedProviderEmail extends BasicCondition {
+public class HasConfirmedProviderEmail extends BasicCondition {
 
     @Override
     public Boolean run(Submission submission) {

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -511,7 +511,7 @@ flow:
     afterSaveAction: SendAutomatedProviderEmail
     nextScreens:
       - name: submit-contact-provider-email-confirmation
-        condition: hasConfirmedProviderEmail
+        condition: HasConfirmedProviderEmail
       - name: submit-edit-provider-email
   submit-edit-provider-email:
     crossFieldValidationAction: ValidateProviderEmailWhenInputIsPresent
@@ -609,8 +609,11 @@ flow:
       - name: contact-providers-confirm-email-address
   contact-providers-confirm-email-address:
     condition: EnableMultipleProviders
+    afterSaveAction: SendAutomatedProviderEmail
     subflow: contactProviders
     nextScreens:
+      - name: contact-providers-email-sent
+        condition: HasConfirmedProviderEmail
       - name: contact-providers-edit-email
   contact-providers-edit-email:
     condition: EnableMultipleProviders

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -619,7 +619,7 @@ flow:
     condition: EnableMultipleProviders
     subflow: contactProviders
     nextScreens:
-      - name: contact-providers-email-sent
+      - name: contact-providers-confirm-email-address
   contact-providers-email-sent:
     condition: EnableMultipleProviders
     subflow: contactProviders

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -603,6 +603,7 @@ flow:
       - name: contact-providers-email-address
   contact-providers-email-address:
     condition: DisplayContactProvidersEmailScreen
+    crossFieldValidationAction: ValidateProviderEmailWhenInputIsPresent
     subflow: contactProviders
     nextScreens:
       - name: contact-providers-confirm-email-address

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -602,7 +602,7 @@ flow:
     nextScreens:
       - name: contact-providers-email-address
   contact-providers-email-address:
-    condition: EnableMultipleProviders
+    condition: DisplayContactProvidersEmailScreen
     subflow: contactProviders
     nextScreens:
       - name: contact-providers-confirm-email-address

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -617,6 +617,7 @@ flow:
       - name: contact-providers-edit-email
   contact-providers-edit-email:
     condition: EnableMultipleProviders
+    crossFieldValidationAction: ValidateProviderEmailWhenInputIsPresent
     subflow: contactProviders
     nextScreens:
       - name: contact-providers-confirm-email-address

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1886,3 +1886,7 @@ contact-providers-email-address.header=What is {0}''s email address?
 contact-providers-email-address.subtext.p1=Use the email address your child care provider has shared with you for online applications.
 contact-providers-email-address.subtext.p2=If they haven't shared one, use the email of the staff member you've been in contact with.
 
+contact-providers-confirm-email-address.title=Confirm provider email
+contact-providers-confirm-email-address.header=Is this the correct email address for your {0}?
+contact-providers-confirm-email-address.body=Email you entered
+

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1881,11 +1881,13 @@ contact-providers-start.email=Email
 contact-providers-start.text=Text
 contact-providers-start.other=Another way
 
+#contact-providers-email-address
 contact-providers-email-address.title=Provider email
 contact-providers-email-address.header=What is {0}''s email address?
 contact-providers-email-address.subtext.p1=Use the email address your child care provider has shared with you for online applications.
 contact-providers-email-address.subtext.p2=If they haven't shared one, use the email of the staff member you've been in contact with.
 
+#contact-providers-confirm-email-address
 contact-providers-confirm-email-address.title=Confirm provider email
 contact-providers-confirm-email-address.header=Is this the correct email address for {0}?
 contact-providers-confirm-email-address.body=Email you entered

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1887,6 +1887,6 @@ contact-providers-email-address.subtext.p1=Use the email address your child care
 contact-providers-email-address.subtext.p2=If they haven't shared one, use the email of the staff member you've been in contact with.
 
 contact-providers-confirm-email-address.title=Confirm provider email
-contact-providers-confirm-email-address.header=Is this the correct email address for your {0}?
+contact-providers-confirm-email-address.header=Is this the correct email address for {0}?
 contact-providers-confirm-email-address.body=Email you entered
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -975,14 +975,6 @@ contact-provider-info.header=Ask your provider to complete their part of the app
 contact-provider-info.subtext=<p>On the next page, you will text or email message a secure link to your child care provider.</p><p>Using the link, your provider can complete their part of the application.</p>
 contact-provider-info.skip=I'd prefer to print and deliver my application in-person.
 
-# Multiple Providers Contact Screens
-#contact-providers-start
-contact-providers-start.title=Contact method
-contact-providers-start.header=How would you like to contact {0}?
-contact-providers-start.email=Email
-contact-providers-start.text=Text
-contact-providers-start.other=Another way
-
 #submit-provider-agreement-handoff
 submit-provider-agreement-handoff.title=Download application
 submit-provider-agreement-handoff.header=Deliver your application in person
@@ -1880,3 +1872,17 @@ providers-info-confirm.title=Contact providers reminder
 providers-info-confirm.header=Contact your child care providers at the end
 providers-info-confirm.body=After you sign, you will be able to <strong>email, text, or message a link</strong> to your providers, so they can complete their part.
 providers-info-confirm.notice=You can't get help with child care costs until both you and your providers finish the application.
+
+# Multiple Providers Contact Screens
+#contact-providers-start
+contact-providers-start.title=Contact method
+contact-providers-start.header=How would you like to contact {0}?
+contact-providers-start.email=Email
+contact-providers-start.text=Text
+contact-providers-start.other=Another way
+
+contact-providers-email-address.title=Provider email
+contact-providers-email-address.header=What is {0}''s email address?
+contact-providers-email-address.subtext.p1=Use the email address your child care provider has shared with you for online applications.
+contact-providers-email-address.subtext.p2=If they haven't shared one, use the email of the staff member you've been in contact with.
+

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1892,3 +1892,11 @@ contact-providers-confirm-email-address.title=Confirm provider email
 contact-providers-confirm-email-address.header=Is this the correct email address for {0}?
 contact-providers-confirm-email-address.body=Email you entered
 
+#contact-providers-edit-email
+contact-providers-edit-email.title=Edit provider email
+contact-providers-edit-email.header=Update your child care provider's information
+
+#contact-providers-email-sent
+contact-providers-email-sent.title=Email sent
+contact-providers-email-sent.header=We emailed your child care provider!
+

--- a/src/main/resources/templates/gcc/contact-providers-confirm-email-address.html
+++ b/src/main/resources/templates/gcc/contact-providers-confirm-email-address.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{contact-providers-confirm-email-address.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -10,15 +10,17 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:with="providerName='PROVIDER FROM LOOP GOES HERE'">
           <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${providerName})}"/>
-          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{contact-providers-confirm-email-address.header(${providerName})})}"/>
           <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
             <th:block th:ref="formContent">
-              <div class="form-card__content">
-                  <!-- Put inputs here -->
+              <div class="grid__item address-validation spacing-below-60">
+                <div class="display-box-green" id="email-entered-label">
+                  <p><strong th:text="#{contact-providers-confirm-email-address.body}"></strong>
+                  </p>
+                  <div id="intended-provider-email" th:text="${fieldData.get('familyIntendedProviderEmail')}"></div>
+                </div>
               </div>
-              <div class="form-card__footer">
-                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-              </div>
+              <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(inputName='hasConfirmedIntendedProviderEmail', ariaDescribe='header')}"/>
             </th:block>
           </th:block>
         </th:block>

--- a/src/main/resources/templates/gcc/contact-providers-edit-email.html
+++ b/src/main/resources/templates/gcc/contact-providers-edit-email.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{contact-providers-edit-email.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -10,7 +10,7 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:with="providerName='PROVIDER FROM LOOP GOES HERE'">
           <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${providerName})}"/>
-          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{contact-providers-edit-email.header})}"/>
           <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
             <th:block th:ref="formContent">
               <div class="form-card__content">

--- a/src/main/resources/templates/gcc/contact-providers-email-address.html
+++ b/src/main/resources/templates/gcc/contact-providers-email-address.html
@@ -1,29 +1,23 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${providerName})}"/>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block th:with="providerName='PROVIDER FROM LOOP GOES HERE'">
+  <th:block th:replace="~{fragments/inputs/subflowScreenWithOneInput ::
+    subflowScreenWithOneInput(
+      title=#{contact-providers-email-address.title},
+      header=#{contact-providers-email-address.header(${providerName})},
+      headerName=${providerName},
+      buttonLabel=#{'general.inputs.continue'},
+      required='true',
+      formAction=${formAction},
+      inputContent=~{::inputContent})}">
+    <th:block th:ref="inputContent">
+      <th:block th:ref="formContent">
+        <div class="form-card__content">
+          <p th:text="#{'contact-providers-email-address.subtext.p1'}"></p>
+          <p th:text="#{'contact-providers-email-address.subtext.p2'}"></p>
+          <th:block th:replace="~{fragments/inputs/text ::
+                text(inputName='familyIntendedProviderEmail',
+                ariaLabel='header')}"/>
+        </div>
+      </th:block>
+    </th:block>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/gcc/contact-providers-email-sent.html
+++ b/src/main/resources/templates/gcc/contact-providers-email-sent.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<head th:replace="~{fragments/head :: head(title=#{contact-providers-email-sent.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -10,7 +10,7 @@
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:with="providerName='PROVIDER FROM LOOP GOES HERE'">
           <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${providerName})}"/>
-          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
+          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{contact-providers-email-sent.header})}"/>
           <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
             <th:block th:ref="formContent">
               <div class="form-card__content">

--- a/src/main/resources/templates/gcc/contact-providers-start.html
+++ b/src/main/resources/templates/gcc/contact-providers-start.html
@@ -1,38 +1,26 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{contact-providers-start.title})}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:with="providerName='PROVIDER FROM LOOP GOES HERE'">
-          <th:block th:replace="~{fragments/inputs/headerNameUnderlined :: headerNameUnderlined(text=${providerName})}"/>
-          <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{contact-providers-start.header(${providerName})}, required='true')}"/>
-          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-            <th:block th:ref="formContent">
-              <div class="form-card__content">
-                <p class="spacing-below-0" th:text="#{general.select-all-that-apply}"></p>
-                <th:block th:replace="~{fragments/inputs/checkboxFieldset :: checkboxFieldset(inputName='contactProviderMethod', ariaLabel='header', content=~{::contactList})}">
-                  <th:block th:ref="contactList">
-                    <th:block th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='contactProviderMethod',value='EMAIL', label=#{contact-providers-start.email})}"/>
-                    <th:block th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='contactProviderMethod',value='TEXT', label=#{contact-providers-start.text})}"/>
-                    <th:block th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='contactProviderMethod',value='OTHER', label=#{contact-providers-start.other})}"/>
-                  </th:block>
-                </th:block>
-              </div>
-              <div class="form-card__footer">
-                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-              </div>
+<th:block th:with="providerName='PROVIDER FROM LOOP GOES HERE'">
+  <th:block th:replace="~{fragments/inputs/subflowScreenWithOneInput ::
+    subflowScreenWithOneInput(
+      title=#{contact-providers-start.title},
+      header=#{contact-providers-start.header(${providerName})},
+      subtext=#{general.select-all-that-apply},
+      headerName=${providerName},
+      buttonLabel=#{'general.inputs.continue'},
+      required='true',
+      formAction=${formAction},
+      inputContent=~{::inputContent})}">
+    <th:block th:ref="inputContent">
+      <th:block th:ref="formContent">
+        <div class="form-card__content">
+          <th:block th:replace="~{fragments/inputs/checkboxFieldset :: checkboxFieldset(inputName='contactProviderMethod', ariaLabel='header', content=~{::contactList})}">
+            <th:block th:ref="contactList">
+              <th:block th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='contactProviderMethod',value='EMAIL', label=#{contact-providers-start.email})}"/>
+              <th:block th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='contactProviderMethod',value='TEXT', label=#{contact-providers-start.text})}"/>
+              <th:block th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='contactProviderMethod',value='OTHER', label=#{contact-providers-start.other})}"/>
             </th:block>
           </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+        </div>
+      </th:block>
+    </th:block>
+  </th:block>
+</th:block>


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-951
https://codeforamerica.atlassian.net/browse/CCAP-952

#### ✍️ Description
CCAP-951:
<img width="593" alt="Screenshot 2025-05-20 at 7 07 55 PM" src="https://github.com/user-attachments/assets/2788cfc6-f839-4ecb-8e85-ba320c952e49" />

CCAP-952:
<img width="596" alt="Screenshot 2025-05-21 at 9 37 44 AM" src="https://github.com/user-attachments/assets/7ad3878c-579e-4745-b107-6af751e88a4b" />

I also updated the prior screen that I made to use the single input style, etc:

<img width="582" alt="Screenshot 2025-05-20 at 7 08 06 PM" src="https://github.com/user-attachments/assets/72ac4aa4-63a4-4819-a2d4-a0ba36a60443" />


#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
