### PR TITLE
[CCAP-939] Fix issues from schedule-start.html

### DIFF
--- a/src/main/resources/templates/gcc/schedules-start.html
+++ b/src/main/resources/templates/gcc/schedules-start.html
@@ -1,7 +1,8 @@
 <th:block th:with="childName=${relatedSubflowIteration.get('childFirstName')},
                    hasProviders=${submission.getInputData().containsKey('providers')},
                    hasMoreThanOneProvider=${hasProviders && submission.getInputData().get('providers').size() > 1},
-                   providersList=${submission.getInputData().get('providers')}">
+                   providersList=${submission.getInputData().get('providers')},
+                   showNoProviderOption=${submission.getInputData().getOrDefault('choseProviderForEveryChildInNeedOfCare', 'false').equals('false')}">
     <th:block
             th:replace="~{fragments/screens/screenWithOneInput ::
   screenWithOneInput(
@@ -26,9 +27,10 @@
                             <th:block
                                     th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='childcareProvidersForCurrentChild',value=${provider.get('uuid')}, label=${provider.get('familyIntendedProviderName')})}"/>
                         </th:block>
-                        <th:block>
+
+                        <th:block th:if="${showNoProviderOption}">
                             <th:block
-                                    th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='childcareProvidersForCurrentChild',value='NO_PROVIDER', label=#{schedules-start.no-provider})}"/>
+                                    th:replace="~{fragments/inputs/checkboxInSet :: checkboxInSet(inputName='childcareProvidersForCurrentChild',value='NO_PROVIDER', label=#{schedules-start.no-provider}, noneOfTheAbove=true)}"/>
                         </th:block>
                     </th:block>
                 </th:block>

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -354,8 +354,8 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         List<Map<String,Object>> providers = (List<Map<String, Object>>) getSessionSubmission().getInputData().get("providers");
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start.title"));
         assertThat(testPage.getHeader()).containsIgnoringCase("Child");
+        testPage.clickElementById("none__checkbox-childcareProvidersForCurrentChild-label");
         testPage.clickElementById(String.format("childcareProvidersForCurrentChild-%s-label", providers.get(0).get("uuid")));
-        testPage.clickElementById("childcareProvidersForCurrentChild-NO_PROVIDER-label");
         testPage.clickContinue();
 
         //schedules-start-care
@@ -399,41 +399,6 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         testPage.selectFromDropdown("childcareEndTimeFridayHour", "12");
         testPage.enter("childcareEndTimeFridayMinute", "00");
         testPage.selectFromDropdown("childcareEndTimeFridayAmPm", "PM");
-
-        testPage.clickContinue();
-
-        // second iteration
-        // skips schedules-start-care
-
-        // skips schedules-start-date
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-date.title"));
-        assertThat(testPage.getHeader()).containsIgnoringCase(getEnMessageWithParams("schedules-start-date.header.no-provider",
-            new Object[]{"Child"}));
-        assertThat(testPage.getHeader()).containsIgnoringCase("Child");
-        testPage.enter("ccapStartMonth", "10");
-        testPage.enter("ccapStartDay", "15");
-        testPage.enter("ccapStartYear", "2025");
-
-        testPage.clickContinue();
-
-        //schedules-days
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-days.title"));
-        assertThat(testPage.getHeader()).containsIgnoringCase(getEnMessageWithParams("schedules-days.header.no-provider",
-            new Object[]{"Child"}));
-        testPage.clickElementById("childcareWeeklySchedule-Monday");
-        testPage.clickContinue();
-
-        //schedules-hours
-        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-hours.title"));
-        assertThat(testPage.getHeader()).containsIgnoringCase(getEnMessageWithParams("schedules-hours.header.no-provider",
-            new Object[]{"Child"}));
-        testPage.selectFromDropdown("childcareStartTimeMondayHour", "10");
-        testPage.enter("childcareStartTimeMondayMinute", "00");
-        testPage.selectFromDropdown("childcareStartTimeMondayAmPm", "AM");
-
-        testPage.selectFromDropdown("childcareEndTimeMondayHour", "10");
-        testPage.enter("childcareEndTimeMondayMinute", "00");
-        testPage.selectFromDropdown("childcareEndTimeMondayAmPm", "PM");
 
         testPage.clickContinue();
 
@@ -665,7 +630,7 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         
         //provider-name
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-name.title"));
-        testPage.enter("childCareProgramName", "Nope Test");
+        testPage.enter("childCareProgramName", "Favorite Daycare");
         testPage.clickContinue();
 
         //provider-location
@@ -692,6 +657,212 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
         //providers-info-confirm
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-info-confirm.title"));
         assertThat(testPage.getHeader()).isEqualTo(getEnMessage("providers-info-confirm.header"));
+        testPage.clickContinue();
+
+        //schedules-intro
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-intro-multiple.title"));
+        assertThat(testPage.findElementTextById("schedules-intro-multiple-step")).isEqualTo("Step 5 of 7");
+
+        testPage.clickContinue();
+
+        //schedules-start
+        List<Map<String,Object>> providers = (List<Map<String, Object>>) getSessionSubmission().getInputData().get("providers");
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Child");
+        testPage.clickElementById(String.format("childcareProvidersForCurrentChild-%s-label", providers.get(0).get("uuid")));
+        testPage.clickContinue();
+
+        //ChildSchedule Iteration 1
+        //ChildSchedule: Child || ProviderSchedule: Nope Test
+        //schedules-start-care
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-care.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Nope Test");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Child");
+        testPage.clickYes();
+
+        //schedules-start-date
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-date.title"));
+        testPage.enter("ccapStartMonth", "10");
+        testPage.enter("ccapStartDay", "15");
+        testPage.enter("ccapStartYear", "2025");
+
+        testPage.clickContinue();
+
+        //schedules-days
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-days.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Nope Test");
+        assertThat(testPage.getHeader()).containsIgnoringCase("First");
+        testPage.clickElementById("childcareWeeklySchedule-Thursday");
+        testPage.clickElementById("childcareWeeklySchedule-Friday");
+        testPage.clickContinue();
+
+        //schedules-hours
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-hours.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Nope Test");
+        assertThat(testPage.getHeader()).containsIgnoringCase("First");
+        testPage.selectFromDropdown("childcareStartTimeThursdayHour", "10");
+        testPage.enter("childcareStartTimeThursdayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeThursdayAmPm", "AM");
+
+        testPage.selectFromDropdown("childcareEndTimeThursdayHour", "1");
+        testPage.enter("childcareEndTimeThursdayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeThursdayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareStartTimeFridayHour", "9");
+        testPage.enter("childcareStartTimeFridayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeFridayAmPm", "AM");
+
+        testPage.selectFromDropdown("childcareEndTimeFridayHour", "12");
+        testPage.enter("childcareEndTimeFridayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeFridayAmPm", "PM");
+
+        testPage.clickContinue();
+
+        //ChildSchedule Iteration 2
+        //schedules-start
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickElementById(String.format("childcareProvidersForCurrentChild-%s-label", providers.get(0).get("uuid")));
+        testPage.clickElementById(String.format("childcareProvidersForCurrentChild-%s-label", providers.get(1).get("uuid")));
+        testPage.clickElementById(String.format("childcareProvidersForCurrentChild-%s-label", providers.get(2).get("uuid")));
+        testPage.clickContinue();
+
+        //ChildSchedule: Second || ProviderSchedule: Nope Test
+        //schedules-start-care
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-care.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Nope Test");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickYes();
+
+        //schedules-start-date
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-date.title"));
+        testPage.enter("ccapStartMonth", "6");
+        testPage.enter("ccapStartDay", "12");
+        testPage.enter("ccapStartYear", "2025");
+
+        testPage.clickContinue();
+
+        //schedules-days
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-days.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Nope Test");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickElementById("childcareWeeklySchedule-Monday");
+        testPage.clickElementById("childcareWeeklySchedule-Tuesday");
+        testPage.clickContinue();
+
+        //schedules-hours
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-hours.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Nope Test");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.selectFromDropdown("childcareStartTimeMondayHour", "4");
+        testPage.enter("childcareStartTimeMondayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeMondayAmPm", "AM");
+
+        testPage.selectFromDropdown("childcareEndTimeMondayHour", "12");
+        testPage.enter("childcareEndTimeMondayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeMondayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareStartTimeTuesdayHour", "2");
+        testPage.enter("childcareStartTimeTuesdayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeTuesdayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareEndTimeTuesdayHour", "10");
+        testPage.enter("childcareEndTimeTuesdayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeTuesdayAmPm", "PM");
+
+        testPage.clickContinue();
+        //ChildSchedule: Second || ProviderSchedule: Third Provider
+        //schedules-start-care
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-care.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Third Provider");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickYes();
+
+        //schedules-start-date
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-date.title"));
+        testPage.enter("ccapStartMonth", "6");
+        testPage.enter("ccapStartDay", "12");
+        testPage.enter("ccapStartYear", "2025");
+
+        testPage.clickContinue();
+
+        //schedules-days
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-days.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Third Provider");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickElementById("childcareWeeklySchedule-Wednesday");
+        testPage.clickElementById("childcareWeeklySchedule-Saturday");
+        testPage.clickContinue();
+
+        //schedules-hours
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-hours.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Third Provider");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.selectFromDropdown("childcareStartTimeWednesdayHour", "4");
+        testPage.enter("childcareStartTimeWednesdayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeWednesdayAmPm", "AM");
+
+        testPage.selectFromDropdown("childcareEndTimeWednesdayHour", "12");
+        testPage.enter("childcareEndTimeWednesdayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeWednesdayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareStartTimeSaturdayHour", "2");
+        testPage.enter("childcareStartTimeSaturdayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeSaturdayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareEndTimeSaturdayHour", "10");
+        testPage.enter("childcareEndTimeSaturdayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeSaturdayAmPm", "PM");
+
+        testPage.clickContinue();
+
+        //ChildSchedule: Second || ProviderSchedule: Favorite Daycare
+        //schedules-start-care
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-care.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Favorite Daycare");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickYes();
+
+        //schedules-start-date
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-start-date.title"));
+        testPage.enter("ccapStartMonth", "8");
+        testPage.enter("ccapStartDay", "12");
+        testPage.enter("ccapStartYear", "2025");
+
+        testPage.clickContinue();
+
+        //schedules-days
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-days.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Favorite Daycare");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.clickElementById("childcareWeeklySchedule-Wednesday");
+        testPage.clickElementById("childcareWeeklySchedule-Saturday");
+        testPage.clickContinue();
+
+        //schedules-hours
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-hours.title"));
+        assertThat(testPage.getHeader()).containsIgnoringCase("Favorite Daycare");
+        assertThat(testPage.getHeader()).containsIgnoringCase("Second");
+        testPage.selectFromDropdown("childcareStartTimeWednesdayHour", "4");
+        testPage.enter("childcareStartTimeWednesdayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeWednesdayAmPm", "AM");
+
+        testPage.selectFromDropdown("childcareEndTimeWednesdayHour", "12");
+        testPage.enter("childcareEndTimeWednesdayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeWednesdayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareStartTimeSaturdayHour", "2");
+        testPage.enter("childcareStartTimeSaturdayMinute", "00");
+        testPage.selectFromDropdown("childcareStartTimeSaturdayAmPm", "PM");
+
+        testPage.selectFromDropdown("childcareEndTimeSaturdayHour", "10");
+        testPage.enter("childcareEndTimeSaturdayMinute", "00");
+        testPage.selectFromDropdown("childcareEndTimeSaturdayAmPm", "PM");
+
+        testPage.clickContinue();
+        // schedules-review
+        assertThat(testPage.getTitle()).isEqualTo(getEnMessage("schedules-review.title"));
+        testPage.clickContinue();
     }
 
     @Test


### PR DESCRIPTION
# bugfix CCAP-939

## Acceptance
- [x] Only show no provider chose checkbox when client has selected no to question Have you chosen a provider for every child in need of child care
- [x] when client as No provider chosen checkbox available they can either select no provider or select
- the available providers.  They can not do both.  

### Has provider for every child
<img width="425" alt="image" src="https://github.com/user-attachments/assets/0412d33d-aacc-487b-92e4-88c44d6d2d32" />


### Does not have a provider for every child
<img width="365" alt="image" src="https://github.com/user-attachments/assets/bfb90bfa-71ba-4d1f-8267-c764fd678f4c" />


Video of No Provider Checkbox
https://www.loom.com/share/5b690e5183734308aed4e0858f2b693b?sid=481377a0-e7b1-4b20-8fce-394320fa28c9

## bugfix CCAP-941
- [x] Screen matches Design for start date
https://loom.com/i/f504369c427c428fa157640619108f43
- [ ] Added relevant tests
- [ ] Meets acceptance criteria
