### PR TITLE
[CCAP-1018], [CCAP-1020] - send email when applying with only providers and no provider

### DIFF
--- a/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailNoProviderTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailNoProviderTemplate.java
@@ -41,15 +41,16 @@ public class FamilyConfirmationEmailNoProviderTemplate {
     }
 
     private String setBodyCopy(Map<String, Object> emailData) {
-        String p1 = messageSource.getMessage("email.family-confirmation.hi", new Object[]{emailData.get("parentFirstName")},
+        String p1 = messageSource.getMessage("email.family-confirmation.p1", new Object[]{emailData.get("parentFirstName")},
                 locale);
-        String p2 = messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale);
-        String p3 = messageSource.getMessage("email.family-confirmation.sent-for-review",
+        String p2 = messageSource.getMessage("email.family-confirmation.p2", null, locale);
+        String p3 = messageSource.getMessage("email.family-confirmation.no-provider.p3",
                 new Object[]{emailData.get("confirmationCode"), emailData.get("submittedDate")},
                 locale);
-        String p4 = messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale);
-        String p5 = messageSource.getMessage("email.family-confirmation.a-staff-member", new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
-        String p6 = messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale);
+        String p4 = messageSource.getMessage("email.family-confirmation.no-provider.p4", null, locale);
+        String p5 = messageSource.getMessage("email.family-confirmation.no-provider.p5", new Object[]{emailData.get("ccrrName"),
+                emailData.get("ccrrPhoneNumber")}, locale);
+        String p6 = messageSource.getMessage("email.family-confirmation.no-provider.p6", null, locale);
         String p7 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
         String p8 = messageSource.getMessage("email.general.footer.cfa", null, locale);
         return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8;

--- a/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailTemplate.java
@@ -22,39 +22,57 @@ public class FamilyConfirmationEmailTemplate {
     private Locale locale;
 
     public FamilyConfirmationEmailTemplate(Map<String, Object> emailData, MessageSource messageSource, Locale locale) {
-       this.emailData = emailData;
-       this.messageSource = messageSource;
-       this.locale = locale;
+        this.emailData = emailData;
+        this.messageSource = messageSource;
+        this.locale = locale;
 
-   }
-   public ILGCCEmailTemplate createTemplate(){
-       return new ILGCCEmailTemplate(senderEmail(), setSubject(emailData), new Content("text/html", setBodyCopy(emailData)), EmailType.FAMILY_CONFIRMATION_EMAIL);
-   }
+    }
+
+    public ILGCCEmailTemplate createTemplate() {
+        return new ILGCCEmailTemplate(senderEmail(), setSubject(emailData), new Content("text/html", setBodyCopy(emailData)),
+                EmailType.FAMILY_CONFIRMATION_EMAIL);
+    }
 
     private Email senderEmail() {
-        return  new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale));
+        return new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale));
     }
 
     private String setSubject(Map<String, Object> emailData) {
-        return messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{emailData.get("confirmationCode")},
+        return messageSource.getMessage("email.general.subject.confirmation-code",
+                new Object[]{emailData.get("confirmationCode")},
                 locale);
     }
 
     private String setBodyCopy(Map<String, Object> emailData) {
-        String p1 = messageSource.getMessage("email.family-confirmation.hi", new Object[]{emailData.get("parentFirstName")},
+        String p1 = messageSource.getMessage("email.family-confirmation.p1", new Object[]{emailData.get("parentFirstName")},
                 locale);
-        String p2 = messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale);
-        String p3 = messageSource.getMessage("email.family-confirmation.you-need-to-email-or-text", new Object[]{emailData.get("shareableLink")}, locale);
-        String p4 = messageSource.getMessage("email.family-confirmation.you-will-recieve-mail",
+        String p2 = messageSource.getMessage("email.family-confirmation.p2", null, locale);
+
+        String p3;
+        String p4;
+
+        if ((boolean) emailData.get("hasMutipleProviders")) {
+            p3 = messageSource.getMessage("email.family-confirmation.p3.multiple-providers", null, locale);
+            p4 = messageSource.getMessage("email.family-confirmation.p4.multiple-providers",
+                    new Object[]{emailData.get("shareableLink")}, locale);
+        } else {
+            p3 = messageSource.getMessage("email.family-confirmation.p3.single-provider", null, locale);
+            p4 = messageSource.getMessage("email.family-confirmation.p4.single-provider",
+                    new Object[]{emailData.get("shareableLink")}, locale);
+        }
+
+        String p5 = messageSource.getMessage("email.family-confirmation.p5", null, locale);
+        String p6 = messageSource.getMessage("email.family-confirmation.p6",
                 new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
-        String p5 = messageSource.getMessage("email.family-confirmation.pending-review",
+        String p7 = messageSource.getMessage("email.family-confirmation.p7",
                 new Object[]{emailData.get("confirmationCode"), emailData.get("submittedDate")},
                 locale);
-        String p6 = messageSource.getMessage("email.family-confirmation.what-happens", null, locale);
-        String p7 = messageSource.getMessage("email.family-confirmation.what-are-the-next", null, locale);
-        String p8 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
-        String p9 = messageSource.getMessage("email.general.footer.cfa", null, locale);
-        return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+        String p8 = messageSource.getMessage("email.family-confirmation.p8", null, locale);
+        String p9 = messageSource.getMessage("email.family-confirmation.p9", null, locale);
+        String p10 = messageSource.getMessage("email.family-confirmation.p10", null, locale);
+        String p11 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
+        String p12 = messageSource.getMessage("email.general.footer.cfa", null, locale);
+        return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9 + p10 + p11 + p12;
     }
 
 }

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -155,6 +155,7 @@ public class ProviderSubmissionUtilities {
         applicationData.put("ccapStartDate",
                 ProviderSubmissionUtilities.getCCAPStartDateFromProviderOrFamilyChildcareStartDate(familySubmission,
                         Optional.empty()));
+        applicationData.put("hasMutipleProviders", hasMoreThan1Provider(familySubmission.getInputData()));
 
         // provider specific fields can come from a subflow and not the main data
         Map<String, Object> data = subflowIteration == null ? familySubmission.getInputData() : subflowIteration;
@@ -168,13 +169,21 @@ public class ProviderSubmissionUtilities {
         if (subflowIteration != null) {
             Map<String, List<Map<String, Object>>> mergedChildrenAndSchedules =
                     SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider(familySubmission.getInputData());
-
             applicationData.put("childrenInitialsList",
                     ProviderSubmissionUtilities.getChildrenInitialsList(mergedChildrenAndSchedules.get(data.get("uuid"))));
 
         }
 
         return applicationData;
+    }
+
+    private static boolean hasMoreThan1Provider(Map<String, Object> familyInputData) {
+        if (familyInputData.containsKey("providers")) {
+            List<Map<String, Object>> familyProviders = (List<Map<String, Object>>) familyInputData.get("providers");
+            return familyProviders.size() > 1;
+        } else {
+            return false;
+        }
     }
 
     public static List<Map<String, Object>> getFamilyIntendedProviders(Submission familySubmission) {
@@ -238,7 +247,7 @@ public class ProviderSubmissionUtilities {
     public static List<Map<String, Object>> getChildrenData(Map<String, Object> inputData) {
         List<Map<String, Object>> children = new ArrayList<>();
 
-        List<Map<String, Object>> childrenNeedingAssistance =  SubmissionUtilities.getChildrenNeedingAssistance(inputData);
+        List<Map<String, Object>> childrenNeedingAssistance = SubmissionUtilities.getChildrenNeedingAssistance(inputData);
         if (!childrenNeedingAssistance.isEmpty()) {
             for (var child : childrenNeedingAssistance) {
                 children.add(setChildData(child));
@@ -507,7 +516,7 @@ public class ProviderSubmissionUtilities {
         childCareHours.forEach((key, val) -> {
             String dayKey = String.format("general.week.%s", key);
             dateString.add(String.format("%s, %s</br>", messageSource.getMessage(dayKey, null,
-                LocaleContextHolder.getLocale()), val));
+                    LocaleContextHolder.getLocale()), val));
         });
 
         return String.join("", dateString);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -127,6 +127,8 @@ email.general.subject.confirmation-code=Your CCAP confirmation code: {0}
 # FAMILY_CONFIRMATION_EMAIL
 email.family-confirmation.p1=<p>Hi {0},</p>
 email.family-confirmation.p2=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
+
+# FAMILY_CONFIRMATION_EMAIL_ONLY_PROVIDERS
 email.family-confirmation.p3.single-provider=<p><strong>If you contacted your child care provider when you were filling out the application, </strong> your provider now has 3 business days to fill out their part.</p>
 email.family-confirmation.p4.single-provider=<p><strong>If you didn''t contact your child care provider when you were filling out the application,</strong> you should now email or text your provider to tell them to fill out their part. They have 3 business days to do this. Send this link to your provider: {0} </p>
 email.family-confirmation.p3.multiple-providers=<p><strong>If you contacted your child care providers when you were filling out the application, </strong> your providers now have 3 business days to fill out their part.</p>
@@ -139,10 +141,10 @@ email.family-confirmation.p9=<p><strong>What happens if my provider doesn't resp
 email.family-confirmation.p10=<p><strong>What are the next steps in the process?</strong><br/>Your application will be reviewed by a worker at your CCR&R who will approve or deny the application based on CCAP program requirements. If they don't have enough information to make a decision, they will reach out to you by phone, email, or mail.</p>
 
 # FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER
-email.family-confirmation.sent-for-review=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Submitted for review<br/>Date of submission: {1}</p>
-email.family-confirmation.review-without-a-child-care-provider=<p><strong>Your application has been sent for review without a child care provider listed.</strong></p>
-email.family-confirmation.a-staff-member=<p>A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact <strong>{0}: <a href="tel:{1}">{1}</a></strong></p>
-email.family-confirmation.you-will-receive=<p>You will receive a letter or email about the status of your case within 13-15 business days.</p>
+email.family-confirmation.no-provider.p3=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Submitted for review<br/>Date of submission: {1}</p>
+email.family-confirmation.no-provider.p4=<p><strong>Your application has been sent for processing without a child care provider listed.</strong></p>
+email.family-confirmation.no-provider.p5=<p>A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact <strong>{0}: <a href="tel:{1}">{1}</a></strong></p>
+email.family-confirmation.no-provider.p6=<p>Within 13-15 business, you'll receive a letter or email from your CCR&R stating their initial decision for your application.</p>
 
 # AUTOMATED_PROVIDER_OUTREACH_EMAIL
 email.automated-provider-outreach.subject=[Action Required] New CCAP application

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -125,15 +125,21 @@ email.general.footer.cfa=<p>Sent by Code for America on behalf of the Illinois D
 email.general.subject.confirmation-code=Your CCAP confirmation code: {0}
 
 # FAMILY_CONFIRMATION_EMAIL
+email.family-confirmation.p1=<p>Hi {0},</p>
+email.family-confirmation.p2=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
+email.family-confirmation.p3.single-provider=<p><strong>If you contacted your child care provider when you were filling out the application, </strong> your provider now has 3 business days to fill out their part.</p>
+email.family-confirmation.p4.single-provider=<p><strong>If you didn''t contact your child care provider when you were filling out the application,</strong> you should now email or text your provider to tell them to fill out their part. They have 3 business days to do this. Send this link to your provider: {0} </p>
+email.family-confirmation.p3.multiple-providers=<p><strong>If you contacted your child care providers when you were filling out the application, </strong> your providers now have 3 business days to fill out their part.</p>
+email.family-confirmation.p4.multiple-providers=<p><strong>If you didn''t contact your child care providers when you were filling out the application,</strong> you should now email or text your providers to tell them to fill out their parts. They have 3 business days to do this. Send this link to your providers: {0} </p>
+email.family-confirmation.p5=<p>Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application</p>
+email.family-confirmation.p6=<p>If you have questions, call your Child Care Resource and Referral (CCR&R) Agency, <strong>{0} by phone: <a href="tel:{1}">{1}</a></strong>.</p>
+email.family-confirmation.p7=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Submitted for review<br/>Date of submission: {1}</p>
+email.family-confirmation.p8=<p><strong>Frequently Asked Questions</strong></p>
+email.family-confirmation.p9=<p><strong>What happens if my provider doesn't respond?</strong><br/>If your provider doesn't complete their part of the application in 3 business days, your application will automatically be forwarded to your CCR&R for processing. A worker will reach out to you and help you find an available child care provider.</p>
+email.family-confirmation.p10=<p><strong>What are the next steps in the process?</strong><br/>Your application will be reviewed by a worker at your CCR&R who will approve or deny the application based on CCAP program requirements. If they don't have enough information to make a decision, they will reach out to you by phone, email, or mail.</p>
+
 # FAMILY_CONFIRMATION_EMAIL_NO_PROVIDER
-email.family-confirmation.hi=<p>Hi {0},</p>
-email.family-confirmation.you-completed-the-online-application=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
-email.family-confirmation.you-need-to-email-or-text=<p><strong>You need to email or text your child care provider so they can complete their part.</strong> They have 3 business days to complete the application using this unique link: {0}
-email.family-confirmation.you-will-recieve-mail=<p>You will receive mail or email about the status of your application within <strong>13-15 business days.</strong> If you don''t receive a notice within that time or need more information, reach out to your Child Care Resource and Referral (CCR&R) Agency, <strong>{0} by phone: <a href="tel:{1}">{1}</a></strong>.</p>
-email.family-confirmation.pending-review=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Pending review<br/>Date of submission: {1}</p>
 email.family-confirmation.sent-for-review=<p><strong>Your application details:</strong><br/>Confirmation code: {0}<br/>Status: Submitted for review<br/>Date of submission: {1}</p>
-email.family-confirmation.what-happens=<p><strong>What happens if my provider doesn't respond?</strong><br/>If your provider doesn't complete their part of the application in 3 business days, your application will automatically be forwarded to your CCR&R for processing. A worker will reach out to you and help you find an available child care provider.</p>
-email.family-confirmation.what-are-the-next=<p><strong>What are the next steps in the process?</strong><br/>Your application will be reviewed by a worker at your CCR&R who will approve or deny the application based on CCAP program requirements. If they don't have enough information to make a decision, they will reach out to you by phone, email, or mail.</p>
 email.family-confirmation.review-without-a-child-care-provider=<p><strong>Your application has been sent for review without a child care provider listed.</strong></p>
 email.family-confirmation.a-staff-member=<p>A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact <strong>{0}: <a href="tel:{1}">{1}</a></strong></p>
 email.family-confirmation.you-will-receive=<p>You will receive a letter or email about the status of your case within 13-15 business days.</p>

--- a/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationEmailTest.java
@@ -11,15 +11,18 @@ import formflow.library.data.SubmissionRepository;
 import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.MessageSource;
@@ -46,6 +49,11 @@ public class SendFamilyConfirmationEmailTest {
     private Submission familySubmission;
 
     private SendFamilyConfirmationEmail sendEmailClass;
+
+    Map<String, Object> programProvider = new HashMap<>();
+    Map<String, Object> individualProvider = new HashMap<>();
+
+    Map<String, Object> emailData;
 
     private final Locale locale = Locale.ENGLISH;
 
@@ -79,53 +87,6 @@ public class SendFamilyConfirmationEmailTest {
     }
 
     @Test
-    void correctlySetsEmailData() {
-        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
-
-        assertThat(emailDataOptional.isPresent()).isTrue();
-
-        Map<String, Object> emailData = emailDataOptional.get();
-
-        assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
-        assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
-        assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
-        assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
-        assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
-        assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
-        assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
-    }
-
-    @Test
-    void correctlySetsEmailTemplateData() {
-        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
-        ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailDataOptional.get());
-
-        assertThat(emailTemplate.getSenderEmail()).isEqualTo(
-                new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
-        assertThat(emailTemplate.getSubject()).isEqualTo(
-                messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
-
-        String emailCopy = emailTemplate.getBody().getValue();
-
-        assertThat(emailCopy).contains(
-                messageSource.getMessage("email.family-confirmation.hi", new Object[]{"FirstName"}, locale));
-        assertThat(emailCopy).contains(
-                messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale));
-        assertThat(emailCopy).contains(
-                messageSource.getMessage("email.family-confirmation.you-need-to-email-or-text", new Object[]{"tempEmailLink"},
-                        locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-recieve-mail",
-                new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.pending-review",
-                new Object[]{"ABC123", "October 10, 2022"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.what-happens", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.what-are-the-next", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
-    }
-
-    @Test
     void correctlyUpdatesEmailSendStatus() {
         assertThat(familySubmission.getInputData().containsKey("familyConfirmationEmailSent")).isFalse();
         sendEmailClass.send(familySubmission);
@@ -147,5 +108,243 @@ public class SendFamilyConfirmationEmailTest {
         sendEmailClass.send(familySubmission);
         verify(sendEmailJob).enqueueSendEmailJob(any(ILGCCEmail.class));
     }
+
+    @Nested
+    class whenThereIsASingleProvider {
+
+        @Test
+        void correctlySetsEmailData() {
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+
+            assertThat(emailDataOptional.isPresent()).isTrue();
+
+            Map<String, Object> emailData = emailDataOptional.get();
+
+            assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+            assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+            assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+            assertThat(emailData.get("hasMutipleProviders")).isEqualTo(false);
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailDataOptional.get());
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                    new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(
+                    messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p1", new Object[]{"FirstName"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p2", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p3.single-provider", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p4.single-provider", new Object[]{"tempEmailLink"},
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p5", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
+                    new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
+                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p8", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p9", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p10", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
+
+    }
+
+    @Nested
+    class whenThereAreMultipleProviders {
+
+        @BeforeEach
+        void setUp() {
+            programProvider.put("uuid", UUID.randomUUID().toString());
+            programProvider.put("iterationIsComplete", true);
+            programProvider.put("childCareProgramName", "Child Care Program Name");
+            programProvider.put("familyIntendedProviderEmail", "ccpn@mail.com");
+            programProvider.put("familyIntendedProviderPhoneNumber", "(123) 123-1234");
+            programProvider.put("familyIntendedProviderAddress", "456 Main St.");
+            programProvider.put("familyIntendedProviderCity", "Chicago");
+            programProvider.put("familyIntendedProviderState", "IL");
+            programProvider.put("providerType", "Care Program");
+
+            individualProvider.put("uuid", UUID.randomUUID().toString());
+            individualProvider.put("iterationIsComplete", true);
+            individualProvider.put("providerFirstName", "FirstName");
+            individualProvider.put("providerLastName", "LastName");
+            individualProvider.put("familyIntendedProviderEmail", "firstLast@mail.com");
+            individualProvider.put("familyIntendedProviderPhoneNumber", "(999) 123-1234");
+            individualProvider.put("familyIntendedProviderAddress", "123 Main St.");
+            individualProvider.put("familyIntendedProviderCity", "Chicago");
+            individualProvider.put("familyIntendedProviderState", "IL");
+            individualProvider.put("providerType", "Individual");
+
+            familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("gcc")
+                    .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
+                    .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
+                    .withCCRR()
+                    .with("providers", List.of(individualProvider, programProvider))
+                    .with("parentContactEmail", "familyemail@test.com")
+                    .with("shareableLink", "tempEmailLink")
+                    .withShortCode("ABC123")
+                    .build());
+
+            sendEmailClass = new SendFamilyConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+            emailData = emailDataOptional.get();
+        }
+
+        @Test
+        void correctlySetsEmailData() {
+            assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+            assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+            assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+            assertThat(emailData.get("hasMutipleProviders")).isEqualTo(true);
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailData);
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                    new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(
+                    messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p1", new Object[]{"FirstName"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p2", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p3.multiple-providers", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p4.multiple-providers", new Object[]{"tempEmailLink"},
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p5", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
+                    new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
+                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p8", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p9", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p10", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
+
+    }
+
+    @Nested
+    class whenThereIsSingleProviderInMultipleProviders {
+
+        @BeforeEach
+        void setUp() {
+            individualProvider.put("uuid", UUID.randomUUID().toString());
+            individualProvider.put("iterationIsComplete", true);
+            individualProvider.put("providerFirstName", "FirstName");
+            individualProvider.put("providerLastName", "LastName");
+            individualProvider.put("familyIntendedProviderEmail", "firstLast@mail.com");
+            individualProvider.put("familyIntendedProviderPhoneNumber", "(999) 123-1234");
+            individualProvider.put("familyIntendedProviderAddress", "123 Main St.");
+            individualProvider.put("familyIntendedProviderCity", "Chicago");
+            individualProvider.put("familyIntendedProviderState", "IL");
+            individualProvider.put("providerType", "Individual");
+
+            familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("gcc")
+                    .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
+                    .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
+                    .withCCRR()
+                    .with("providers", List.of(individualProvider))
+                    .with("parentContactEmail", "familyemail@test.com")
+                    .with("shareableLink", "tempEmailLink")
+                    .withShortCode("ABC123")
+                    .build());
+
+            sendEmailClass = new SendFamilyConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+            emailData = emailDataOptional.get();
+        }
+
+        @Test
+        void correctlySetsEmailData() {
+            assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+            assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+            assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+            assertThat(emailData.get("hasMutipleProviders")).isEqualTo(false);
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailData);
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                    new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(
+                    messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p1", new Object[]{"FirstName"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p2", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p3.single-provider", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p4.single-provider", new Object[]{"tempEmailLink"},
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p5", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
+                    new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
+                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p8", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p9", null, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p10", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
+
+    }
+
 
 }

--- a/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationNoProviderEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationNoProviderEmailTest.java
@@ -19,6 +19,7 @@ import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.ilgcc.jobs.SendEmailJob;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,6 +48,8 @@ public class SendFamilyConfirmationNoProviderEmailTest {
 
     private SendFamilyConfirmationNoProviderEmail sendEmailClass;
 
+    Map<String, Object> emailData;
+
     private final Locale locale = Locale.ENGLISH;
 
 
@@ -63,6 +66,9 @@ public class SendFamilyConfirmationNoProviderEmailTest {
                 .build());
 
         sendEmailClass = new SendFamilyConfirmationNoProviderEmail(sendEmailJob, messageSource, submissionRepositoryService);
+
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+        emailData = emailDataOptional.get();
     }
 
     @AfterEach
@@ -72,50 +78,7 @@ public class SendFamilyConfirmationNoProviderEmailTest {
 
     @Test
     void correctlySetsEmailRecipient(){
-        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
-        Map<String, Object> emailData = emailDataOptional.get();
-
         assertThat(sendEmailClass.getRecipientEmail(emailData)).isEqualTo("familyemail@test.com");
-    }
-
-    @Test
-    void correctlySetsEmailData() {
-        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
-
-        assertThat(emailDataOptional.isPresent()).isTrue();
-
-        Map<String, Object> emailData = emailDataOptional.get();
-
-        assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
-        assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
-        assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
-        assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
-        assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
-        assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
-        assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
-    }
-
-    @Test
-    void correctlySetsEmailTemplateData() {
-        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
-        ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailDataOptional.get());
-
-        assertThat(emailTemplate.getSenderEmail()).isEqualTo(new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
-        assertThat(emailTemplate.getSubject()).isEqualTo(messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
-
-        String emailCopy = emailTemplate.getBody().getValue();
-
-        assertThat(emailCopy).contains(
-                messageSource.getMessage("email.family-confirmation.hi", new Object[]{"FirstName"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-completed-the-online-application", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.sent-for-review",
-                new Object[]{"ABC123", "October 10, 2022"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.review-without-a-child-care-provider", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.a-staff-member", new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.you-will-receive", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
-        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
     }
 
     @Test
@@ -139,6 +102,102 @@ public class SendFamilyConfirmationNoProviderEmailTest {
     void correctlyEnqueuesSendEmailJob() {
         sendEmailClass.send(familySubmission);
         verify(sendEmailJob).enqueueSendEmailJob(any(ILGCCEmail.class));
+    }
+
+    @Nested
+    class whenSubmissionHasNoProviders {
+        @Test
+        void correctlySetsEmailData() {
+            assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+            assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+            assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailData);
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p1", new Object[]{"FirstName"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p2", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p3",
+                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p4", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p5", new Object[]{
+                    "Sample Test CCRR", "(603) 555-1244"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p6", null,
+                    locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
+    }
+
+    @Nested
+    class whenNoProviderSelectedInSingleProviderFlow {
+
+        @BeforeEach
+        void setUp() {
+            familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("gcc")
+                    .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
+                    .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
+                    .withCCRR()
+                    .with("providers", List.of())
+                    .with("parentContactEmail", "familyemail@test.com")
+                    .with("shareableLink", "tempEmailLink")
+                    .withShortCode("ABC123")
+                    .build());
+
+            sendEmailClass = new SendFamilyConfirmationNoProviderEmail(sendEmailJob, messageSource, submissionRepositoryService);
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+            emailData = emailDataOptional.get();
+
+        }
+
+        @Test
+        void correctlySetsEmailData() {
+            assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+            assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+            assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailData);
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-confirmation.p1", new Object[]{"FirstName"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p2", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p3",
+                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p4", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p5", new Object[]{
+                    "Sample Test CCRR", "(603) 555-1244"}, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.no-provider.p6", null,
+                    locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
     }
 
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-1018](https://codeforamerica.atlassian.net/browse/CCAP-1018)
[CCAP-1020](https://codeforamerica.atlassian.net/browse/CCAP-1020)

#### ✍️ Description
- updates email copy and sends different version when there is a single provider and when there are multiple

#### 📷 Design reference
_**CCAP-1018 : Emailing with providers**_
**When enable multiple providers flag is off**
<img width="932" alt="Screenshot 2025-07-08 at 2 14 00 PM" src="https://github.com/user-attachments/assets/445ed7f4-0880-40cd-9b6f-325aaff32e84" />
**When enable multiple providers flag is on**
... and there are multiple providers
<img width="927" alt="Screenshot 2025-07-08 at 2 13 49 PM" src="https://github.com/user-attachments/assets/b47b9ec9-928b-4625-8840-1e02e8567c90" />
... and there is a single provider
<img width="908" alt="Screenshot 2025-07-08 at 2 13 33 PM" src="https://github.com/user-attachments/assets/db322858-732c-4345-a367-ebdb6a8488bf" />

_**CCAP-1020 : Emailing with no provider**_
**When enable multiple providers flag is off**
<img width="1102" alt="Screenshot 2025-07-08 at 3 00 01 PM" src="https://github.com/user-attachments/assets/540fc5bc-2bef-4045-bd06-3149e13552be" />

**When enable multiple providers flag is on**
<img width="919" alt="Screenshot 2025-07-08 at 3 02 58 PM" src="https://github.com/user-attachments/assets/9ce56a5b-c8de-4421-97d7-76c2590c0b9a" />


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-1018]: https://codeforamerica.atlassian.net/browse/CCAP-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCAP-1020]: https://codeforamerica.atlassian.net/browse/CCAP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ