### PR TITLE
[CCAP-932] storing providerResponseAgreeToCare at the provider level for multi provider

### DIFF
--- a/src/main/java/org/ilgcc/app/data/SubmissionSenderService.java
+++ b/src/main/java/org/ilgcc/app/data/SubmissionSenderService.java
@@ -91,7 +91,7 @@ public class SubmissionSenderService {
 
                 if (multipleProvidersEnabled) {
                     String currentProviderUuid = providerSubmission.getInputData().get("currentProviderUuid").toString();
-                    String providerResponseAgreeToCare = providerSubmission.getInputData().get("providerResponseAgreeToCare").toString();
+                    String providerResponseAgreeToCare = (String) providerSubmission.getInputData().get("providerResponseAgreeToCare");
 
                     boolean allProvidersResponded = true;
                     List<Map<String, Object>> providers = SubmissionUtilities.getProviders(familySubmission.getInputData());

--- a/src/main/java/org/ilgcc/app/data/SubmissionSenderService.java
+++ b/src/main/java/org/ilgcc/app/data/SubmissionSenderService.java
@@ -91,6 +91,7 @@ public class SubmissionSenderService {
 
                 if (multipleProvidersEnabled) {
                     String currentProviderUuid = providerSubmission.getInputData().get("currentProviderUuid").toString();
+                    String providerResponseAgreeToCare = providerSubmission.getInputData().get("providerResponseAgreeToCare").toString();
 
                     boolean allProvidersResponded = true;
                     List<Map<String, Object>> providers = SubmissionUtilities.getProviders(familySubmission.getInputData());
@@ -100,6 +101,7 @@ public class SubmissionSenderService {
                         if (currentProviderUuid.equals(provider.get("uuid").toString())) {
                             provider.put("providerResponseSubmissionId", providerSubmission.getId().toString());
                             provider.put("providerResponseStatus", SubmissionStatus.RESPONDED.name());
+                            provider.put("providerResponseAgreeToCare", providerResponseAgreeToCare);
                             providers.set(i, provider);
                         } else if (!provider.containsKey("providerResponseStatus") || !SubmissionStatus.RESPONDED.name().equals(provider.get("providerResponseStatus").toString())) {
                             allProvidersResponded = false;


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-932

#### ✍️ Description
Most of this ticket was covered by CCAP-1048, but this will add `providerResponseAgreeToCare` back into the family submission's `providers`: 

For example the second provider here:

```
"providers": [
    {
      "uuid": "0f377eb5-092a-45d6-8e79-64ea89caa13f",
      "providerType": "Individual",
      "providerLastName": "Spaghetti",
      "providerFirstName": "Mom",
      "iterationIsComplete": true,
      "familyIntendedProviderCity": "Austin",
      "familyIntendedProviderName": "Mom Spaghetti",
      "familyIntendedProviderEmail": "",
      "familyIntendedProviderState": "IL",
      "familyIntendedProviderAddress": "1 Main St",
      "familyIntendedProviderPhoneNumber": ""
    },
    {
      "uuid": "b22dde9c-2264-48b6-bd34-de5e22fea0e5",
      "providerType": "Care Program",
      "providerLastName": "Stinson",
      "providerFirstName": "Tommy",
      "iterationIsComplete": true,
      "childCareProgramName": "ACME Daycare",
      "providerResponseStatus": "RESPONDED",
      "familyIntendedProviderCity": "Boston",
      "familyIntendedProviderName": "ACME Daycare",
      "familyIntendedProviderEmail": "",
      "familyIntendedProviderState": "IL",
      "providerResponseAgreeToCare": "true",
      "providerResponseSubmissionId": "a7c6b3da-60c2-4f22-a53b-84092c9dfe34",
      "familyIntendedProviderAddress": "Somewhere Else",
      "familyIntendedProviderPhoneNumber": ""
    }
  ]
  ```

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
