### PR TITLE
[CCAP-981] - creates multiple-providers screen and updates confirm-pr…

### DIFF
--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -22,6 +22,9 @@ public class Providerresponse extends FlowInputs {
 
     private String familySubmissionId;
 
+    @NotBlank(message="{errors.select-provider}")
+    private String currentProviderUuid;
+
     MultipartFile providerUploadDocuments;
 
     @NotNull(message = "{errors.provide-provider-number}")

--- a/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
@@ -32,7 +32,7 @@ public class FindApplicationData implements Action {
         if (familySubmissionId.isPresent()) {
             Optional<Submission> familySubmission = submissionRepositoryService.findById(familySubmissionId.get());
             providerSubmission.getInputData()
-                    .put("clientResponse", ProviderSubmissionUtilities.getFamilySubmissionForProviderResponse(familySubmission));
+                    .put("clientResponse", ProviderSubmissionUtilities.getFamilySubmission(familySubmission));
 
             List<Map<String, Object>> childData = ProviderSubmissionUtilities.getChildrenDataForProviderResponse(
                     familySubmission.get());

--- a/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyFamilySubmissionForDev.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/GenerateDummyFamilySubmissionForDev.java
@@ -82,7 +82,7 @@ public class GenerateDummyFamilySubmissionForDev implements Action {
         inputData.put("parentHasPartner", "false");
         inputData.put("earliestChildcareStartDate", "01/10/2025");
 
-        if(enableMultipleProviders){
+        if (enableMultipleProviders) {
             inputData.putAll(createMultipleProviders());
         } else {
             inputData.putAll(createSingleProvider(1));
@@ -181,13 +181,18 @@ public class GenerateDummyFamilySubmissionForDev implements Action {
         data.put(inputPrefix + startOrEndKey + "Time" + dayPostFix + "AmPm", amOrPm);
     }
 
-    public Map<String, Object> createMultipleProviders(){
+    public Map<String, Object> createMultipleProviders() {
         Map<String, Object> intendedFamilyData = new HashMap<>();
 
         List<Object> providers = new ArrayList<>();
 
         Map<String, Object> provider1 = createSingleProvider(1);
         provider1.put("iterationIsComplete", true);
+        provider1.put("uuid", "first-provider-id");
+        provider1.put("providerType", "Care Program");
+        provider1.put("providerLastName", "Hanson");
+        provider1.put("providerFirstName", "Philip");
+        provider1.put("childCareProgramName", "Baby Children Day Care Center");
         provider1.put("familyIntendedProviderCity", "Chicago");
         provider1.put("familyIntendedProviderState", "IL");
         provider1.put("familyIntendedProviderAddress", "123 Main Street");
@@ -196,6 +201,12 @@ public class GenerateDummyFamilySubmissionForDev implements Action {
 
         Map<String, Object> provider2 = createSingleProvider(2);
         provider2.put("iterationIsComplete", true);
+        provider2.put("uuid", "second-provider-id");
+        provider2.put("providerType", "Individual");
+        provider2.put("providerLastName", "King");
+        provider2.put("providerFirstName", "Brielle");
+        provider2.put("childCareProgramName", "Baby Children Day Care Center");
+        provider2.put("familyIntendedProviderName", "Baby Children Day Care Center");
         provider2.put("familyIntendedProviderCity", "Chicago");
         provider2.put("familyIntendedProviderState", "IL");
         provider2.put("familyIntendedProviderAddress", "223 Main Street");
@@ -204,6 +215,12 @@ public class GenerateDummyFamilySubmissionForDev implements Action {
 
         Map<String, Object> provider3 = createSingleProvider(3);
         provider3.put("iterationIsComplete", true);
+        provider3.put("uuid", "third-provider-id");
+        provider3.put("providerType", "Care Program");
+        provider3.put("providerLastName", "Holden");
+        provider3.put("providerFirstName", "Callum");
+        provider3.put("childCareProgramName", "");
+        provider3.put("familyIntendedProviderName", "Holden Callum");
         provider3.put("familyIntendedProviderCity", "Chicago");
         provider3.put("familyIntendedProviderState", "IL");
         provider3.put("familyIntendedProviderAddress", "323 Main Street");

--- a/src/main/java/org/ilgcc/app/submission/actions/SetProvidersData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetProvidersData.java
@@ -1,0 +1,40 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SetProvidersData implements Action {
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+
+    @Autowired
+    MessageSource messageSource;
+
+    @Override
+    public void run(Submission providerSubmission) {
+        Optional<String> familySubmissionShortCode =
+                ProviderSubmissionUtilities.getFamilySubmissionByShortCode(providerSubmission);
+        if (familySubmissionShortCode.isPresent()) {
+            Optional<Submission> familySubmission = submissionRepositoryService.findByShortCode(familySubmissionShortCode.get());
+
+            List<Map<String, Object>> providersData = ProviderSubmissionUtilities.getMultipleProviderDataForProviderResponse(
+                    familySubmission.get());
+
+            providerSubmission.getInputData().put("providersData", providersData);
+            submissionRepositoryService.save(providerSubmission);
+        }
+    }
+
+}

--- a/src/main/java/org/ilgcc/app/submission/actions/SetProvidersData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetProvidersData.java
@@ -25,11 +25,11 @@ public class SetProvidersData implements Action {
     @Override
     public void run(Submission providerSubmission) {
         Optional<String> familySubmissionShortCode =
-                ProviderSubmissionUtilities.getFamilySubmissionByShortCode(providerSubmission);
+                ProviderSubmissionUtilities.getFamilySubmissionShortCode(providerSubmission);
         if (familySubmissionShortCode.isPresent()) {
             Optional<Submission> familySubmission = submissionRepositoryService.findByShortCode(familySubmissionShortCode.get());
 
-            List<Map<String, Object>> providersData = ProviderSubmissionUtilities.getMultipleProviderDataForProviderResponse(
+            List<Map<String, Object>> providersData = ProviderSubmissionUtilities.getFamilyIntendedProviders(
                     familySubmission.get());
 
             providerSubmission.getInputData().put("providersData", providersData);

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -76,7 +76,7 @@ public class ProviderSubmissionUtilities {
         return Optional.empty();
     }
 
-    public static Optional<String> getFamilySubmissionByShortCode(Submission providerSubmission) {
+    public static Optional<String> getFamilySubmissionShortCode(Submission providerSubmission) {
         if (providerSubmission.getInputData().containsKey("providerResponseFamilyShortCode")) {
             String providerResponseFamilyShortCode = (String) providerSubmission.getInputData().get(
                     "providerResponseFamilyShortCode");
@@ -86,7 +86,7 @@ public class ProviderSubmissionUtilities {
         return Optional.empty();
     }
 
-    public static Map<String, String> getFamilySubmissionForProviderResponse(Optional<Submission> familySubmission) {
+    public static Map<String, String> getFamilySubmission(Optional<Submission> familySubmission) {
         Map<String, String> applicationData = new HashMap<>();
 
         if (familySubmission.isPresent()) {
@@ -152,7 +152,7 @@ public class ProviderSubmissionUtilities {
         return applicationData;
     }
 
-    public static List<Map<String, Object>> getMultipleProviderDataForProviderResponse(Submission familySubmission) {
+    public static List<Map<String, Object>> getFamilyIntendedProviders(Submission familySubmission) {
         List<Map<String, Object>> displayProviders = new ArrayList<>();
 
         List<Map<String, Object>> providers = (List<Map<String, Object>>) familySubmission.getInputData()
@@ -192,17 +192,18 @@ public class ProviderSubmissionUtilities {
         return displayProviders;
     }
 
-    public static Map<String, Object> getCurrentProvider(Submission providerSubmission){
+    public static Map<String, Object> getCurrentProvider(Submission providerSubmission) {
         String currentProviderUuid = providerSubmission.getInputData().getOrDefault("currentProviderUuid", "").toString();
-        List<Map<String, Object>> providers = (List<Map<String, Object>>) providerSubmission.getInputData().getOrDefault("providersData",
-                Collections.EMPTY_LIST);
+        List<Map<String, Object>> providers = (List<Map<String, Object>>) providerSubmission.getInputData()
+                .getOrDefault("providersData",
+                        Collections.EMPTY_LIST);
 
         Optional<Map<String, Object>> currentProvider = Optional.empty();
-        if(!currentProviderUuid.isBlank() && !providers.isEmpty()){
+        if (!currentProviderUuid.isBlank() && !providers.isEmpty()) {
             currentProvider = providers.stream().filter(provider -> provider.get("uuid").equals(currentProviderUuid)).findFirst();
         }
 
-        if(currentProvider.isPresent()){
+        if (currentProvider.isPresent()) {
             return currentProvider.get();
         } else {
             return null;

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -809,10 +809,12 @@ flow:
         condition: EnableMultipleProviders
       - name: paid-by-ccap
   multiple-providers:
+    condition: EnableMultipleProviders
     beforeDisplayAction: SetProvidersData
     nextScreens:
       - name: confirm-provider
   confirm-provider:
+    condition: EnableMultipleProviders
     nextScreens:
       - name: paid-by-ccap
   paid-by-ccap:

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -809,6 +809,7 @@ flow:
         condition: EnableMultipleProviders
       - name: paid-by-ccap
   multiple-providers:
+    beforeDisplayAction: SetProvidersData
     nextScreens:
       - name: confirm-provider
   confirm-provider:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -245,6 +245,8 @@ errors.invalid-communication-preference=Select mail or email to continue
 errors.invalid-dollar-amount=Enter a valid dollar amount. Example: 1.50
 errors.general-banner-warning=<strong>Sorry,</strong> You've either skipped a required question or provided information in an incorrect format. Check your answers to continue.
 errors.general-title=Check your answers
+errors.select-provider=Select one provider.
+
 
 # confirm-address
 confirm-address.title=Confirm Address
@@ -1281,6 +1283,11 @@ provider-response-submit-start.responded.notice=<div class='notice spacing-below
 provider-response-submit-start.responded.button=Return to home
 
 provider-response-submit-start.provider-placeholder=child care provider
+
+#provider-response-multiple-providers
+provider-response-multiple-providers.title=Multiple providers
+provider-response-multiple-providers.header=This family is applying with multiple child care providers
+provider-response-multiple-providers.subtext=<h3 class='with-no-padding'>Which provider are you?</h3><span class='text--help with-no-padding'><p>Select one.</p><p>For privacy reasons, names of the individuals are shown as initials only.</p><p>Some provider names may have errors because they were written by the family.</p>
 
 #provider-response-confirm-provider
 provider-response-confirm-provider.title=Confirm provider

--- a/src/main/resources/templates/providerresponse/confirm-provider.html
+++ b/src/main/resources/templates/providerresponse/confirm-provider.html
@@ -10,14 +10,15 @@
             <main id="content" role="main" class="form-card spacing-above-35">
                 <th:block th:replace="~{fragments/gcc-icons :: care}"></th:block>
                 <th:block
-                        th:with="selectedProviderIsIndividual=${true}, providerName=${'[PROVIDER]'}">
-                    <th:block th:if="${selectedProviderIsIndividual}">
+                        th:with="selectedProviderIsIndividual=${true},
+                        currentProvider=${T(org.ilgcc.app.utils.ProviderSubmissionUtilities).getCurrentProvider(submission)}">
+                    <th:block th:if="${currentProvider.getOrDefault('providerType', '').equals('Individual')}">
                         <th:block
-                                th:replace="~{fragments/cardHeader :: cardHeader(header=${#messages.msg('provider-response-confirm-provider.individual.header', providerName)}, subtext=#{provider-response-confirm-provider.individual.subtext})}"/>
+                                th:replace="~{fragments/cardHeader :: cardHeader(header=${#messages.msg('provider-response-confirm-provider.individual.header', currentProvider.get('displayName'))}, subtext=#{provider-response-confirm-provider.individual.subtext})}"/>
                     </th:block>
-                    <th:block th:unless="${selectedProviderIsIndividual}">
+                    <th:block th:if="${currentProvider.getOrDefault('providerType', '').equals('Care Program')}">
                         <th:block
-                                th:replace="~{fragments/cardHeader :: cardHeader(header=${#messages.msg('provider-response-confirm-provider.program.header', providerName)})}"/>
+                                th:replace="~{fragments/cardHeader :: cardHeader(header=${#messages.msg('provider-response-confirm-provider.program.header', currentProvider.get('displayName'))})}"/>
                     </th:block>
                     <th:block
                             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
@@ -33,7 +34,7 @@
                                         <a id="selected-wrong-provider-individual"
                                            th:href="'/flow/' + ${flow} + '/multiple-providers'"
                                            class="spacing-above-15">
-                                            <span th:text="${selectedProviderIsIndividual ? #messages.msg('provider-response-confirm-provider.individual.cta', providerName) : #messages.msg('provider-response-confirm-provider.program.cta', providerName)}"></span>
+                                            <span th:text="${#messages.msg('provider-response-confirm-provider.program.cta', currentProvider.get('displayName'))}"></span>
                                         </a>
                                     </div>
                                 </div>

--- a/src/main/resources/templates/providerresponse/multiple-providers.html
+++ b/src/main/resources/templates/providerresponse/multiple-providers.html
@@ -1,27 +1,52 @@
 <!DOCTYPE html>
-<html th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="~{fragments/head :: head(title='TEMPLATE')}"></head>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{provider-response-multiple-providers.title})}"></head>
 <body>
 <div class="page-wrapper">
-  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
-  <section class="slab">
-    <div class="grid">
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-      <main id="content" role="main" class="form-card spacing-above-35">
-        <th:block th:replace="~{fragments/cardHeader :: cardHeader(header=#{placeholder}, subtext=#{placeholder})}"/>
-        <th:block th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
-          <th:block th:ref="formContent">
-            <div class="form-card__content">
-                <!-- Put inputs here -->
-            </div>
-            <div class="form-card__footer">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
-            </div>
-          </th:block>
-        </th:block>
-      </main>
-    </div>
-  </section>
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/gcc-icons :: people}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{provider-response-multiple-providers.header}, noSpacingBelow=true, subtext=#{provider-response-multiple-providers.subtext})}"/>
+                <th:block
+                        th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
+                    <th:block th:ref="formContent">
+                        <div class="form-card__content">
+                            <th:block th:replace="~{fragments/inputs/radioFieldset ::
+                              radioFieldset(inputName='currentProviderUuid',
+                              ariaLabel='header',
+                              content=~{::content})}">
+                                <th:block th:ref="content">
+                                    <div class="grid__item address-validation spacing-below-60">
+                                        <th:block
+                                                th:each="provider: ${submission.getInputData.get('providersData')}">
+                                            <label th:for="${'current-provider-option-'+provider.get(displayName)}"
+                                                   class="radio-button">
+                                                <p class="spacing-below-15"
+                                                   th:text="${provider.get('displayName')}"></p>
+                                                <div th:utext="${provider.get('location')}"></div>
+                                                <input type="radio" th:name="currentProviderUuid"
+                                                       th:id="${'currentProviderUuid-'+provider.get(displayName)}"
+                                                       th:value="${provider.get('uuid')}"
+                                                       th:checked="false">
+                                            </label>
+                                        </th:block>
+                                    </div>
+                                </th:block>
+                            </th:block>
+                        </div>
+                        <div class="form-card__footer">
+                            <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(
+                  text=#{general.inputs.continue})}"/>
+                        </div>
+                    </th:block>
+                </th:block>
+            </main>
+        </div>
+    </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
 </body>


### PR DESCRIPTION
…ovider screen

#### 🔗 Jira ticket
CCAP-981

#### ✍️ Description
<!-- Brief summary of changes  -->

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks

- [ ] The providerresponse/multiple-providers screen exists
- [ ] The providerresponse/multiple-providers screen matches the designs
- [ ] The providerresponse/multiple-providers screen should only be shown
- [ ] When the ENABLE_MULTIPLE_PROVIDERS feature flag is enabled
- [ ] When the family application that the provider is responding to has multiple providers on it
- [ ] Otherwise the screen should be skipped
- [ ] The screen should display the details for all the providers added to the family application as radio button options
- [ ] For a provider that the family has indicated is a child care center, display
1. The provider name
2. The provider street address
3. The provider city
4.  The provider state

- [ ] For a provider that the family has indicated is providing child care in someone’s home, display
1.  Intials
2. The provider city
3. The provider state

- [ ] When the provider tries to proceed without selecting an option, display an error: Select one option
- [ ] Update the providerresponse/confirm-provider to include the details from the family application for the provider that the user selected on the providerresponse/multiple-providers screen
- [ ] Update the providerresponse/confirm-provider to include the details from the family application for the provider that the user selected on the providerresponse/multiple-providers screen

