### PR TITLE
[CCAP-1019] - Implements Family confirmation where some providers and…

### DIFF
--- a/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailTemplate.java
@@ -1,6 +1,7 @@
 package org.ilgcc.app.email.templates;
 
 import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+import static org.ilgcc.app.utils.SubmissionUtilities.hasSelectedAProviderAndNoProvider;
 
 import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Email;
@@ -11,6 +12,7 @@ import lombok.Setter;
 import org.ilgcc.app.email.ILGCCEmail;
 import org.ilgcc.app.email.ILGCCEmail.EmailType;
 import org.ilgcc.app.email.ILGCCEmailTemplate;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.context.MessageSource;
 
 @Getter
@@ -59,6 +61,11 @@ public class FamilyConfirmationEmailTemplate {
             p3 = messageSource.getMessage("email.family-confirmation.p3.single-provider", null, locale);
             p4 = messageSource.getMessage("email.family-confirmation.p4.single-provider",
                     new Object[]{emailData.get("shareableLink")}, locale);
+        }
+
+        if((boolean) emailData.get("hasProviderAndNoProvider")){
+            p4 = p4 + messageSource.getMessage("email.family-confirmation.some-providers.did-not-choose",
+                    new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
         }
 
         String p5 = messageSource.getMessage("email.family-confirmation.p5", null, locale);

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -156,6 +156,8 @@ public class ProviderSubmissionUtilities {
                 ProviderSubmissionUtilities.getCCAPStartDateFromProviderOrFamilyChildcareStartDate(familySubmission,
                         Optional.empty()));
         applicationData.put("hasMutipleProviders", hasMoreThan1Provider(familySubmission.getInputData()));
+        applicationData.put("hasProviderAndNoProvider",
+                SubmissionUtilities.hasSelectedAProviderAndNoProvider(familySubmission.getInputData()));
 
         // provider specific fields can come from a subflow and not the main data
         Map<String, Object> data = subflowIteration == null ? familySubmission.getInputData() : subflowIteration;
@@ -178,12 +180,8 @@ public class ProviderSubmissionUtilities {
     }
 
     private static boolean hasMoreThan1Provider(Map<String, Object> familyInputData) {
-        if (familyInputData.containsKey("providers")) {
-            List<Map<String, Object>> familyProviders = (List<Map<String, Object>>) familyInputData.get("providers");
-            return familyProviders.size() > 1;
-        } else {
-            return false;
-        }
+        List<Map<String, Object>> familyProviders = (List<Map<String, Object>>) familyInputData.get("providers");
+        return familyProviders != null && familyProviders.size() > 1;
     }
 
     public static List<Map<String, Object>> getFamilyIntendedProviders(Submission familySubmission) {

--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.utils;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Collections.emptyList;
+import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider;
 
 import formflow.library.data.Submission;
 import jakarta.validation.constraints.NotBlank;
@@ -9,10 +10,12 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.enums.SubmissionStatus;
@@ -218,6 +221,12 @@ public class SubmissionUtilities {
         } else {
             return "false".equals(familyInputData.get("hasChosenProvider"));
         }
+    }
+
+    public static boolean hasSelectedAProviderAndNoProvider(Map<String, Object> familyInputData) {
+        Set<String> providersWithSchedules = getRelatedChildrenSchedulesForProvider(familyInputData).keySet();
+        return providersWithSchedules.size() > 1 && providersWithSchedules.contains("NO_PROVIDER");
+
     }
 
     public static boolean hasChosenProvider(Submission submission) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -146,6 +146,9 @@ email.family-confirmation.no-provider.p4=<p><strong>Your application has been se
 email.family-confirmation.no-provider.p5=<p>A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact <strong>{0}: <a href="tel:{1}">{1}</a></strong></p>
 email.family-confirmation.no-provider.p6=<p>Within 13-15 business, you'll receive a letter or email from your CCR&R stating their initial decision for your application.</p>
 
+# FAMILY_CONFIRMATION_EMAIL_SOME_PROVIDER_AND_NO_PROVIDER
+email.family-confirmation.some-providers.did-not-choose=<p><strong>You didn''t chose a child care provider for at least one child. </strong> A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child. Contact <strong>{0}: <a href="tel:{1}">{1}</a></p>
+
 # AUTOMATED_PROVIDER_OUTREACH_EMAIL
 email.automated-provider-outreach.subject=[Action Required] New CCAP application
 email.automated-provider-outreach.p1=<p>Hello,</p>

--- a/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
@@ -409,6 +409,42 @@ public class SubmissionTestBuilder {
         return this;
     }
 
+    public SubmissionTestBuilder withMultipleChildcareSchedules(List<String> childIDs, List<String> providerUUIDs) {
+        List<Map<String, Object>> childcareSchedules = new ArrayList<>();
+
+        for (int i = 0; i < childIDs.size(); i++) {
+            Map<String, Object> childcareSchedule = new HashMap<>();
+            childcareSchedule.put("childUuid", childIDs.get(i));
+
+            List<Map<String, Object>> providerSchedules = new ArrayList<>();
+            Map<String, Object> providerSchedule = new HashMap<>();
+
+            providerSchedule.put("uuid", "provider-child-schedule");
+            providerSchedule.put("childInCare", true);
+            providerSchedule.put("ccapStartDate", "11/17/2025");
+            providerSchedule.put("repeatForValue", providerUUIDs.get(i));
+            providerSchedule.put("iterationIsComplete", true);
+            providerSchedule.put("childcareWeeklySchedule[]", List.of("Monday", "Tuesday"));
+            providerSchedule.put("childcareEndTimeAllDaysAmPm", "PM");
+            providerSchedule.put("childcareEndTimeAllDaysHour", "10");
+            providerSchedule.put("childcareHoursSameEveryDay[]", List.of("yes"));
+            providerSchedule.put("childcareEndTimeAllDaysMinute", "21");
+            providerSchedule.put("childcareStartTimeAllDaysAmPm", "AM");
+            providerSchedule.put("childcareStartTimeAllDaysHour", "10");
+            providerSchedule.put("childcareStartTimeAllDaysMinute", "24");
+
+            providerSchedules.add(providerSchedule);
+            childcareSchedule.put("providerSchedules", providerSchedules);
+
+            childcareSchedules.add(childcareSchedule);
+        }
+
+        submission.getInputData().put("childcareSchedules", childcareSchedules);
+
+        return this;
+
+    }
+
     public SubmissionTestBuilder withConstantChildcareSchedule(int childPosition) {
 
         List<Map<String, Object>> children = (List<Map<String, Object>>) submission.getInputData().get("children");


### PR DESCRIPTION
… a no provider is selected

#### 🔗 Jira ticket
[CCAP-1019](https://codeforamerica.atlassian.net/browse/CCAP-1019)

#### ✍️ Description
- Updates family confirmation email so that if any of the selected providers is "NO_PROVIDER", it will add an extra line in the email copy of SendFamilyConfirmation (see highlighted below)

#### 📷 Design reference
<img width="655" height="641" alt="Screenshot 2025-07-10 at 10 22 55 AM" src="https://github.com/user-attachments/assets/35b3f3e7-d121-48b2-8dd6-bc7cdd1f4fb2" />


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-1019]: https://codeforamerica.atlassian.net/browse/CCAP-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ