### PR TITLE
[CCAP-755] Fixing timezone issue on expiration date in query

### DIFF
--- a/src/main/java/org/ilgcc/app/data/TransactionRepository.java
+++ b/src/main/java/org/ilgcc/app/data/TransactionRepository.java
@@ -23,7 +23,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, UUID> 
                     "OR s.input_data->>'providerResponseStatus' IS NULL " +
                     ") " +
                     "AND s.input_data->>'providerApplicationResponseExpirationDate' IS NOT NULL " +
-                    "AND TO_TIMESTAMP((s.input_data->>'providerApplicationResponseExpirationDate')::double precision)::timestamptz <= (now() AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') " +
+                    "AND TO_TIMESTAMP((s.input_data->>'providerApplicationResponseExpirationDate')::double precision)::timestamptz <= (now() AT TIME ZONE 'UTC') " +
                     "AND s.flow = 'gcc' " +
                     "AND t.transaction_id IS NULL " +
                     "ORDER BY s.created_at ASC",

--- a/src/main/java/org/ilgcc/app/data/TransmissionRepository.java
+++ b/src/main/java/org/ilgcc/app/data/TransmissionRepository.java
@@ -23,7 +23,7 @@ public interface TransmissionRepository extends JpaRepository<Transmission, UUID
                     "OR s.input_data->>'providerResponseStatus' IS NULL " +
                     ") " +
                     "AND s.input_data->>'providerApplicationResponseExpirationDate' IS NOT NULL " +
-                    "AND TO_TIMESTAMP((s.input_data->>'providerApplicationResponseExpirationDate')::double precision)::timestamptz <= (now() AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') " +
+                    "AND TO_TIMESTAMP((s.input_data->>'providerApplicationResponseExpirationDate')::double precision)::timestamptz <= (now() AT TIME ZONE 'UTC') " +
                     "AND s.flow = 'gcc' " +
                     "AND t.transmission_id IS NULL " +
                     "ORDER BY s.created_at ASC",


### PR DESCRIPTION
#### 🔗 Jira ticket
<!-- Add link to the issue -->

#### ✍️ Description
The timezone shifting was incorrect in these queries, causing submissions that were expired for 1 hour to be picked up in < 1 hour.

Here is a slightly modified version of the transaction query as proof of the issue.

```
SELECT id, submitted_at, short_code, TO_TIMESTAMP((s.input_data->>'providerApplicationResponseExpirationDate')::double precision)::timestamptz as expiration, (now() AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') as queryNow, (now() AT TIME ZONE 'UTC') as actualNow
FROM submissions s 
JOIN transactions t ON t.submission_id = s.id 
WHERE s.submitted_at IS NOT NULL 
AND ( 
s.input_data->>'providerResponseStatus' = 'ACTIVE' 
OR s.input_data->>'providerResponseStatus' IS NULL 
) 
AND s.input_data->>'providerApplicationResponseExpirationDate' IS NOT NULL 
AND TO_TIMESTAMP((s.input_data->>'providerApplicationResponseExpirationDate')::double precision)::timestamptz <= (now() AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') 
AND s.flow = 'gcc' 
AND s.short_code = 'STG-KXOUPT'
ORDER BY s.created_at ASC;
```

The result set is:

```
                  id                  |         submitted_at          | short_code |          expiration           |           querynow            |         actualnow          
--------------------------------------+-------------------------------+------------+-------------------------------+-------------------------------+----------------------------
 a572ffb4-ab20-4c50-bf9b-3afa57e6c570 | 2025-07-17 19:23:02.902562+00 | STG-KXOUPT | 2025-07-17 20:23:02.902562+00 | 2025-07-18 01:57:38.828563+00 | 2025-07-17 20:57:38.828563
(1 row)

```

Which shows:

`submitted_at` = 2025-07-17 19:23:02.902562+00
`expiration` = 2025-07-17 20:23:02.902562+00
`querynow` = 2025-07-18 01:57:38.828563+00
`actualnow` = 2025-07-17 20:57:38.828563

submitted_at is accurate. That was the time I submitted the application, in UTC.

expiration is an alias for the original query and how it pulls the timestamp out of the input_data and makes a date. Staging had a 1 hour expiration policy set, and this is 1 hour later exactly.

querynow is an alias for the original query and how it was calculating "now" when the job runs. UH OH! 😱 

actualnow is an alias for the fixed query's calculation of "now" and it is correct.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
