### PR TITLE
[CCAP-966] Updated logic to match navigation intention for same-screen

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
@@ -27,8 +27,19 @@ public class DisplaySchedulesSameScreen extends EnableMultipleProviders implemen
         repeatForIterationUuid);
             String currentProviderUuidOrNoProvider = (String) currentProviderSchedule.get("repeatForValue");
             return super.run(submission) && (
-                SubmissionUtilities.getAnyChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider, currentChildcareSchedule).size() == 1);
+               hasOnlyOneProviderScheduleForTheSameProvider(SubmissionUtilities.getAnyChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider, currentChildcareSchedule), currentProviderUuidOrNoProvider));
         }
         return false;
+    }
+
+    private static boolean hasOnlyOneProviderScheduleForTheSameProvider(List<Map<String, Object>> childcareSchedulesWithSameProvider, String currentProviderUuidOrNoProvider){
+        return childcareSchedulesWithSameProvider.stream().noneMatch(chilcareSchedule -> {
+            Map<String, Object> providerSchedule = SubmissionUtilities.getProviderScheduleByRepeatForValue(chilcareSchedule, currentProviderUuidOrNoProvider);
+            if (providerSchedule == null) {
+                return true;
+            }else {
+                return providerSchedule.getOrDefault("sameSchedule", "").equals("false");
+            }
+        });
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
@@ -26,15 +26,16 @@ public class DisplaySchedulesSameScreen extends EnableMultipleProviders implemen
             Map<String, Object> currentProviderSchedule = relatedSubflowIterationData(currentChildcareSchedule, "providerSchedules",
         repeatForIterationUuid);
             String currentProviderUuidOrNoProvider = (String) currentProviderSchedule.get("repeatForValue");
-            return super.run(submission) && (
-               hasOnlyOneProviderScheduleForTheSameProvider(SubmissionUtilities.getAnyChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider, currentChildcareSchedule), currentProviderUuidOrNoProvider));
+            List<Map<String, Object>> childcareSchedulesWithTheSameProvider = SubmissionUtilities.getAnyChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider, currentChildcareSchedule);
+            return super.run(submission) && (!childcareSchedulesWithTheSameProvider.isEmpty() &&
+               hasOnlyOneProviderScheduleForTheSameProvider(childcareSchedulesWithTheSameProvider, currentProviderUuidOrNoProvider));
         }
         return false;
     }
 
     private static boolean hasOnlyOneProviderScheduleForTheSameProvider(List<Map<String, Object>> childcareSchedulesWithSameProvider, String currentProviderUuidOrNoProvider){
-        return childcareSchedulesWithSameProvider.stream().noneMatch(chilcareSchedule -> {
-            Map<String, Object> providerSchedule = SubmissionUtilities.getProviderScheduleByRepeatForValue(chilcareSchedule, currentProviderUuidOrNoProvider);
+        return childcareSchedulesWithSameProvider.stream().noneMatch(childcareSchedule -> {
+            Map<String, Object> providerSchedule = SubmissionUtilities.getProviderScheduleByRepeatForValue(childcareSchedule, currentProviderUuidOrNoProvider);
             if (providerSchedule == null) {
                 return true;
             }else {

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
@@ -38,7 +38,7 @@ public class DisplaySchedulesSameScreen extends EnableMultipleProviders implemen
             Map<String, Object> providerSchedule = SubmissionUtilities.getProviderScheduleByRepeatForValue(childcareSchedule, currentProviderUuidOrNoProvider);
             if (providerSchedule == null) {
                 return true;
-            }else {
+            } else {
                 return providerSchedule.getOrDefault("sameSchedule", "").equals("false");
             }
         });

--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -309,4 +309,9 @@ public class SubmissionUtilities {
     List<Map<String, Object>> providerSchedules = (List<Map<String, Object>>) Optional.ofNullable(childcareSchedule.get("providerSchedules")).orElse(emptyList());
     return providerSchedules.stream().anyMatch(providerSchedule -> providerUuidOrNoProvider.equals(providerSchedule.getOrDefault("repeatForValue", "")));
   }
+
+  public static Map<String, Object> getProviderScheduleByRepeatForValue(Map<String, Object> childcareSchedule, String repeatForValue) {
+     List<Map<String, Object>> providerSchedules = (List<Map<String, Object>>) childcareSchedule.getOrDefault("providerSchedules", emptyList());
+     return providerSchedules.stream().filter(providerSchedule -> providerSchedule.get("repeatForValue").equals(repeatForValue)).toList().stream().findFirst().orElse(null);
+  }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-966

#### ✍️ Description

##### Update this ticket to match the logic below:
***
The intention is that the screen should not be displayed if there are two or more different schedules with the same provider. If the family report a schedule for the first provider, then use the schedules-same screen to specify that the schedule for the second child is the same as for the first child, they should also be presented with the schedules-same screen for a third child and so on until there are two different schedules for that provider.
***

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
