### PR TITLE
[CCAP-1174] Only send emails one time for new provider registration

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/SendProviderAndFamilyEmails.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SendProviderAndFamilyEmails.java
@@ -1,13 +1,15 @@
 package org.ilgcc.app.submission.actions;
 
+import formflow.library.config.submission.Action;
 import formflow.library.data.Submission;
 import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.email.SendProviderAgreesToCareFamilyConfirmationEmail;
 import org.ilgcc.app.email.SendProviderConfirmationEmail;
 import org.ilgcc.app.email.SendProviderDeclinesCareFamilyConfirmationEmail;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import formflow.library.config.submission.Action;
+
 @Component
 @Slf4j
 public class SendProviderAndFamilyEmails implements Action {
@@ -23,8 +25,12 @@ public class SendProviderAndFamilyEmails implements Action {
 
     @Override
     public void run(Submission submission) {
-        sendProviderAgreesToCareFamilyConfirmationEmail.send(submission);
-        sendProviderConfirmationEmail.send(submission);
-        sendProviderDeclinesCareFamilyConfirmationEmail.send(submission);
+        // If a provider is an existing provider that has done CCAP stuff before, send emails
+        // New Provider Registration will send the emails later
+        if (!ProviderSubmissionUtilities.isProviderRegistering(submission)) {
+            sendProviderAgreesToCareFamilyConfirmationEmail.send(submission);
+            sendProviderConfirmationEmail.send(submission);
+            sendProviderDeclinesCareFamilyConfirmationEmail.send(submission);
+        }
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1174

#### ✍️ Description
We already fixed the fact that we were double sending new provider submissions to CCMS, which is the `afterSaveAction` ... but we need to do the same check in the `beforeSaveAction`. 

As discussed on the ticket, this PR does _not_ solve the issue that if a new provider declines care, zero emails will be sent.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
