### PR TITLE
[CCAP-940] create new schedules-start-care screen

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -665,5 +665,5 @@ public class Gcc extends FlowInputs {
     @NotBlank(message = "{errors.provide-state}")
     private String familyIntendedProviderState;
 
-    private String currentChildcareProvider;
+    private List<String> currentChildcareProvider;
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/PopulateChildcareSchedulesIteration.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/PopulateChildcareSchedulesIteration.java
@@ -13,13 +13,13 @@ public class PopulateChildcareSchedulesIteration implements Action {
     @Override
     public void run(Submission submission, String subflowUuid) {
         Map<String, Object> childcareSchedulesSubflow = submission.getSubflowEntryByUuid("childcareSchedules", subflowUuid);
-        if (childcareSchedulesSubflow.containsKey("childrenUuid")) {
-            String childrenUuid = (String) childcareSchedulesSubflow.get("childrenUuid");
-            Map<String, Object> childrenSubflow = submission.getSubflowEntryByUuid("children", childrenUuid);
-            if (childrenSubflow != null) {
-                Map<String, Object> childcareScheduleData = childcareSchedulesSubflow;
-                childcareScheduleData.put("childFirstName", childrenSubflow.get("childFirstName"));
-                submission.mergeFormDataWithSubflowIterationData("childcareSchedules", childcareSchedulesSubflow, childcareScheduleData);
+        if (childcareSchedulesSubflow.containsKey("childUuid")) {
+            String childUuid = (String) childcareSchedulesSubflow.get("childUuid");
+            Map<String, Object> childSubflow = submission.getSubflowEntryByUuid("children", childUuid);
+            if (childSubflow != null) {
+              childcareSchedulesSubflow.put("childFirstName", childSubflow.get("childFirstName"));
+                submission.mergeFormDataWithSubflowIterationData("childcareSchedules", childcareSchedulesSubflow,
+                    childcareSchedulesSubflow);
             }
         }
     }

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesStartCareScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesStartCareScreen.java
@@ -1,5 +1,7 @@
 package org.ilgcc.app.submission.conditions;
 
+import static java.util.Collections.emptyList;
+
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import java.util.List;
@@ -13,7 +15,10 @@ public class DisplaySchedulesStartCareScreen extends EnableMultipleProviders imp
     @Override
     public Boolean run(Submission submission, String subflowUuid) {
         Map<String, Object> childcareSubflow = submission.getSubflowEntryByUuid("childcareSchedules", subflowUuid);
-        return super.run(submission) && hasSelectedOneProvider(childcareSubflow);
+        return super.run(submission) && (hasSelectedOneProvider(childcareSubflow) || hasOnlyOneProvider(submission));
+    }
+    private boolean hasOnlyOneProvider(Submission submission) {
+      return ((List<Map<String, Object>>) submission.getInputData().getOrDefault("providers", emptyList())).size() <= 1;
     }
     private boolean hasSelectedOneProvider(Map<String, Object> childcareSubflow) {
          return Optional.ofNullable(childcareSubflow.get("currentChildcareProvider[]"))

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesStartCareScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesStartCareScreen.java
@@ -1,0 +1,27 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DisplaySchedulesStartCareScreen extends EnableMultipleProviders implements Condition {
+
+    @Override
+    public Boolean run(Submission submission, String subflowUuid) {
+        Map<String, Object> childcareSubflow = submission.getSubflowEntryByUuid("childcareSchedules", subflowUuid);
+        return super.run(submission) && hasSelectedOneProvider(childcareSubflow);
+    }
+    private boolean hasSelectedOneProvider(Map<String, Object> childcareSubflow) {
+         return Optional.ofNullable(childcareSubflow.get("currentChildcareProvider[]"))
+             .filter(List.class::isInstance)
+             .map(list -> ((List<?>) list).stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .anyMatch(item -> !item.equals("NO_PROVIDER")))
+             .orElse(false);
+    }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -261,7 +261,7 @@ flow:
       - name: schedules-start-care
   schedules-start-care:
     subflow: childcareSchedules
-    condition: EnableMultipleProviders
+    condition: DisplaySchedulesStartCareScreen
     nextScreens:
       - name: schedules-start-date
   schedules-start-date:
@@ -735,7 +735,7 @@ subflows:
   childcareSchedules:
     relationship:
       relatesTo: children
-      relationAlias: childrenUuid
+      relationAlias: childUuid
     entryScreen: schedules-intro
     iterationStartScreen: schedules-start
     reviewScreen: schedules-review

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -256,6 +256,7 @@ flow:
   schedules-start:
     subflow: childcareSchedules
     condition: EnableMultipleProviders
+    beforeSaveAction: PopulateChildcareSchedulesIteration
     nextScreens:
       - name: schedules-start-care
   schedules-start-care:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1920,3 +1920,8 @@ schedules-start.header=Tell us about {0}''s child care details.
 schedules-start.single-provider.subtext=We''ll ask you which days and hours you want child care for {0}.
 schedules-start.select-provider=Which providers will be taking care of {0}?
 schedules-start.no-provider=No provider chosen yet
+
+#schedules-start-care
+schedules-start-care.title=In care
+schedules-start-care.header=Is {0} already in child care with [PROVIDER_NAME]?
+

--- a/src/main/resources/templates/fragments/inputs/subflowScreenWithOneInput.html
+++ b/src/main/resources/templates/fragments/inputs/subflowScreenWithOneInput.html
@@ -1,5 +1,6 @@
 <th:block
         th:fragment="subflowScreenWithOneInput"
+        th:with="hasNoSubmitButtonInput=${!#strings.isEmpty(noSubmitButton)}"
         th:assert="
       ${!#strings.isEmpty(title)},
       ${!#strings.isEmpty(header)},
@@ -27,8 +28,10 @@
                 <th:block th:replace="${inputContent}"/>
               </div>
               <div class="form-card__footer">
-                <th:block
-                        th:replace="~{fragments/inputs/submitButton :: submitButton(text=${buttonLabel != null ? buttonLabel : 'Submit'})}"/>
+                <th:block th:unless="${hasNoSubmitButtonInput && ('true'.equals(noSubmitButton.toString()))}">
+                  <th:block
+                      th:replace="~{fragments/inputs/submitButton :: submitButton(text=${buttonLabel != null ? buttonLabel : 'Submit'})}"/>
+                </th:block>
               </div>
             </th:block>
           </th:block>

--- a/src/main/resources/templates/gcc/schedules-start-care.html
+++ b/src/main/resources/templates/gcc/schedules-start-care.html
@@ -5,6 +5,7 @@
       header=#{schedules-start-care.header(${childName})},
       headerName='[PROVIDER_NAME]',
       formAction=${formAction},
+      noSubmitButton='true',
       inputContent=~{::inputContent})}">
     <th:block th:ref="inputContent">
       <th:block th:ref="formContent">

--- a/src/main/resources/templates/gcc/schedules-start-care.html
+++ b/src/main/resources/templates/gcc/schedules-start-care.html
@@ -1,28 +1,19 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block th:with="childName=${relatedSubflowIteration.get('childFirstName')}">
+  <th:block th:replace="~{fragments/inputs/subflowScreenWithOneInput ::
+    subflowScreenWithOneInput(
+      title=#{schedules-start-care.title},
+      header=#{schedules-start-care.header(${providerName})},
+      headerName='[PROVIDER_NAME]',
+      formAction=${formAction},
+      inputContent=~{::inputContent})}">
+    <th:block th:ref="inputContent">
+      <th:block th:ref="formContent">
+        <div class="form-card__content">
+          <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+            inputName='childInCare',
+            ariaDescribe='header')}"/>
+        </div>
+      </th:block>
+    </th:block>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/gcc/schedules-start-care.html
+++ b/src/main/resources/templates/gcc/schedules-start-care.html
@@ -2,7 +2,7 @@
   <th:block th:replace="~{fragments/inputs/subflowScreenWithOneInput ::
     subflowScreenWithOneInput(
       title=#{schedules-start-care.title},
-      header=#{schedules-start-care.header(${providerName})},
+      header=#{schedules-start-care.header(${childName})},
       headerName='[PROVIDER_NAME]',
       formAction=${formAction},
       inputContent=~{::inputContent})}">

--- a/src/main/resources/templates/gcc/schedules-start.html
+++ b/src/main/resources/templates/gcc/schedules-start.html
@@ -25,6 +25,10 @@
               <th:block
                   th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='currentChildcareProvider',value=${provider.get('familyIntendedProviderName')}, label=${provider.get('familyIntendedProviderName')})}"/>
             </th:block>
+            <th:block>
+              <th:block
+                  th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='currentChildcareProvider',value='NO_PROVIDER', label=#{schedules-start.no-provider})}"/>
+            </th:block>
           </th:block>
         </th:block>
       </th:block>


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-940]

#### ✍️ Description
<!-- Brief summary of changes  -->The schedules-start-care screen exists

- [ ] schedules-start-care screen matches the designs
- [ ] schedules-start-care screen is only shown to users when the ENABLE_MULTIPLE_PROVIDERS feature flag is enabled
- [ ] who have at least one provider on their application
- [ ] who chose at least one provider for the child on the schedules-start screen
- [ ] Otherwise the schedules-start-care screen should be skipped

**Note**
There are some corrections.  
schedules-start screen was missing the no-provider checkbox.  That is added in this repo
schedules-start-care screen was missing logic to skip the screen when a provider was not selected.  That action has been added.  

#### 📷 Design reference
- [Figma](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5211&t=MC1BbY3r9xh0tTqM-4)
- [Content Manager](https://docs.google.com/document/d/1vwtwI1-GcqrGDGf3l1UEk161ahoGqVlCAX0BhmoYnlY/edit?tab=t.0#bookmark=id.ig52mr8xx7dm)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-940]: https://codeforamerica.atlassian.net/browse/CCAP-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ