### PR TITLE
[CCAP-1004] - sets provider initials in SendFamilyApplicationTransmit…

### DIFF
--- a/src/main/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmail.java
@@ -1,6 +1,7 @@
 package org.ilgcc.app.email;
 
 import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getFamilySubmissionDataForEmails;
+import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getInitials;
 import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getProviderSubmissionDataForEmails;
 
 import formflow.library.data.Submission;
@@ -80,6 +81,9 @@ public class SendFamilyApplicationTransmittedConfirmationEmail extends SendEmail
                         }
 
                         currentProviderData.putAll(currentProvider.get());
+                        currentProviderData.put("childCareProviderInitials",
+                                getInitials(currentProvider.get().getOrDefault("providerFirstName", "").toString(),
+                                        currentProvider.get().getOrDefault("providerLastName", "").toString()));
                         currentProviderData.put("childrenInitialsList",
                                 ProviderSubmissionUtilities.getChildrenInitialsList(providerSchedules.get(providerId)));
                         providerData.add(currentProviderData);

--- a/src/main/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmail.java
@@ -60,7 +60,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmail extends SendEmail
                             .filter(provider -> provider.get("uuid").equals(providerId)).findFirst();
                     if (currentProvider.isPresent()) {
                         String earliestCCAPDateForCurrentProvider =
-                                (String) DateUtilities.getEarliestDate(providerSchedules.get(providerId).stream().map(s -> s.get("ccapStartDate").toString()).toList());
+                                (String) DateUtilities.getEarliestDate(providerSchedules.get(providerId).stream().map(s -> s.getOrDefault("ccapStartDate", "").toString()).toList());
 
                         if (currentProvider.get().containsKey("providerResponseSubmissionId")) {
                             Optional<Submission> currentProviderSubmission = submissionRepositoryService.findById(

--- a/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmailTest.java
@@ -295,7 +295,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
 
         assertThat(emailCopy).contains(messageSource.getMessage(
                 "email.family-application-transmitted-confirmation-email.li-did-not-agree-to-care",
-                new Object[]{"P.P.", "F.C. and S.C."},
+                new Object[]{"F.L.", "F.C. and S.C."},
                 locale));
 
         assertThat(emailCopy).contains(messageSource.getMessage(

--- a/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmailTest.java
@@ -237,7 +237,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
         assertThat(currentProviderData.get("ccapStartDate")).isEqualTo("January 10, 2025");
         assertThat(currentProviderData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
         assertThat(currentProviderData.get("providerType")).isEqualTo("Individual");
-        assertThat(currentProviderData.get("childCareProviderInitials")).isEqualTo("P.P.");
+        assertThat(currentProviderData.get("childCareProviderInitials")).isEqualTo("F.L.");
         assertThat(currentProviderData.get("providerResponseAgreeToCare")).isEqualTo("false");
         assertThat(currentProviderData.get("providerResponseContactEmail")).isEqualTo("provideremail@test.com");
     }


### PR DESCRIPTION
…ted confirmation email

#### 🔗 Jira ticket
[Bug Reported in Slack](https://cfastaff.slack.com/archives/C085NRJ60P7/p1753201772163449)

#### ✍️ Description
- Error occurring in email because missing key when provider applying is individual.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
