### PR TITLE
[CCAP-1057] : Update copy on the providerresponse/submit-start screen

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1310,7 +1310,7 @@ provider-response-submit-start.active.reveal-body-2=To learn more about the Chil
 provider-response-submit-start.active.button=Continue to see details
 
 provider-response-submit-start.expired.header=Sorry, {0}. This link has expired.
-provider-response-submit-start.expired.notice=<div class='notice spacing-below-60 notice--warning'><p>This application has been sent to the CCR&R without your response.</p><br><p>A family listed you as their child care provider on a Child Care Assistance (CCAP) application and <strong>you had 3 business days</strong> to respond.</p></div>
+provider-response-submit-start.expired.notice=<div class='notice spacing-below-60 notice--warning'><p>This application has been submitted for processing without your response.</p><br><p>A family listed you as their child care provider on a Child Care Assistance (CCAP) application and <strong>you had 3 business days</strong> to respond.</p></div>
 
 provider-response-submit-start.responded.header=Hi, {0}. A response has already been recorded for this application.
 provider-response-submit-start.responded.notice=<div class='notice spacing-below-60 notice--gray'><p>The family's Child Care Assistance (CCAP) application has been sent to the CCR&R for processing.</p></div>


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1057

#### ✍️ Description
Update the copy for the version of the content that is shown to users on the submit-start screen if the time for the provider to respond has expired.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
