### PR TITLE
[CCAP-999] FormatSubmittedAtDate needs to support subflow

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/FormatSubmittedAtDate.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FormatSubmittedAtDate.java
@@ -26,4 +26,9 @@ public class FormatSubmittedAtDate implements Action {
             submission.getInputData().put("formattedSubmittedAtTime", formattedSubmittedAtTime);
         }
     }
+
+    @Override
+    public void run(Submission submission, String subflowUuid) {
+        this.run(submission);
+    }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-999

#### ✍️ Description

This block of code is being run in ActionManager:

```
private void runAction(String name, Submission submission, String uuid) {
    runAction(name, () -> getAction(name).run(submission, uuid));
  }
 ```
 
 And the FormatSubmittedAtDate class did not have the subflow version of the method that takes the UUID implemented.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
