### PR TITLE
[CCAP-1041] - childcareHoursSameEveryDay[] is not always set so we ne…

### DIFF
--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -12,6 +12,7 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -203,7 +204,7 @@ public class ProviderSubmissionUtilities {
     }
 
     public static Map<String, String> hoursRequested(Map<String, Object> child) {
-        List<String> sameHoursEveryday = (List) child.get("childcareHoursSameEveryDay[]");
+        List<String> sameHoursEveryday = (List) child.getOrDefault("childcareHoursSameEveryDay[]", Collections.EMPTY_LIST);
         List<String> daysRequested = (List) child.get("childcareWeeklySchedule[]");
         Map<String, String> dates = new LinkedHashMap<>();
         for (String day : daysRequested) {


### PR DESCRIPTION
…ed a default value

#### 🔗 Jira ticket
[CCAP-1041](https://codeforamerica.atlassian.net/browse/CCAP-1041)

#### ✍️ Description
- childcareHoursSameEveryDay[] is not always set, causing an error when referencing it in the schedules-review screen

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-1041]: https://codeforamerica.atlassian.net/browse/CCAP-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ