### PR TITLE
[CCAP-967] - moved child care mapping to application data so it alway…

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/ApplicationPreparer.java
+++ b/src/main/java/org/ilgcc/app/pdf/ApplicationPreparer.java
@@ -102,6 +102,10 @@ public class ApplicationPreparer implements SubmissionFieldPreparer {
         results.put("clientResponseConfirmationCode",
                 new SingleField("clientResponseConfirmationCode", submission.getShortCode(), null));
 
+        results.put("childcareStartDate",
+                new SingleField("childcareStartDate",
+                        inputData.getOrDefault("earliestChildcareStartDate", "").toString(), null));
+
         return results;
     }
 

--- a/src/main/java/org/ilgcc/app/pdf/helpers/FamilyIntendedProviderPreparerHelper.java
+++ b/src/main/java/org/ilgcc/app/pdf/helpers/FamilyIntendedProviderPreparerHelper.java
@@ -17,13 +17,9 @@ public class FamilyIntendedProviderPreparerHelper extends InputDataPreparerHelpe
         if ("false".equals(familyInputData.get("hasChosenProvider"))) {
             results.putAll(prepareNoProviderData());
         } else {
-
             // toDo: we can keep the same field name for each provider in providers;
             String submissionStatus = (String) familyInputData.getOrDefault("providerSubmissionStatus", "");
             Boolean hasExpired = SubmissionStatus.EXPIRED.name().equals(submissionStatus);
-            results.put("childcareStartDate",
-                    new SingleField("childcareStartDate",
-                            familyInputData.getOrDefault("earliestChildcareStartDate", "").toString(), null));
             results.putAll(prepareFamilyIntendedProviderData(familyInputData, hasExpired));
         }
 

--- a/src/main/java/org/ilgcc/app/pdf/helpers/ProviderApplicationPreparerHelper.java
+++ b/src/main/java/org/ilgcc/app/pdf/helpers/ProviderApplicationPreparerHelper.java
@@ -31,12 +31,6 @@ public class ProviderApplicationPreparerHelper extends InputDataPreparerHelper {
             results.put(fieldName, new SingleField(fieldName, providerInputData.getOrDefault(fieldName, "").toString(), null));
         }
 
-        Map<String, String> client = (Map<String, String>) providerInputData.getOrDefault("clientResponse",
-                new HashMap<String, String>());
-        results.put("clientResponseConfirmationCode",
-                new SingleField("clientResponseConfirmationCode", client.getOrDefault("clientResponseConfirmationCode", ""),
-                        null));
-
         results.put("providerSignature", new SingleField("providerSignature", providerSignature(providerInputData), null));
         results.put("providerResponse", new SingleField("providerResponse", providerResponse(providerInputData), null));
 

--- a/src/test/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerServiceTest_SingleProvider.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerServiceTest_SingleProvider.java
@@ -46,7 +46,6 @@ public class ProviderSubmissionFieldPreparerServiceTest_SingleProvider {
     private static String FAM_INTENDED_PROVIDER_NAME = "IntendedProviderName";
     private static String FAM_INTENDED_PROVIDER_PHONE = "(125) 785-67896";
     private static String FAM_INTENDED_PROVIDER_EMAIL = "mail@test.com";
-    private static String FAM_EARLIEST_CHILD_CARE_DATE = "11/12/2023";
 
     @BeforeEach
     void setUp() {
@@ -57,7 +56,6 @@ public class ProviderSubmissionFieldPreparerServiceTest_SingleProvider {
                 .with("familyIntendedProviderName", FAM_INTENDED_PROVIDER_NAME)
                 .with("familyIntendedProviderPhoneNumber", FAM_INTENDED_PROVIDER_PHONE)
                 .with("familyIntendedProviderEmail", FAM_INTENDED_PROVIDER_EMAIL)
-                .with("earliestChildcareStartDate", FAM_EARLIEST_CHILD_CARE_DATE)
                 .build();
     }
 
@@ -75,8 +73,6 @@ public class ProviderSubmissionFieldPreparerServiceTest_SingleProvider {
                     new SingleField("providerResponseContactPhoneNumber", FAM_INTENDED_PROVIDER_PHONE, null));
             assertThat(result.get("providerResponseContactEmail")).isEqualTo(
                     new SingleField("providerResponseContactEmail", FAM_INTENDED_PROVIDER_EMAIL, null));
-            assertThat(result.get("childcareStartDate")).isEqualTo(
-                    new SingleField("childcareStartDate", FAM_EARLIEST_CHILD_CARE_DATE, null));
             assertThat(result.get("providerResponse")).isEqualTo(
                     new SingleField("providerResponse", "No response from provider", null));
         }
@@ -92,8 +88,6 @@ public class ProviderSubmissionFieldPreparerServiceTest_SingleProvider {
                     new SingleField("providerResponseContactPhoneNumber", FAM_INTENDED_PROVIDER_PHONE, null));
             assertThat(result.get("providerResponseContactEmail")).isEqualTo(
                     new SingleField("providerResponseContactEmail", FAM_INTENDED_PROVIDER_EMAIL, null));
-            assertThat(result.get("childcareStartDate")).isEqualTo(
-                    new SingleField("childcareStartDate", FAM_EARLIEST_CHILD_CARE_DATE, null));
             assertThat(result.get("providerResponse")).isNull();
         }
     }


### PR DESCRIPTION
…s runs. Added Multiple provider dummy data for dev testing

#### 🔗 Jira ticket
[[CCAP-974] ](https://codeforamerica.atlassian.net/browse/CCAP-974)

#### ✍️ Description
- Earliest child care date preparer was nested within the provider section but actually needed to be in the application section so that it would always get mapped
- Added the ability to create multiple providers for our dummy family submission to test locally
- Removed duplicative clientResponseConfirmationCode because it is already set in the family application preparer

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-974]: https://codeforamerica.atlassian.net/browse/CCAP-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ