### PR TITLE
[CCAP-942] Add schedules-days.html screen to flow

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1930,3 +1930,10 @@ schedules-start-date.title=Care start date
 schedules-start-date.header.already-started=When did {0} start care with {1}?
 schedules-start-date.header.not-started=When will {0} start care with {1}?
 schedules-start-date.header.no-provider=When do you want {0} to start care?
+
+#schedules-days
+schedules-days.title=Days of care
+schedules-days.header.already-started=What days does {0} provide child care for {1}?
+schedules-days.header.not-started=What days will {0} provide child care for {1}?
+schedules-days.header.no-provider=What days do you want child care for {0}?
+

--- a/src/main/resources/templates/gcc/schedules-days.html
+++ b/src/main/resources/templates/gcc/schedules-days.html
@@ -1,28 +1,24 @@
-<!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
-<body>
-<div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
-</div>
-<th:block th:replace="~{fragments/footer :: footer}"/>
-</body>
-</html>
+<th:block th:with="childName=${relatedSubflowIteration.get('childFirstName')},
+                   providerName='[PROVIDER_NAME]'">
+  <th:block th:replace="~{fragments/inputs/subflowScreenWithOneInput ::
+    subflowScreenWithOneInput(
+      title=#{schedules-days.title},
+      header=#{schedules-days.header.already-started(${childName}, ${providerName})},
+      headerName=${providerName},
+      formAction=${formAction},
+      required='true',
+      buttonLabel=#{'general.inputs.continue'},
+      inputContent=~{::inputContent})}">
+    <th:block th:ref="inputContent">
+      <th:block th:ref="formContent"
+                th:with="dayOfWeekOptions=${T(org.ilgcc.app.utils.DayOfWeekOption).values()}">
+        <div class="form-card__content">
+          <th:block th:replace="~{fragments/inputs/checkboxFieldset ::
+                  checkboxFieldset(inputName='childcareWeeklySchedule',
+                    ariaLabel='header',
+                    options=${dayOfWeekOptions})}"/>
+        </div>
+      </th:block>
+    </th:block>
+  </th:block>
+</th:block>


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-942

#### ✍️ Description
Acceptance criteria
- [ ] The schedules-days screen exists
- [ ] The schedules-days screen matches the designs
- [ ] The schedules-days screen is only shown to users when the ENABLE_MULTIPLE_PROVIDERS feature flag is enabled
- [ ] The content shown on the screen is different for
  - [ ] Care with a provider and the care has already started: [IL CCAP Families Application](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5344&t=MC1BbY3r9xh0tTqM-4) 
  - [ ] Care with a provider and the care has not yet started: [IL CCAP Families Application](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5362&t=380pdphns0nvQxDV-4) 
  - [ ] No provider: [IL CCAP Families Application](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5248&t=C195sRx8OVFfOyCQ-4)  

Store the answer to the question in the existing field: childcareWeeklySchedule

#### 📷 Design reference
- [ ] [Care Started](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5344&t=MC1BbY3r9xh0tTqM-4) 
- [ ] [Care NOT Started](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5362&t=380pdphns0nvQxDV-4) 
- [ ]  [No Provider](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=19449-5248&t=C195sRx8OVFfOyCQ-4)  

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
