### PR TITLE
[CCAP-1021] Add provider name and type screens - update provider-info to provider-location

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Gcc.java
+++ b/src/main/java/org/ilgcc/app/inputs/Gcc.java
@@ -667,4 +667,13 @@ public class Gcc extends FlowInputs {
 
     @NotEmpty
     private List<String> childcareProvidersForCurrentChild;
+
+    // providers-type
+    @NotBlank(message = "{errors.select-one-option}")
+    private String providerType;
+
+    // providers-name
+    private String childCareProgramName;
+    private String providerFirstName;
+    private String providerLastName;
 }

--- a/src/main/java/org/ilgcc/app/pdf/helpers/FamilyIntendedProviderPreparerHelper.java
+++ b/src/main/java/org/ilgcc/app/pdf/helpers/FamilyIntendedProviderPreparerHelper.java
@@ -46,7 +46,11 @@ public class FamilyIntendedProviderPreparerHelper extends InputDataPreparerHelpe
         Map<String, SubmissionField> results = new HashMap<>();
 
         results.put("providerResponseBusinessName", new SingleField("providerResponseBusinessName",
-                inputData.getOrDefault("familyIntendedProviderName", "").toString(), null));
+                inputData.getOrDefault("childCareProgramName", "").toString(), null));
+        results.put("providerResponseFirstName", new SingleField("providerResponseFirstName",
+                inputData.getOrDefault("providerFirstName", "").toString(), null));
+        results.put("providerResponseLastName", new SingleField("providerResponseLastName",
+                inputData.getOrDefault("providerLastName", "").toString(), null));
         results.put("providerResponseContactPhoneNumber",
                 new SingleField("providerResponseContactPhoneNumber",
                         inputData.getOrDefault("familyIntendedProviderPhoneNumber", "").toString(),

--- a/src/main/java/org/ilgcc/app/pdf/helpers/FamilyIntendedProviderPreparerHelper.java
+++ b/src/main/java/org/ilgcc/app/pdf/helpers/FamilyIntendedProviderPreparerHelper.java
@@ -45,8 +45,20 @@ public class FamilyIntendedProviderPreparerHelper extends InputDataPreparerHelpe
             Boolean providerApplicationExpired) {
         Map<String, SubmissionField> results = new HashMap<>();
 
-        results.put("providerResponseBusinessName", new SingleField("providerResponseBusinessName",
-                inputData.getOrDefault("childCareProgramName", "").toString(), null));
+        String familyIntendedProviderName = inputData.getOrDefault("familyIntendedProviderName", "").toString();
+
+        String childCareProgramName = inputData.getOrDefault("childCareProgramName", "").toString();
+
+        if (!familyIntendedProviderName.isEmpty()) {
+            results.put("providerResponseBusinessName", new SingleField("providerResponseBusinessName",
+                    familyIntendedProviderName, null));
+        }
+
+        if (!childCareProgramName.isEmpty()) {
+            results.put("providerResponseBusinessName", new SingleField("providerResponseBusinessName",
+                    childCareProgramName, null));
+        }
+
         results.put("providerResponseFirstName", new SingleField("providerResponseFirstName",
                 inputData.getOrDefault("providerFirstName", "").toString(), null));
         results.put("providerResponseLastName", new SingleField("providerResponseLastName",

--- a/src/main/java/org/ilgcc/app/submission/actions/SetFamilyIntendedProviderName.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetFamilyIntendedProviderName.java
@@ -1,0 +1,35 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SetFamilyIntendedProviderName implements Action {
+    
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+    
+    @Override
+    public void run(FormSubmission formData, Submission submission, String iterationId) {
+        Map<String, Object> subflowEntryByUuid = submission.getSubflowEntryByUuid("providers", iterationId);
+        String childCareProgramName = formData.getFormData().getOrDefault("childCareProgramName", "").toString();
+        String providerFirstName = formData.getFormData().getOrDefault("providerFirstName", "").toString();
+        String providerLastName = formData.getFormData().getOrDefault("providerLastName", "").toString();
+        
+        if (!childCareProgramName.isBlank()) {
+            subflowEntryByUuid.put("familyIntendedProviderName", childCareProgramName);
+        }
+        else if (!providerFirstName.isBlank() && !providerLastName.isBlank()) {
+            subflowEntryByUuid.put("familyIntendedProviderName", providerFirstName + " " + providerLastName);
+        }
+        
+        submissionRepositoryService.save(submission);
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateProviderName.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateProviderName.java
@@ -23,9 +23,8 @@ public class ValidateProviderName implements Action {
     public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {
         Map<String, List<String>> errorMessages = new HashMap<>();
         Locale locale = LocaleContextHolder.getLocale();
-        
-        boolean providerIsIndividual = submission.getInputData().getOrDefault("providerType", "").equals("Individual");
-        boolean providerIsCareProgram = submission.getInputData().getOrDefault("providerType", "").equals("Care Program");
+        boolean providerIsCareProgram = formSubmission.getFormData().containsKey("childCareProgramName");
+        boolean providerIsIndividual = !formSubmission.getFormData().containsKey("childCareProgramName");
         String providerFirstName = formSubmission.getFormData().getOrDefault("providerFirstName", "").toString();
         String providerLastName = formSubmission.getFormData().getOrDefault("providerLastName", "").toString();
         String providerCareProgramName = formSubmission.getFormData().getOrDefault("childCareProgramName", "").toString();
@@ -35,7 +34,7 @@ public class ValidateProviderName implements Action {
                 errorMessages.put("providerFirstName", List.of(messageSource.getMessage("provider-name.enter-full-name", null, locale)));
             }
             if (providerLastName.isBlank()) {
-                errorMessages.put("providerFirstName", List.of(messageSource.getMessage("provider-name.enter-full-name", null, locale)));
+                errorMessages.put("providerLastName", List.of(messageSource.getMessage("provider-name.enter-full-name", null, locale)));
             }
         } 
         else if (providerIsCareProgram) {

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateProviderName.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateProviderName.java
@@ -1,0 +1,57 @@
+package org.ilgcc.app.submission.actions;
+
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidateProviderName implements Action {
+
+    @Autowired
+    MessageSource messageSource;
+    
+    @Override
+    public Map<String, List<String>> runValidation(FormSubmission formSubmission, Submission submission) {
+        Map<String, List<String>> errorMessages = new HashMap<>();
+        Locale locale = LocaleContextHolder.getLocale();
+        
+        boolean providerIsIndividual = submission.getInputData().getOrDefault("providerType", "").equals("Individual");
+        boolean providerIsCareProgram = submission.getInputData().getOrDefault("providerType", "").equals("Care Program");
+        String providerFirstName = formSubmission.getFormData().getOrDefault("providerFirstName", "").toString();
+        String providerLastName = formSubmission.getFormData().getOrDefault("providerLastName", "").toString();
+        String providerCareProgramName = formSubmission.getFormData().getOrDefault("childCareProgramName", "").toString();
+        
+        if (providerIsIndividual) {
+            if (providerFirstName.isBlank()) {
+                errorMessages.put("providerFirstName", List.of(messageSource.getMessage("provider-name.enter-full-name", null, locale)));
+            }
+            if (providerLastName.isBlank()) {
+                errorMessages.put("providerFirstName", List.of(messageSource.getMessage("provider-name.enter-full-name", null, locale)));
+            }
+        } 
+        else if (providerIsCareProgram) {
+            if (providerCareProgramName.isBlank()) {
+                // If they don't enter a care program name, they need to enter both a first and last name
+                if (providerFirstName.isBlank()) {
+                    errorMessages.put("providerFirstName", List.of(messageSource.getMessage("providers-name.enter-one-or-other", null, locale)));
+                }
+                if (providerLastName.isBlank()) {
+                    errorMessages.put("providerLastName", List.of(messageSource.getMessage("providers-name.enter-one-or-other", null, locale)));
+                }
+                if (providerFirstName.isBlank() && providerLastName.isBlank()) {
+                    errorMessages.put("childCareProgramName", List.of(messageSource.getMessage("providers-name.enter-one-or-other", null, locale)));
+                }
+            }
+        }
+        return errorMessages;
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsCareProgram.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsCareProgram.java
@@ -1,0 +1,16 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProviderIsCareProgram implements Condition {
+   
+    @Override
+    public Boolean run(Submission submission) {
+        return submission.getInputData().getOrDefault("providerType", "")
+                .toString()
+                .equals("Care Program");
+    }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsCareProgram.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsCareProgram.java
@@ -2,14 +2,16 @@ package org.ilgcc.app.submission.conditions;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ProviderIsCareProgram implements Condition {
    
     @Override
-    public Boolean run(Submission submission) {
-        return submission.getInputData().getOrDefault("providerType", "")
+    public Boolean run(Submission submission, String iterationId) {
+        Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("providers", iterationId);
+        return subflowEntry.getOrDefault("providerType", "")
                 .toString()
                 .equals("Care Program");
     }

--- a/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsIndividual.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsIndividual.java
@@ -2,14 +2,16 @@ package org.ilgcc.app.submission.conditions;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ProviderIsIndividual implements Condition {
    
     @Override
-    public Boolean run(Submission submission) {
-        return submission.getInputData().getOrDefault("providerType", "")
+    public Boolean run(Submission submission, String iterationId) {
+        Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("providers", iterationId);
+        return subflowEntry.getOrDefault("providerType", "")
                 .toString()
                 .equals("Individual");
     }

--- a/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsIndividual.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ProviderIsIndividual.java
@@ -1,0 +1,16 @@
+package org.ilgcc.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProviderIsIndividual implements Condition {
+   
+    @Override
+    public Boolean run(Submission submission) {
+        return submission.getInputData().getOrDefault("providerType", "")
+                .toString()
+                .equals("Individual");
+    }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -227,7 +227,14 @@ flow:
     beforeDisplayAction: SetProvidersAndMaxProvidersWhileRemovingIncompleteIterations
     condition: EnableMultipleProviders
     nextScreens:
-      - name: providers-info-confirm
+      - name: providers-type
+  providers-type:
+    nextScreens:
+      - name: providers-name
+  providers-name:
+    crossFieldValidationAction: ValidateProviderName
+    nextScreens:
+      - name: providers-location
   providers-info:
     condition: EnableMultipleProviders
     subflow: providers

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -176,7 +176,7 @@ flow:
     condition: SkipWhenEnableMultipleProvidersIsEnabled
     subflow: children
     crossFieldValidationAction: ValidateChildrenCCAPStartDate
-    onPostAction: SaveCCAPStartDate
+    beforeSaveAction: SaveCCAPStartDate
     nextScreens:
       - name: children-childcare-weekly-schedule
   children-childcare-weekly-schedule:

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -176,7 +176,7 @@ flow:
     condition: SkipWhenEnableMultipleProvidersIsEnabled
     subflow: children
     crossFieldValidationAction: ValidateChildrenCCAPStartDate
-    beforeSaveAction: SaveCCAPStartDate
+    onPostAction: SaveCCAPStartDate
     nextScreens:
       - name: children-childcare-weekly-schedule
   children-childcare-weekly-schedule:
@@ -229,13 +229,16 @@ flow:
     nextScreens:
       - name: providers-type
   providers-type:
+    subflow: providers
     nextScreens:
       - name: providers-name
   providers-name:
+    subflow: providers
+    onPostAction: SetFamilyIntendedProviderName
     crossFieldValidationAction: ValidateProviderName
     nextScreens:
       - name: providers-location
-  providers-info:
+  providers-location:
     condition: EnableMultipleProviders
     subflow: providers
     nextScreens:
@@ -712,7 +715,7 @@ flow:
 subflows:
   providers:
     entryScreen: providers-add
-    iterationStartScreen: providers-info
+    iterationStartScreen: providers-type
     reviewScreen: providers-add
     deleteConfirmationScreen: delete-provider
   children:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1816,6 +1816,27 @@ providers-add.button.add-a-provider=Add a provider
 providers-add.button.that-is-all=That is all the providers
 providers-add.list.header=Your Providers
 
+#providers-type
+providers-type.title=Provider type
+providers-type.header=Which best describes your child care provider?
+providers-type.option1=An individual
+providers-type.option1-help=A friend or relative
+providers-type.option2=A child care program
+providers-type.option2-help=A day care center, home day care, or school
+
+#providers-name
+providers-name.title=Provider name
+providers-name.header=Add the provider name
+providers-name.first-name=Provider first name
+providers-name.help-text=This is optional if you've already entered a program name.
+providers-name.last-name=Provider last name
+providers-name.at-least-one=You must enter <strong>at least one type</strong> of name
+provider-name.care-program=Child care program name
+provider-name.business-name=Enter the business name of the day care program or school.
+provider-name.enter-full-name=Enter the provider's first and last name to continue.
+providers-name.enter-one-or-other=Make sure to enter the child care program name or the provider's first and last name
+
+
 #providers-info
 providers-info.title=Add a child care provider
 providers-info.header=Add a child care provider

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1837,15 +1837,13 @@ provider-name.enter-full-name=Enter the provider's first and last name to contin
 providers-name.enter-one-or-other=Make sure to enter the child care program name or the provider's first and last name
 
 
-#providers-info
-providers-info.title=Add a child care provider
-providers-info.header=Add a child care provider
-providers-info.name=Provider name
-providers-info.name.subtext=Either first and last name, or name of the child care center.
-providers-info.street-address=Provider street address
-providers-info.street-address.subtext=Enter the street address where they are providing the care.
-providers-info.city=Provider city
-providers-info.state=Provider state
+#providers-location
+providers-location.title=Add a child care provider
+providers-location.header=Add a child care provider
+providers-location.street-address=Provider street address
+providers-location.street-address.subtext=Enter the street address where they are providing the care.
+providers-location.city=Provider city
+providers-location.state=Provider state
 
 #providers-contact-info
 providers-contact-info.title=Provider contact info

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -1807,15 +1807,13 @@ providers-add.button.add-a-provider=Agregar un proveedor
 providers-add.button.that-is-all=Esos son todos los proveedores
 providers-add.list.header=Sus proveedores
 
-#providers-info
-providers-info.title=Agregar a sus proveedores de cuidado de niños
-providers-info.header=Agregar a sus proveedores de cuidado de niños
-providers-info.name=Nombre del proveedor
-providers-info.name.subtext=Nombre y apellido, o nombre del centro de cuidado de niños.
-providers-info.street-address=Dirección del proveedor
-providers-info.street-address.subtext=Ingrese la dirección donde están brindando el cuidado.
-providers-info.city=Ciudad del proveedo
-providers-info.state=Estado del proveedo
+#providers-location
+providers-location.title=Agregar a sus proveedores de cuidado de niños
+providers-location.header=Agregar a sus proveedores de cuidado de niños
+providers-location.street-address=Dirección del proveedor
+providers-location.street-address.subtext=Ingrese la dirección donde están brindando el cuidado.
+providers-location.city=Ciudad del proveedo
+providers-location.state=Estado del proveedo
 
 #providers-contact-info
 providers-contact-info.title=Información de contacto

--- a/src/main/resources/pdf-map.yaml
+++ b/src/main/resources/pdf-map.yaml
@@ -144,7 +144,6 @@ inputFields:
   providerResponse: PROVIDER_RESPONSE
   providerResponseFirstName: PROVIDER_NAME_FIRST
   providerResponseLastName: PROVIDER_NAME_LAST
-  providerFirstName: PROVIDER_NAME_FIRST
   providerResponseBusinessName: PROVIDER_NAME_CORPORATE
   providerResponseServiceStreetAddress1: PROVIDER_ADDRESS_SERVICE_STREET
   providerResponseServiceStreetAddress2: PROVIDER_ADDRESS_SERVICE_APT

--- a/src/main/resources/pdf-map.yaml
+++ b/src/main/resources/pdf-map.yaml
@@ -144,6 +144,7 @@ inputFields:
   providerResponse: PROVIDER_RESPONSE
   providerResponseFirstName: PROVIDER_NAME_FIRST
   providerResponseLastName: PROVIDER_NAME_LAST
+  providerFirstName: PROVIDER_NAME_FIRST
   providerResponseBusinessName: PROVIDER_NAME_CORPORATE
   providerResponseServiceStreetAddress1: PROVIDER_ADDRESS_SERVICE_STREET
   providerResponseServiceStreetAddress2: PROVIDER_ADDRESS_SERVICE_APT

--- a/src/main/resources/templates/fragments/inputs/overrides/cardHeaderForSingleInputScreen.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/cardHeaderForSingleInputScreen.html
@@ -1,0 +1,15 @@
+<header th:classappend="${headerClasses}"
+        th:fragment="cardHeaderForSingleInputScreen"
+        th:with="
+    hasSubtext=${!#strings.isEmpty(subtext)},
+    requiredInputsForFlow=${requiredInputs.get(flow)},
+      isRequiredInput=${(requiredInputsForFlow != null && inputName != null && requiredInputsForFlow.getOrDefault(inputName, false)) || (required != null && required)}"
+        th:assert="${!#strings.isEmpty(header)}"
+        class="form-card__header">
+  <h1 id="header" class="h2">
+    <span th:text="${header + ' '}"></span><span th:if="${isRequiredInput}" class="required-input" th:text="#{general.required-field}"></span>
+  </h1>
+  <p id="header-help-message"
+     th:if="${hasSubtext}"
+     th:utext="${subtext}"></p>
+</header>

--- a/src/main/resources/templates/fragments/inputs/overrides/screenWithOneInput.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/screenWithOneInput.html
@@ -1,0 +1,45 @@
+<th:block
+        th:fragment="screenWithOneInput"
+        th:with="
+      hasIconFragment=${!#strings.isEmpty(iconFragment)},
+      hasIconName=${!#strings.isEmpty(iconName)}"
+        th:assert="
+      ${!#strings.isEmpty(title)},
+      ${!#strings.isEmpty(header)},
+      ${!#strings.isEmpty(formAction)},
+      ${inputContent != null}">
+  <!DOCTYPE html>
+  <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="~{fragments/head :: head(title=${title})}"></head>
+  <body>
+  <div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+      <div class="grid">
+        <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+        <main id="content" role="main" class="form-card spacing-above-35">
+          <th:block th:replace="${hasIconName} ? ~{'fragments/icons' :: ${iconName}} : _"/>
+          <th:block th:replace="${hasIconFragment} ? ${iconFragment} : _"/>
+          <th:block
+                  th:replace="~{fragments/inputs/overrides/cardHeaderForSingleInputScreen :: 
+              cardHeaderForSingleInputScreen(header=${header}, subtext=${subtext}, inputName=${inputName}, required=${required}, headerClasses=${headerClasses})}"/>
+          <th:block
+                  th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+            <th:block th:ref="formContent">
+              <div class="form-card__content">
+                <th:block th:replace="${inputContent}"/>
+              </div>
+              <div class="form-card__footer">
+                <th:block
+                        th:replace="~{fragments/inputs/submitButton :: submitButton(text=${buttonLabel != null ? buttonLabel : 'Submit'})}"/>
+              </div>
+            </th:block>
+          </th:block>
+        </main>
+      </div>
+    </section>
+  </div>
+  <th:block th:replace="~{fragments/footer :: footer}"/>
+  </body>
+  </html>
+</th:block>

--- a/src/main/resources/templates/gcc/providers-add.html
+++ b/src/main/resources/templates/gcc/providers-add.html
@@ -38,7 +38,7 @@
                               <li th:class="spacing-below-0"
                                   th:utext="${provider.familyIntendedProviderEmail}"></li>
                               <li class="text--small spacing-above-15 spacing-below-25 spacing-right-25">
-                                <a th:href="'/flow/' + ${flow} + '/providers-info/' + ${provider.uuid} + '/edit'"
+                                <a th:href="'/flow/' + ${flow} + '/providers-location/' + ${provider.uuid} + '/edit'"
                                    th:text="#{general.edit}"
                                    class="subflow-delete padding-right-25"
                                    th:id="'edit-iteration-' + ${provider.uuid}"></a>
@@ -64,7 +64,7 @@
                   </a>
                 </div>
                 <div th:if="${hasProviders}">
-                  <a th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'"
+                  <a th:href="'/flow/' + ${flow} + '/providers-info-confirm'"
                      th:text="#{providers-add.button.that-is-all}"
                      class="button spacing-left-0"
                      id="continue-link"></a>

--- a/src/main/resources/templates/gcc/providers-add.html
+++ b/src/main/resources/templates/gcc/providers-add.html
@@ -57,7 +57,7 @@
               <div class="form-card__footer">
                 <div class="spacing-below-15">
                   <a id="add-providers"
-                     th:href="'/flow/' + ${flow} + '/providers-info'"
+                     th:href="'/flow/' + ${flow} + '/providers-type'"
                      th:class="'button button--primary spacing-above-15' + ${maxProvidersReached ? ' disabled' : ''}">
                     <i class="icon-add"></i>
                     <span th:text="#{providers-add.button.add-a-provider}"></span>

--- a/src/main/resources/templates/gcc/providers-add.html
+++ b/src/main/resources/templates/gcc/providers-add.html
@@ -38,7 +38,7 @@
                               <li th:class="spacing-below-0"
                                   th:utext="${provider.familyIntendedProviderEmail}"></li>
                               <li class="text--small spacing-above-15 spacing-below-25 spacing-right-25">
-                                <a th:href="'/flow/' + ${flow} + '/providers-location/' + ${provider.uuid} + '/edit'"
+                                <a th:href="'/flow/' + ${flow} + '/providers-type/' + ${provider.uuid} + '/edit'"
                                    th:text="#{general.edit}"
                                    class="subflow-delete padding-right-25"
                                    th:id="'edit-iteration-' + ${provider.uuid}"></a>

--- a/src/main/resources/templates/gcc/providers-location.html
+++ b/src/main/resources/templates/gcc/providers-location.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title=#{providers-info.title})}"></head>
+<head th:replace="~{fragments/head :: head(title=#{providers-location.title})}"></head>
 <body>
 <div class="page-wrapper">
   <div th:replace="~{fragments/toolbar :: toolbar}"></div>
@@ -9,24 +9,20 @@
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:replace="~{fragments/gcc-icons :: care}"></th:block>
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{providers-info.header})}"/>
+        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{providers-location.header})}"/>
         <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
             <div class="form-card__content">
               <th:block th:replace="~{fragments/inputs/text ::
-                text(inputName='familyIntendedProviderName',
-                label=#{providers-info.name},
-                helpText=#{providers-info.name.subtext})}" />
-              <th:block th:replace="~{fragments/inputs/text ::
                   text(inputName='familyIntendedProviderAddress',
-                  label=#{providers-info.street-address},
-                  helpText=#{providers-info.street-address.subtext})}"/>
+                  label=#{providers-location.street-address},
+                  helpText=#{providers-location.street-address.subtext})}"/>
               <th:block th:replace="~{fragments/inputs/text ::
                   text(inputName='familyIntendedProviderCity',
-                  label=#{providers-info.city})}"/>
+                  label=#{providers-location.city})}"/>
               <th:block th:replace="~{fragments/inputs/state ::
                   state(inputName='familyIntendedProviderState',
-                  label=#{providers-info.state})}"/>
+                  label=#{providers-location.state})}"/>
             <div class="form-card__footer">
               <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
             </div>

--- a/src/main/resources/templates/gcc/providers-name.html
+++ b/src/main/resources/templates/gcc/providers-name.html
@@ -7,8 +7,8 @@
   <section class="slab">
     <div class="grid">
       <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main th:with="providerIsIndividual=${@providerIsIndividual.run(submission)},
-                     providerIsCareProgram=${@providerIsCareProgram.run(submission)},
+      <main th:with="providerIsIndividual=${@providerIsIndividual.run(submission, currentSubflowItem.get('uuid'))},
+                     providerIsCareProgram=${@providerIsCareProgram.run(submission, currentSubflowItem.get('uuid'))},
                      subtext=${providerIsCareProgram} ? #{providers-name.at-least-one} : null,
                      helpText=${providerIsCareProgram} ? #{providers-name.help-text} : null,"
                      id="content" role="main" class="form-card spacing-above-35">

--- a/src/main/resources/templates/gcc/providers-name.html
+++ b/src/main/resources/templates/gcc/providers-name.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(title=#{providers-name.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+      <main th:with="providerIsIndividual=${@providerIsIndividual.run(submission)},
+                     providerIsCareProgram=${@providerIsCareProgram.run(submission)},
+                     subtext=${providerIsCareProgram} ? #{providers-name.at-least-one} : null,
+                     helpText=${providerIsCareProgram} ? #{providers-name.help-text} : null,"
+                     id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="~{fragments/gcc-icons :: care}"></th:block>
+        <th:block
+            th:replace="~{fragments/cardHeader :: cardHeader(required=${providerIsCareProgram}, header=#{providers-name.header}, subtext=${subtext})}"/>
+          <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::content})}">
+            <th:block th:ref="content">
+              <div class="form-card__content">
+                <th:block th:if="${providerIsCareProgram}">
+                  <th:block th:replace="~{fragments/inputs/text ::
+                  text(inputName='childCareProgramName',
+                  label=#{provider-name.care-program},
+                  helpText=#{provider-name.business-name})}"/>
+                </th:block>
+                <th:block th:replace="~{fragments/inputs/text ::
+                  text(inputName='providerFirstName',
+                  required=${providerIsIndividual},
+                  label=#{providers-name.first-name},
+                  helpText=${helpText})}"/>
+                <th:block th:replace="~{fragments/inputs/text ::
+                  text(inputName='providerLastName',
+                  required=${providerIsIndividual},
+                  label=#{providers-name.last-name},
+                  helpText=${helpText})}"/>
+              </div>
+            <div class="form-card__footer">
+              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{general.inputs.continue})}"/>
+            </div>
+          </th:block>
+        </th:block>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}" />
+</body>
+</html>

--- a/src/main/resources/templates/gcc/providers-type.html
+++ b/src/main/resources/templates/gcc/providers-type.html
@@ -1,0 +1,29 @@
+<th:block
+  th:replace="~{fragments/inputs/overrides/screenWithOneInput ::
+  screenWithOneInput(
+    title=#{providers-type.title},
+    required=true,
+    iconFragment=~{fragments/gcc-icons :: care},
+    header=#{providers-type.header},
+    headerClasses='spacing-below-0',
+    inputName='providerType',
+    formAction=${formAction},
+    inputContent=~{::inputContent})}">
+  <th:block th:ref="inputContent">
+    <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                  radioFieldset(inputName='providerType',
+                  ariaLabel='header',
+                  content=~{::content})}">
+                  <th:block th:ref="content">
+                    <th:block
+                        th:replace="~{fragments/inputs/radio :: radio(inputName='providerType', value='Individual', 
+                        label=#{providers-type.option1}, 
+                        radioHelpText=#{providers-type.option1-help})}"/>
+                    <th:block
+                            th:replace="~{fragments/inputs/radio :: radio(inputName='providerType', value='Care Program', 
+                        label=#{providers-type.option2}, 
+                        radioHelpText=#{providers-type.option2-help})}"/>
+                  </th:block>
+                </th:block>
+  </th:block>
+</th:block>

--- a/src/main/resources/templates/gcc/providers-type.html
+++ b/src/main/resources/templates/gcc/providers-type.html
@@ -8,6 +8,7 @@
     headerClasses='spacing-below-0',
     inputName='providerType',
     formAction=${formAction},
+    buttonLabel=#{general.inputs.continue},
     inputContent=~{::inputContent})}">
   <th:block th:ref="inputContent">
     <th:block th:replace="~{fragments/inputs/radioFieldset ::

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -517,10 +517,6 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-chosen.title"));
         testPage.clickYes();
 
-        //providers-all-ccap-children
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-all-ccap-children.title"));
-        testPage.clickYes();
-
         //First Iteration
         //providers-add
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-add.title"));
@@ -873,10 +869,18 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-add.header"));
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
 
-        //providers-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
+        //providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
 
-        testPage.enter("familyIntendedProviderName", "First Daycare");
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "First Daycare");
+        testPage.clickContinue();
+
+        //providers-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         testPage.enter("familyIntendedProviderAddress", "222 Test St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -517,6 +517,10 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-chosen.title"));
         testPage.clickYes();
 
+        //providers-all-ccap-children
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-all-ccap-children.title"));
+        testPage.clickYes();
+
         //First Iteration
         //providers-add
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-add.title"));

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -250,16 +250,41 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-add.title"));
         assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-add.header"));
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
-
-        //providers-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-info.header"));
+        
+        //providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Individual");
+        testPage.clickContinue();
+        
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        assertThat(testPage.elementDoesNotExistById("childCareProgramName")).isTrue();
+        assertThat(testPage.findElementById("providerFirstName")).isNotNull();
+        assertThat(testPage.findElementById("providerLastName")).isNotNull();
+        
+        // Go back and Select Care Program
+        testPage.goBack();
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        assertThat(testPage.findElementById("childCareProgramName")).isNotNull();
+        assertThat(testPage.findElementById("providerFirstName")).isNotNull();
+        assertThat(testPage.findElementById("providerLastName")).isNotNull();
+        testPage.enter("childCareProgramName", "ACME Daycare");
         testPage.clickContinue();
 
+        //providers-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
+        assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-location.header"));
+        testPage.clickContinue();
+        
+        
         assertThat(testPage.hasErrorText(getEnMessage("errors.provide-street"))).isTrue();
         assertThat(testPage.hasErrorText(getEnMessage("errors.provide-city"))).isTrue();
-
-        testPage.enter("familyIntendedProviderName", "ACME Daycare");
+        
         testPage.enter("familyIntendedProviderAddress", "101 Test St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -287,9 +312,18 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
 
         //Second Iteration
+        // providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        // providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "Nope Test");
+        testPage.clickContinue();
+        
         //provider-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        testPage.enter("familyIntendedProviderName", "Nope Test");
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         testPage.enter("familyIntendedProviderAddress", "151 Second St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -492,16 +526,25 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-add.title"));
         assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-add.header"));
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
+        
+        //providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "ACME Daycare");
+        testPage.clickContinue();
 
-        //providers-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-info.header"));
+        //providers-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
+        assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-location.header"));
         testPage.clickContinue();
 
         assertThat(testPage.hasErrorText(getEnMessage("errors.provide-street"))).isTrue();
         assertThat(testPage.hasErrorText(getEnMessage("errors.provide-city"))).isTrue();
 
-        testPage.enter("familyIntendedProviderName", "ACME Daycare");
         testPage.enter("familyIntendedProviderAddress", "101 Test St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -529,9 +572,18 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
 
         //Second Iteration
-        //provider-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        testPage.enter("familyIntendedProviderName", "Nope Test");
+        // providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        // providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "Nope Test");
+        testPage.clickContinue();
+
+        //provider-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         testPage.enter("familyIntendedProviderAddress", "151 Second St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -551,9 +603,19 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
 
         //Third Iteration
-        //provider-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        testPage.enter("familyIntendedProviderName", "Third Provider");
+        //providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "Third Provider");
+        testPage.clickContinue();
+        
+        
+        //provider-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         testPage.enter("familyIntendedProviderAddress", "441 Third St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -595,10 +657,19 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.findElementById("continue-link").getCssValue("pointer-events")).isEqualTo("auto");
         assertThat(testPage.findElementById("add-providers").getCssValue("pointer-events")).isEqualTo("auto");
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
+        
+        //provider-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        //provider-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "Nope Test");
+        testPage.clickContinue();
 
-        //provider-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        testPage.enter("familyIntendedProviderName", "Nope Test");
+        //provider-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         testPage.enter("familyIntendedProviderAddress", "151 Second St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -648,11 +719,20 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-add.title"));
         assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-add.header"));
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
+        
+        //providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "First Daycare");
+        testPage.clickContinue();
 
-        //providers-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
+        //providers-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
 
-        testPage.enter("familyIntendedProviderName", "First Daycare");
         testPage.enter("familyIntendedProviderAddress", "222 Test St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -687,9 +767,18 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickButton(getEnMessage("providers-add.button.add-a-provider"));
 
         //Second Iteration
+        //provider-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        testPage.selectRadio("providerType", "Care Program");
+        testPage.clickContinue();
+        
+        //provider-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        testPage.enter("childCareProgramName", "No Provider");
+        testPage.clickContinue();
+        
         //provider-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        testPage.enter("familyIntendedProviderName", "No Provider");
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         testPage.enter("familyIntendedProviderAddress", "323 Second St");
         testPage.enter("familyIntendedProviderCity", "Chicago");
         testPage.selectFromDropdown("familyIntendedProviderState", "IL - Illinois");
@@ -708,9 +797,10 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.findElementById("add-providers").getCssValue("pointer-events")).isEqualTo("none");
         testPage.clickLink(getEnMessage("general.edit"));
 
-        //providers-info
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info.title"));
-        assertThat(testPage.getInputValue("familyIntendedProviderName")).isEqualTo("First Daycare");
+        //providers-location
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
+        assertThat(testPage.getInputValue("familyIntendedProviderAddress")).isEqualTo("222 Test St");
+
         testPage.clickContinue();
 
         //providers-contact-info

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -796,7 +796,17 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         assertThat(testPage.findElementById("continue-link").getCssValue("pointer-events")).isEqualTo("auto");
         assertThat(testPage.findElementById("add-providers").getCssValue("pointer-events")).isEqualTo("none");
         testPage.clickLink(getEnMessage("general.edit"));
-
+        
+        //providers-type
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-type.title"));
+        assertThat(testPage.findElementById("providerType-Care Program").isSelected()).isTrue();
+        testPage.clickContinue();
+        
+        //providers-name
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
+        assertThat(testPage.getInputValue("childCareProgramName")).isEqualTo("First Daycare");
+        testPage.clickContinue();
+        
         //providers-location
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-location.title"));
         assertThat(testPage.getInputValue("familyIntendedProviderAddress")).isEqualTo("222 Test St");

--- a/src/test/java/org/ilgcc/app/journeys/GccSingleProviderJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccSingleProviderJourneyTest.java
@@ -1,8 +1,19 @@
 package org.ilgcc.app.journeys;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.awaitility.Awaitility.await;
+import static org.ilgcc.app.data.importer.FakeResourceOrganizationAndCountyData.ACTIVE_FOUR_C_COUNTY;
+
 import com.lowagie.text.pdf.AcroFields;
 import com.lowagie.text.pdf.PdfReader;
 import formflow.library.data.SubmissionRepository;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.AbstractBasePageTest;
@@ -10,18 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.fail;
-import static org.awaitility.Awaitility.await;
-import static org.ilgcc.app.data.importer.FakeResourceOrganizationAndCountyData.ACTIVE_FOUR_C_COUNTY;
 
 @Slf4j
 public class GccSingleProviderJourneyTest extends AbstractBasePageTest {

--- a/src/test/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerServiceTest_MultipleProvider.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerServiceTest_MultipleProvider.java
@@ -33,7 +33,7 @@ public class ProviderSubmissionFieldPreparerServiceTest_MultipleProvider {
 
     private Submission familySubmission;
 
-    private static String FAM_INTENDED_PROVIDER_NAME = "IntendedProviderName";
+    private static String FAM_INTENDED_PROVIDER_NAME = "ChildCareProgramName";
     private static String FAM_INTENDED_PROVIDER_PHONE = "(125) 785-67896";
     private static String FAM_INTENDED_PROVIDER_EMAIL = "mail@test.com";
 
@@ -42,7 +42,7 @@ public class ProviderSubmissionFieldPreparerServiceTest_MultipleProvider {
         Map<String, Object> provider = new HashMap<>();
         provider.put("uuid", "first-provider-uuid");
         provider.put("iterationIsComplete", true);
-        provider.put("familyIntendedProviderName", FAM_INTENDED_PROVIDER_NAME);
+        provider.put("childCareProgramName", FAM_INTENDED_PROVIDER_NAME);
         provider.put("familyIntendedProviderEmail", FAM_INTENDED_PROVIDER_EMAIL);
         provider.put("familyIntendedProviderPhoneNumber", FAM_INTENDED_PROVIDER_PHONE);
 

--- a/src/test/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerServiceTest_SingleProvider.java
+++ b/src/test/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerServiceTest_SingleProvider.java
@@ -53,7 +53,7 @@ public class ProviderSubmissionFieldPreparerServiceTest_SingleProvider {
                 .withFlow("gcc")
                 .withSubmittedAtDate(OffsetDateTime.now().minusDays(10))
                 .withDayCareProvider()
-                .with("familyIntendedProviderName", FAM_INTENDED_PROVIDER_NAME)
+                .with("childCareProgramName", FAM_INTENDED_PROVIDER_NAME)
                 .with("familyIntendedProviderPhoneNumber", FAM_INTENDED_PROVIDER_PHONE)
                 .with("familyIntendedProviderEmail", FAM_INTENDED_PROVIDER_EMAIL)
                 .build();


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1021

#### ✍️ Description
Adds provider type and provider name screens with conditional display logic for inputs on provider-name depending on provider-type selection:

**provider-type:**
![Screenshot 2025-06-23 at 10 07 08 AM](https://github.com/user-attachments/assets/51f45b93-ed33-42f5-8336-8111e580f4ec)

**provider-name (individual):**
![Screenshot 2025-06-23 at 11 04 02 AM](https://github.com/user-attachments/assets/b3e5e546-39a2-4f73-9679-a2516f102679)

**provider-name (Care Program):**
![Screenshot 2025-06-23 at 11 04 47 AM](https://github.com/user-attachments/assets/0b65947d-d8da-4d07-a9b6-1ed26403e7bb)

**The `provider-info` screen now becomes `provider-location` and the name input is removed.**
![Screenshot 2025-06-23 at 2 50 20 PM](https://github.com/user-attachments/assets/3269c100-2572-4add-b6f6-95657794c80a)



#### 📷 Design reference
[<!-- Figma link or screenshot if applicable -->
](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=20371-54603)
