### PR TITLE
[CCAP-961] Update HouseholdHasAtLeastOneChildWithoutAProvider.java

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/conditions/HouseholdHasAtLeastOneChildWithoutAProvider.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/HouseholdHasAtLeastOneChildWithoutAProvider.java
@@ -13,7 +13,7 @@ public class HouseholdHasAtLeastOneChildWithoutAProvider implements Condition {
         this.enableMultipleProviders = enableMultipleProviders;
     }
     @Override
-    public Boolean run(Submission submission, String subflowUuid) {
+    public Boolean run(Submission submission) {
         boolean hasOneChildOrMoreWithoutAProvider = submission.getInputData().getOrDefault("choseProviderForEveryChildInNeedOfCare", "").equals("false");
         return enableMultipleProviders && hasOneChildOrMoreWithoutAProvider;
     }

--- a/src/test/java/org/ilgcc/app/submission/conditions/HouseholdHasAtLeastOneChildWithoutAProviderTest.java
+++ b/src/test/java/org/ilgcc/app/submission/conditions/HouseholdHasAtLeastOneChildWithoutAProviderTest.java
@@ -11,30 +11,27 @@ class HouseholdHasAtLeastOneChildWithoutAProviderTest {
   @Test
   void shouldReturnFalseWhenEnableMultipleProvidersIsFalse() {
     boolean mockEnableMultipleProviders = false;
-    String mockContactProviderUUID = "mockContactProviderUUID";
     Submission submission = new SubmissionTestBuilder().with("choseProviderForEveryChildInNeedOfCare", "false").build();
     HouseholdHasAtLeastOneChildWithoutAProvider condition = new HouseholdHasAtLeastOneChildWithoutAProvider(mockEnableMultipleProviders);
 
-    assertFalse(condition.run(submission, mockContactProviderUUID));
+    assertFalse(condition.run(submission));
   }
   //If all the children have a chosen provider this should return false
   @Test
   void shouldReturnFalseWhenEnableMultipleProvidersIsTrueAndChoseProviderForEveryChildInNeedOfCareIsTrue() {
     boolean mockEnableMultipleProviders = true;
-    String mockContactProviderUUID = "mockContactProviderUUID";
     Submission submission = new SubmissionTestBuilder().with("choseProviderForEveryChildInNeedOfCare", "true").build();
     HouseholdHasAtLeastOneChildWithoutAProvider condition = new HouseholdHasAtLeastOneChildWithoutAProvider(mockEnableMultipleProviders);
 
-    assertFalse(condition.run(submission, mockContactProviderUUID));
+    assertFalse(condition.run(submission));
   }
 
   //If at least one child does not have a chose provider this should return true
   @Test
   void shouldReturnFalseWhenEnableMultipleProvidersIsTrueAndChoseProviderForEveryChildInNeedOfCareIsFalse() {
     boolean mockEnableMultipleProviders = true;
-    String mockContactProviderUUID = "mockContactProviderUUID";
     Submission submission = new SubmissionTestBuilder().with("choseProviderForEveryChildInNeedOfCare", "false").build();
     HouseholdHasAtLeastOneChildWithoutAProvider condition = new HouseholdHasAtLeastOneChildWithoutAProvider(mockEnableMultipleProviders);
-    assertTrue(condition.run(submission, mockContactProviderUUID));
+    assertTrue(condition.run(submission));
   }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-961

#### ✍️ Description
HouseholdHasAtLeastOneChildWithoutAProvider.java condition fails.  This change fixes the error.

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
