### PR TITLE
[CCAP-1097] Skip multi-provider and confirm-provider screens for single provider applications

### DIFF
--- a/src/main/java/org/ilgcc/app/pdf/MultiProviderPDFService.java
+++ b/src/main/java/org/ilgcc/app/pdf/MultiProviderPDFService.java
@@ -2,7 +2,7 @@ package org.ilgcc.app.pdf;
 
 import static org.ilgcc.app.utils.FileNameUtility.getCCMSFileNameForAdditionalProviderPDF;
 import static org.ilgcc.app.utils.FileNameUtility.getCCMSFileNameForApplicationPDF;
-import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider;
+import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForEachProvider;
 import static org.ilgcc.app.utils.SubmissionUtilities.formatToStringFromLocalDate;
 
 import formflow.library.data.Submission;
@@ -109,7 +109,7 @@ public class MultiProviderPDFService {
         List<Map<String, Object>> providers = SubmissionUtilities.getProviders(familySubmission.getInputData());
 
         Map<String, List<Map<String, Object>>> mergedChildrenAndSchedules =
-                getRelatedChildrenSchedulesForProvider(familySubmission.getInputData());
+                getRelatedChildrenSchedulesForEachProvider(familySubmission.getInputData());
 
         if (mergedChildrenAndSchedules.isEmpty()) {
             return additionalPDFs;

--- a/src/main/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerService.java
+++ b/src/main/java/org/ilgcc/app/pdf/ProviderSubmissionFieldPreparerService.java
@@ -1,6 +1,6 @@
 package org.ilgcc.app.pdf;
 
-import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider;
+import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForEachProvider;
 import static org.ilgcc.app.utils.SubmissionUtilities.formatToStringFromLocalDate;
 import static org.ilgcc.app.utils.SubmissionUtilities.getProviderSubmissionId;
 
@@ -76,7 +76,7 @@ public class ProviderSubmissionFieldPreparerService implements SubmissionFieldPr
 
         if (enableMultipleProviders) {
             Map<String, List<Map<String, Object>>> mergedChildrenAndSchedules =
-                    getRelatedChildrenSchedulesForProvider(familySubmission.getInputData());
+                    getRelatedChildrenSchedulesForEachProvider(familySubmission.getInputData());
 
             String providerUuid = mergedChildrenAndSchedules.keySet().stream().toList().get(0);
 

--- a/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
@@ -1,7 +1,7 @@
 package org.ilgcc.app.submission.actions;
 
 import static org.ilgcc.app.utils.ProviderSubmissionUtilities.setChildData;
-import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider;
+import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForEachProvider;
 
 import formflow.library.config.submission.Action;
 import formflow.library.data.Submission;
@@ -47,7 +47,7 @@ public class FindApplicationData implements Action {
             if (enableMultipleProviders) {
                 childData = new ArrayList<>();
                 Map<String, List<Map<String, Object>>> mergedChildrenAndSchedules =
-                        getRelatedChildrenSchedulesForProvider(familySubmission.get().getInputData());
+                        getRelatedChildrenSchedulesForEachProvider(familySubmission.get().getInputData());
 
                 String currentProviderUuid = (String) providerSubmission.getInputData().getOrDefault("currentProviderUuid",
                         "");

--- a/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/FindApplicationData.java
@@ -40,7 +40,7 @@ public class FindApplicationData implements Action {
         if (familySubmissionId.isPresent()) {
             Optional<Submission> familySubmission = submissionRepositoryService.findById(familySubmissionId.get());
             providerSubmission.getInputData()
-                    .put("clientResponse", ProviderSubmissionUtilities.getFamilySubmission(familySubmission));
+                    .put("clientResponse", ProviderSubmissionUtilities.getFamilyConfirmationCodeAndParentName(familySubmission));
 
             List<Map<String, Object>> childData;
 

--- a/src/main/java/org/ilgcc/app/submission/conditions/MultiProviderIsEnabledAndHasMultipleProviders.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/MultiProviderIsEnabledAndHasMultipleProviders.java
@@ -1,6 +1,6 @@
 package org.ilgcc.app.submission.conditions;
 
-import static org.ilgcc.app.utils.SubmissionUtilities.isNotASingleProviderApplication;
+import static org.ilgcc.app.utils.SubmissionUtilities.isMultiProviderApplication;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class MultiProviderIsEnabledAndIsNotSingleProviderApplication implements Condition {
+public class MultiProviderIsEnabledAndHasMultipleProviders implements Condition {
 
     @Value("${il-gcc.enable-multiple-providers}")
     private boolean enableMultipleProviders;
@@ -55,6 +55,6 @@ public class MultiProviderIsEnabledAndIsNotSingleProviderApplication implements 
 
         Submission familySubmission = familySubmissionOptional.get();
 
-        return enableMultipleProviders && isNotASingleProviderApplication(familySubmission);
+        return enableMultipleProviders && isMultiProviderApplication(familySubmission);
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/filters/ProvidersWithChildcareSchedules.java
+++ b/src/main/java/org/ilgcc/app/submission/filters/ProvidersWithChildcareSchedules.java
@@ -1,6 +1,6 @@
 package org.ilgcc.app.submission.filters;
 
-import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider;
+import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForEachProvider;
 
 import formflow.library.config.submission.SubflowRelationshipFilter;
 import formflow.library.data.Submission;
@@ -15,7 +15,7 @@ public class ProvidersWithChildcareSchedules implements SubflowRelationshipFilte
 
     @Override
     public List<HashMap<String, Object>> filter(List<HashMap<String, Object>> providers, Submission submission) {
-        Set<String> providerIdsWithSchedules = getRelatedChildrenSchedulesForProvider(submission.getInputData()).keySet();
+        Set<String> providerIdsWithSchedules = getRelatedChildrenSchedulesForEachProvider(submission.getInputData()).keySet();
 
         return providers.stream().filter(provider -> providerIdsWithSchedules.contains(provider.get("uuid").toString()))
                 .collect(Collectors.toList());

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -169,7 +169,7 @@ public class ProviderSubmissionUtilities {
                         data.getOrDefault("providerLastName", "").toString()));
         if (subflowIteration != null) {
             Map<String, List<Map<String, Object>>> mergedChildrenAndSchedules =
-                    SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider(familySubmission.getInputData());
+                    SchedulePreparerUtility.getRelatedChildrenSchedulesForEachProvider(familySubmission.getInputData());
             applicationData.put("childrenInitialsList",
                     ProviderSubmissionUtilities.getChildrenInitialsList(mergedChildrenAndSchedules.get(data.get("uuid"))));
 

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -1,7 +1,6 @@
 package org.ilgcc.app.utils;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
-import static org.ilgcc.app.utils.SchedulePreparerUtility.getRelatedChildrenSchedulesForProvider;
 import static org.ilgcc.app.utils.SubmissionUtilities.MM_DD_YYYY;
 
 import formflow.library.data.Submission;
@@ -89,7 +88,7 @@ public class ProviderSubmissionUtilities {
         return Optional.empty();
     }
 
-    public static Map<String, String> getFamilySubmission(Optional<Submission> familySubmission) {
+    public static Map<String, String> getFamilyConfirmationCodeAndParentName(Optional<Submission> familySubmission) {
         Map<String, String> applicationData = new HashMap<>();
 
         if (familySubmission.isPresent()) {

--- a/src/main/java/org/ilgcc/app/utils/SchedulePreparerUtility.java
+++ b/src/main/java/org/ilgcc/app/utils/SchedulePreparerUtility.java
@@ -125,7 +125,7 @@ public class SchedulePreparerUtility {
         return currentIteration.orElse(null);
     }
 
-    public static Map<String, List<Map<String, Object>>> getRelatedChildrenSchedulesForProvider(Map<String, Object> inputData) {
+    public static Map<String, List<Map<String, Object>>> getRelatedChildrenSchedulesForEachProvider(Map<String, Object> inputData) {
         List<Map<String, Object>> childcareSchedules = (List<Map<String, Object>>) inputData.getOrDefault("childcareSchedules",
                 Collections.EMPTY_LIST);
         Set<Map<String, Object>> providerSchedules = new LinkedHashSet<>();

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -814,17 +814,17 @@ flow:
       - name: submit-start
         condition: IsConfirmationCodeInactive
       - name: multiple-providers
-        condition: EnableMultipleProviders
+        condition: MultiProviderIsEnabledAndIsNotSingleProviderApplication
       - name: paid-by-ccap
   multiple-providers:
-    condition: EnableMultipleProviders
+    condition: MultiProviderIsEnabledAndIsNotSingleProviderApplication
     beforeDisplayAction: SetProvidersData
     nextScreens:
       - name: error-response-recorded
         condition: CurrentProviderHasResponded
       - name: confirm-provider
   confirm-provider:
-    condition: EnableMultipleProviders
+    condition: MultiProviderIsEnabledAndIsNotSingleProviderApplication
     nextScreens:
       - name: paid-by-ccap
   error-response-recorded:

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -814,17 +814,17 @@ flow:
       - name: submit-start
         condition: IsConfirmationCodeInactive
       - name: multiple-providers
-        condition: MultiProviderIsEnabledAndIsNotSingleProviderApplication
+        condition: MultiProviderIsEnabledAndHasMultipleProviders
       - name: paid-by-ccap
   multiple-providers:
-    condition: MultiProviderIsEnabledAndIsNotSingleProviderApplication
+    condition: MultiProviderIsEnabledAndHasMultipleProviders
     beforeDisplayAction: SetProvidersData
     nextScreens:
       - name: error-response-recorded
         condition: CurrentProviderHasResponded
       - name: confirm-provider
   confirm-provider:
-    condition: MultiProviderIsEnabledAndIsNotSingleProviderApplication
+    condition: MultiProviderIsEnabledAndHasMultipleProviders
     nextScreens:
       - name: paid-by-ccap
   error-response-recorded:

--- a/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionTestBuilder.java
@@ -409,6 +409,42 @@ public class SubmissionTestBuilder {
         return this;
     }
 
+    public SubmissionTestBuilder withMultipleChildcareSchedulesAllBelongingToTheSameProvider(List<String> childIDs, String providerUUID) {
+        List<Map<String, Object>> childcareSchedules = new ArrayList<>();
+
+        for (String childUUID : childIDs) {
+            Map<String, Object> childcareSchedule = new HashMap<>();
+            childcareSchedule.put("childUuid", childUUID);
+
+            List<Map<String, Object>> providerSchedules = new ArrayList<>();
+            Map<String, Object> providerSchedule = new HashMap<>();
+
+            providerSchedule.put("uuid", "provider-child-schedule");
+            providerSchedule.put("childInCare", true);
+            providerSchedule.put("ccapStartDate", "11/17/2025");
+            providerSchedule.put("repeatForValue", providerUUID);
+            providerSchedule.put("iterationIsComplete", true);
+            providerSchedule.put("childcareWeeklySchedule[]", List.of("Monday", "Tuesday"));
+            providerSchedule.put("childcareEndTimeAllDaysAmPm", "PM");
+            providerSchedule.put("childcareEndTimeAllDaysHour", "10");
+            providerSchedule.put("childcareHoursSameEveryDay[]", List.of("yes"));
+            providerSchedule.put("childcareEndTimeAllDaysMinute", "21");
+            providerSchedule.put("childcareStartTimeAllDaysAmPm", "AM");
+            providerSchedule.put("childcareStartTimeAllDaysHour", "10");
+            providerSchedule.put("childcareStartTimeAllDaysMinute", "24");
+
+            providerSchedules.add(providerSchedule);
+            childcareSchedule.put("providerSchedules", providerSchedules);
+
+            childcareSchedules.add(childcareSchedule);
+            childcareSchedule.put("childcareProvidersForCurrentChild[]", List.of(providerUUID));
+        }
+
+        submission.getInputData().put("childcareSchedules", childcareSchedules);
+
+        return this;
+    }
+
     public SubmissionTestBuilder withMultipleChildcareSchedules(List<String> childIDs, List<String> providerUUIDs) {
         List<Map<String, Object>> childcareSchedules = new ArrayList<>();
 
@@ -435,6 +471,43 @@ public class SubmissionTestBuilder {
 
             providerSchedules.add(providerSchedule);
             childcareSchedule.put("providerSchedules", providerSchedules);
+
+            childcareSchedules.add(childcareSchedule);
+        }
+
+        submission.getInputData().put("childcareSchedules", childcareSchedules);
+
+        return this;
+
+    }
+
+    public SubmissionTestBuilder withMultipleChildcareSchedulesBelongingToDifferentProviders(List<String> childIDs, List<String> providerUUIDs) {
+        List<Map<String, Object>> childcareSchedules = new ArrayList<>();
+
+        for (int i = 0; i < childIDs.size(); i++) {
+            Map<String, Object> childcareSchedule = new HashMap<>();
+            childcareSchedule.put("childUuid", childIDs.get(i));
+
+            List<Map<String, Object>> providerSchedules = new ArrayList<>();
+            Map<String, Object> providerSchedule = new HashMap<>();
+
+            providerSchedule.put("uuid", "provider-child-schedule");
+            providerSchedule.put("childInCare", true);
+            providerSchedule.put("ccapStartDate", "11/17/2025");
+            providerSchedule.put("repeatForValue", providerUUIDs.get(i));
+            providerSchedule.put("iterationIsComplete", true);
+            providerSchedule.put("childcareWeeklySchedule[]", List.of("Monday", "Tuesday"));
+            providerSchedule.put("childcareEndTimeAllDaysAmPm", "PM");
+            providerSchedule.put("childcareEndTimeAllDaysHour", "10");
+            providerSchedule.put("childcareHoursSameEveryDay[]", List.of("yes"));
+            providerSchedule.put("childcareEndTimeAllDaysMinute", "21");
+            providerSchedule.put("childcareStartTimeAllDaysAmPm", "AM");
+            providerSchedule.put("childcareStartTimeAllDaysHour", "10");
+            providerSchedule.put("childcareStartTimeAllDaysMinute", "24");
+
+            providerSchedules.add(providerSchedule);
+            childcareSchedule.put("providerSchedules", providerSchedules);
+            childcareSchedule.put("childcareProvidersForCurrentChild[]", List.of(providerUUIDs.get(i)));
 
             childcareSchedules.add(childcareSchedule);
         }
@@ -795,6 +868,11 @@ public class SubmissionTestBuilder {
         data.put(inputPrefix + startOrEndKey + "Time" + dayPostFix + "Minute", timeOption.getMinute());
         data.put(inputPrefix + startOrEndKey + "Time" + dayPostFix + "AmPm", timeOption.getAmOrPm());
 
+        return this;
+    }
+    
+    public SubmissionTestBuilder withFamilyIntendedProviderName(String providerName) {
+        submission.getInputData().put("familyIntendedProviderName", providerName);
         return this;
     }
 }

--- a/src/test/java/org/ilgcc/app/utils/SubmissionUtilitiesTest.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionUtilitiesTest.java
@@ -3,27 +3,79 @@ package org.ilgcc.app.utils;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import formflow.library.data.Submission;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class SubmissionUtilitiesTest {
 
     @Test
     void allChildcareSchedulesAreForTheSameProviderReturnsTrueWhenAllChildcareSchedulesHaveSameProviderUuid() {
+        Map<String, Object> child1  = new HashMap<>();
+        Map<String, Object> child2  = new HashMap<>();
+        child1.put("uuid", UUID.randomUUID().toString());
+        child1.put("childFirstName", "First");
+        child1.put("childLastName", "Child");
+        child1.put("childInCare", "true");
+        child1.put("childDateOfBirthMonth", "10");
+        child1.put("childDateOfBirthDay", "11");
+        child1.put("childDateOfBirthYear", "2002");
+        child1.put("needFinancialAssistanceForChild", true);
+        child1.put("childIsUsCitizen", "Yes");
+        child1.put("ccapStartDate", "01/10/2025");
+
+        child2.put("uuid", UUID.randomUUID().toString());
+        child2.put("childFirstName", "Second");
+        child2.put("childLastName", "Child");
+        child2.put("childInCare", "true");
+        child2.put("childDateOfBirthMonth", "10");
+        child2.put("childDateOfBirthDay", "11");
+        child2.put("childDateOfBirthYear", "2002");
+        child2.put("needFinancialAssistanceForChild", true);
+        child2.put("childIsUsCitizen", "Yes");
+        child2.put("ccapStartDate", "01/10/2025");
+        
         Submission submission = new SubmissionTestBuilder()
-                .withMultipleChildcareSchedulesAllBelongingToTheSameProvider(List.of("child-1", "child-2"), "provider-id").build();
+                .with("children", List.of(child1, child2))
+                .withMultipleChildcareSchedulesAllBelongingToTheSameProvider(
+                        List.of(child1.get("uuid").toString(), child2.get("uuid").toString()), "provider-id").build();
         boolean result = SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(
-                (List<Map<String, Object>>) submission.getInputData().get("childcareSchedules"));
+                submission.getInputData());
         assertThat(result).isTrue();
     }
 
     @Test
     void allChildcareSchedulesAreForTheSameProviderReturnsFalseWhenAllChildcareSchedulesDoNotHaveSameProviderUuid() {
+        Map<String, Object> child1  = new HashMap<>();
+        Map<String, Object> child2  = new HashMap<>();
+        child1.put("uuid", UUID.randomUUID().toString());
+        child1.put("childFirstName", "First");
+        child1.put("childLastName", "Child");
+        child1.put("childInCare", "true");
+        child1.put("childDateOfBirthMonth", "10");
+        child1.put("childDateOfBirthDay", "11");
+        child1.put("childDateOfBirthYear", "2002");
+        child1.put("needFinancialAssistanceForChild", true);
+        child1.put("childIsUsCitizen", "Yes");
+        child1.put("ccapStartDate", "01/10/2025");
+
+        child2.put("uuid", UUID.randomUUID().toString());
+        child2.put("childFirstName", "Second");
+        child2.put("childLastName", "Child");
+        child2.put("childInCare", "true");
+        child2.put("childDateOfBirthMonth", "10");
+        child2.put("childDateOfBirthDay", "11");
+        child2.put("childDateOfBirthYear", "2002");
+        child2.put("needFinancialAssistanceForChild", true);
+        child2.put("childIsUsCitizen", "Yes");
+        child2.put("ccapStartDate", "01/10/2025");
+        
         Submission submission = new SubmissionTestBuilder()
-                .withMultipleChildcareSchedulesBelongingToDifferentProviders(List.of("c1", "c2"), List.of("p1", "p2")).build();
-        boolean result = SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(
-                (List<Map<String, Object>>) submission.getInputData().get("childcareSchedules"));
+                .with("children", List.of(child1, child2))
+                .withMultipleChildcareSchedulesBelongingToDifferentProviders(List.of(child1.get("uuid").toString(), child2.get("uuid").toString()), List.of("p1", "p2")).build();
+        boolean result = SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(submission.getInputData());
         assertThat(result).isFalse();
     }
 

--- a/src/test/java/org/ilgcc/app/utils/SubmissionUtilitiesTest.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionUtilitiesTest.java
@@ -1,0 +1,43 @@
+package org.ilgcc.app.utils;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import formflow.library.data.Submission;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SubmissionUtilitiesTest {
+
+    @Test
+    void allChildcareSchedulesAreForTheSameProviderReturnsTrueWhenAllChildcareSchedulesHaveSameProviderUuid() {
+        Submission submission = new SubmissionTestBuilder()
+                .withMultipleChildcareSchedulesAllBelongingToTheSameProvider(List.of("child-1", "child-2"), "provider-id").build();
+        boolean result = SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(
+                (List<Map<String, Object>>) submission.getInputData().get("childcareSchedules"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void allChildcareSchedulesAreForTheSameProviderReturnsFalseWhenAllChildcareSchedulesDoNotHaveSameProviderUuid() {
+        Submission submission = new SubmissionTestBuilder()
+                .withMultipleChildcareSchedulesBelongingToDifferentProviders(List.of("c1", "c2"), List.of("p1", "p2")).build();
+        boolean result = SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(
+                (List<Map<String, Object>>) submission.getInputData().get("childcareSchedules"));
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isPreMultiProviderApplicationWithSingleProviderShouldReturnTrueIfApplicationUsesPreMultiProviderDataStructure() {
+        Submission submission = new SubmissionTestBuilder().withFamilyIntendedProviderName("provider-name").build();
+        boolean result = SubmissionUtilities.isPreMultiProviderApplicationWithSingleProvider(submission);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isPreMultiProviderApplicationWithSingleProviderShouldReturnFalseIfIsMultiproviderApplication() {
+        Submission submission = new SubmissionTestBuilder().withMultipleChildcareSchedules(List.of("C1", "C2"), List.of("P1", "P2")).build();
+        boolean result = SubmissionUtilities.isPreMultiProviderApplicationWithSingleProvider(submission);
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1097

#### Description

This implements a change that will skip the `multi-provider` and `confirm-provider` screens in the `providerresponse` flow if: 

- The family application was only for a single provider when `ENABLE_MULTIPLE_PROVIDERS` is turned on
- The family application had multiple providers but only one was actually selected for all child care schedules
- The application uses the data structure prior to multi providers being enabled