### PR TITLE
[CCAP-1191] Fix current provider ID bug

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/SetCurrentProviderForSingleProviderSubmission.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetCurrentProviderForSingleProviderSubmission.java
@@ -8,13 +8,14 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class SetProvidersData implements Action {
+public class SetCurrentProviderForSingleProviderSubmission implements Action {
 
     @Autowired
     SubmissionRepositoryService submissionRepositoryService;
@@ -28,12 +29,14 @@ public class SetProvidersData implements Action {
                 ProviderSubmissionUtilities.getFamilySubmissionShortCode(providerSubmission);
         if (familySubmissionShortCode.isPresent()) {
             Optional<Submission> familySubmission = submissionRepositoryService.findByShortCode(familySubmissionShortCode.get());
-
-            List<Map<String, Object>> providersData = ProviderSubmissionUtilities.getFamilyIntendedProviders(
-                    familySubmission.get());
-
-            providerSubmission.getInputData().put("providersData", providersData);
-            submissionRepositoryService.save(providerSubmission);
+            if (familySubmission.isPresent()) {
+                if (SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(familySubmission.get().getInputData())) {
+                    List<Map<String, Object>> providers = (List<Map<String, Object>>) familySubmission.get().getInputData().get("providers");
+                    String providerId = providers.getFirst().get("uuid").toString();
+                    providerSubmission.getInputData().put("currentProviderUuid", providerId);
+                    submissionRepositoryService.save(providerSubmission);
+                }
+            }
         }
     }
 }

--- a/src/main/java/org/ilgcc/app/submission/conditions/MultiProviderIsEnabledAndHasMultipleProviders.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/MultiProviderIsEnabledAndHasMultipleProviders.java
@@ -6,7 +6,6 @@ import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 import org.jetbrains.annotations.NotNull;
@@ -41,15 +40,15 @@ public class MultiProviderIsEnabledAndHasMultipleProviders implements Condition 
 
     @NotNull
     private Boolean multiproviderIsEnabledAndIsNotSingleProviderApplication(Submission submission) {
-        Optional<UUID> familySubmissionIdOptional = ProviderSubmissionUtilities.getFamilySubmissionId(submission);
-        if (familySubmissionIdOptional.isEmpty()) {
-            log.warn("No family submission found ID was found for provider submission: {}.", submission.getId());
-            return false; // If we have no family submission, we can't do anything
+        Optional<String> familySubmissionShortCode = ProviderSubmissionUtilities.getFamilySubmissionShortCode(submission);
+        
+        if (familySubmissionShortCode.isEmpty()) {
+            log.warn("No family submission short code was found for provider submission: {}.", submission.getId());
+            return false; // If we have no shortcode, we can't do anything
         }
-
-        Optional<Submission> familySubmissionOptional = submissionRepositoryService.findById(familySubmissionIdOptional.get());
+        Optional<Submission> familySubmissionOptional = submissionRepositoryService.findByShortCode(familySubmissionShortCode.get());
         if (familySubmissionOptional.isEmpty()) {
-            log.warn("No family submission with ID {} found for the provider submission: {}.", familySubmissionIdOptional.get(), submission.getId());
+            log.warn("No family submission found for the provider submission: {}.", submission.getId());
             return false; // If we have no family submission, we can't do anything
         }
 

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -831,6 +831,7 @@ flow:
     condition: EnableMultipleProviders
     nextScreens: null
   paid-by-ccap:
+    beforeDisplayAction: SetCurrentProviderForSingleProviderSubmission
     nextScreens:
       - name: provider-info
         condition: IsPaidByCCAP

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseMultiProviderFlowJourneyTest.java
@@ -132,17 +132,15 @@ public class ProviderresponseMultiProviderFlowJourneyTest extends AbstractBasePa
             assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-confirmation-code.title"));
             testPage.enter("providerResponseFamilyShortCode", familySubmission.getShortCode());
             testPage.clickContinue();
-
-            //TODO: Uncomment once this has been resolved
-            // multiple-providers
-            /*assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-multiple-providers.title"));
+            
+            assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-multiple-providers.title"));
             testPage.clickElementById(String.format("currentProviderUuid-%s", individualProvider.get("uuid")));
             testPage.clickContinue();
 
             // confirm-provider
             assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-confirm-provider.title"));
             assertThat(testPage.getHeader()).contains("F.L.");
-            testPage.clickContinue();*/
+            testPage.clickContinue();
 
             // paid-by-ccap
             assertThat(testPage.getTitle()).isEqualTo(getEnMessage("paid-by-ccap.title"));
@@ -189,14 +187,13 @@ public class ProviderresponseMultiProviderFlowJourneyTest extends AbstractBasePa
             testPage.enter("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
             testPage.clickContinue();
 
-            // TODO: remove once it's fixed
             // response
-//            assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
-//            assertThat(testPage.findElementTextById("confirmation-code")).contains(familySubmission.getShortCode());
-//            assertThat(testPage.findElementTextById("parent-name")).contains("parent first parent last");
-//            assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
-//            assertThat(testPage.findElementTextById("child-name-1")).contains("Second Child");
-//            assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
+            assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
+            assertThat(testPage.findElementTextById("confirmation-code")).contains(familySubmission.getShortCode());
+            assertThat(testPage.findElementTextById("parent-name")).contains("parent first parent last");
+            assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
+            assertThat(testPage.findElementTextById("child-name-1")).contains("Second Child");
+            assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
 
             testPage.clickElementById("providerResponseAgreeToCare-true-label");
             testPage.clickButton("Submit");
@@ -377,13 +374,12 @@ public class ProviderresponseMultiProviderFlowJourneyTest extends AbstractBasePa
             testPage.clickContinue();
 
             // response
-            // TODO: uncomment once single provider is fixed
             assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
-//            assertThat(testPage.findElementTextById("confirmation-code")).contains(familySubmission.getShortCode());
-//            assertThat(testPage.findElementTextById("parent-name")).contains("parent first parent last");
-//            assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
-//            assertThat(testPage.findElementTextById("child-name-1")).contains("Second Child");
-//            assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
+            assertThat(testPage.findElementTextById("confirmation-code")).contains(familySubmission.getShortCode());
+            assertThat(testPage.findElementTextById("parent-name")).contains("parent first parent last");
+            assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
+            assertThat(testPage.findElementTextById("child-name-1")).contains("Second Child");
+            assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
 
             testPage.clickElementById("providerResponseAgreeToCare-true-label");
             testPage.clickButton("Submit");
@@ -454,13 +450,12 @@ public class ProviderresponseMultiProviderFlowJourneyTest extends AbstractBasePa
             testPage.enter("providerResponseProviderNumber", CURRENT_APPROVED_PROVIDER.getProviderId().toString());
             testPage.clickContinue();
 
-            // TODO: uncomment once single provider is fixed
             assertThat(testPage.getTitle()).isEqualTo(getEnMessage("provider-response-response.title"));
-//            assertThat(testPage.findElementTextById("confirmation-code")).contains(familySubmission.getShortCode());
-//            assertThat(testPage.findElementTextById("parent-name")).contains("parent first parent last");
-//            assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
-//            assertThat(testPage.findElementTextById("child-name-1")).contains("Second Child");
-//            assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
+            assertThat(testPage.findElementTextById("confirmation-code")).contains(familySubmission.getShortCode());
+            assertThat(testPage.findElementTextById("parent-name")).contains("parent first parent last");
+            assertThat(testPage.findElementTextById("child-name-0")).contains("First Child");
+            assertThat(testPage.findElementTextById("child-name-1")).contains("Second Child");
+            assertThat(testPage.elementDoesNotExistById("child-name-2")).isTrue();
 
             testPage.clickElementById("providerResponseAgreeToCare-true-label");
             testPage.clickButton("Submit");


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1191

#### ✍️ Description
Fixes the following issues:

**Scenario 1:**

1. Create a family application with 2 or more children
2. Indicate that not all children have a provider on the providers-all-ccap-children screen
3. In the schedules section, assign all children to one or more providers. i.e. do not add a schedule for any child with no provider
4. Respond on behalf of all the providers on the application
5. Transmission of the application to CCMS will fail

**Scenario 2:**

1. Create a family application with multiple children and providers
2. Respond on behalf of the provider but start on the https://localhost:8080/flow/providerresponse/submit-start screen
3. Add the confirmation code
4. The multiple-provider screen will skip


