### PR TITLE
[CCAP-1215] Provider docs need to filter out original files if PDF modification is enabled

### DIFF
--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -108,24 +108,18 @@ public class CCMSTransactionPayloadService {
                 if (provider.containsKey("providerResponseSubmissionId")) {
                     UUID providerSubmissionId = UUID.fromString(provider.get("providerResponseSubmissionId").toString());
                     submissionRepositoryService.findById(providerSubmissionId).ifPresent(
-                            providerSubmission -> allFiles.addAll(
-                                    userFileRepositoryService.findAllOrderByOriginalName(providerSubmission, PDF_CONTENT_TYPE)));
+                            providerSubmission -> allFiles.addAll(findAllFiles(providerSubmission)));
                 }
             }
         } else {
             if (familySubmission.getInputData().containsKey("providerResponseSubmissionId")) {
                 submissionRepositoryService.findById(
                                 UUID.fromString(familySubmission.getInputData().get("providerResponseSubmissionId").toString()))
-                        .ifPresent(
-                                providerSubmission -> allFiles.addAll(
-                                        userFileRepositoryService.findAllOrderByOriginalName(providerSubmission,
-                                                PDF_CONTENT_TYPE)));
+                        .ifPresent(providerSubmission -> allFiles.addAll(findAllFiles(providerSubmission)));
             }
         }
 
-        List<UserFile> userFiles = allowPdfModification ? userFileRepositoryService.findAllConvertedOrderByOriginalName(
-                familySubmission, PDF_CONTENT_TYPE)
-                : userFileRepositoryService.findAllOrderByOriginalName(familySubmission, PDF_CONTENT_TYPE);
+        List<UserFile> userFiles = findAllFiles(familySubmission);
 
         allFiles.addAll(userFiles);
 
@@ -154,5 +148,13 @@ public class CCMSTransactionPayloadService {
         }
 
         return transactionFiles;
+    }
+
+    private List<UserFile> findAllFiles(Submission submission) {
+        if (allowPdfModification) {
+            return userFileRepositoryService.findAllConvertedOrderByOriginalName(submission, PDF_CONTENT_TYPE);
+        } else {
+            return userFileRepositoryService.findAllOrderByOriginalName(submission, PDF_CONTENT_TYPE);
+        }
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1215

#### ✍️ Description
Provider user files need to follow the same pattern as family user files, and if pdf modification is enabled, we need to use a different method so we don't send the locked/encrypted files too. Pulled this out into a little helper method which could, theoretically, wind up in FFL at some point but not sure about that. Would rather fix the bug and contemplate that at some other point.

Currently in Staging, we see when a CCMS transaction for a submission + 2 files being uploaded:

<img width="1008" height="186" alt="Screenshot 2025-07-29 at 4 47 01 PM" src="https://github.com/user-attachments/assets/a23c6972-4a65-406d-b8e0-12f624fbe55e" />

There are 2 logging statements for each of the 2 files, so 4 total logging statements.

Here's what's in the database for the user_files for the family side:

<img width="1043" height="126" alt="Screenshot 2025-07-29 at 4 46 10 PM" src="https://github.com/user-attachments/assets/3ab7030c-955c-403f-9526-2defa142ab51" />

... and then:

The Provider also uploaded 2 documents, we converted them (by removing the security settings) and wound up with 4 files in the database:

<img width="1069" height="165" alt="Screenshot 2025-07-29 at 4 26 26 PM" src="https://github.com/user-attachments/assets/dfb2b762-0e4e-4908-9744-76a09069c60e" />

2 originals, 2 with the original file id as they are the new files we created. This is correct and what we'd expect that Family and Provider file uploads do the same thing!

But we also then see that when the submission is transmitted to CCMS, we grab all 4 provider files:

<img width="1008" height="287" alt="Screenshot 2025-07-29 at 4 26 04 PM" src="https://github.com/user-attachments/assets/99a346b4-caef-475f-9862-2f7022fc3983" />

There are 2 logging statements for each of the 4 files, so 8 total logging statements. 

***This is the bug! Provider files are sending all of them, and the original file breaks CCMS!*** 

Here is the fix in action!

Family submission has 2 files, both converted/stripped of security settings, so there are 4 in the database:

<img width="885" height="154" alt="Screenshot 2025-07-29 at 5 06 33 PM" src="https://github.com/user-attachments/assets/ad55b2c2-4d9b-45cc-b98b-ee8394f1c52d" />

And similarly Provider has 2 files, both converted/stripped of security settings, so there are 4 in the database:

<img width="878" height="128" alt="Screenshot 2025-07-29 at 5 12 51 PM" src="https://github.com/user-attachments/assets/b968e54a-0a29-454b-b2a0-6eabb248bc68" />

And then we see the family submission transmitting to CCMS in the dev logs, and there are only four files being transmitted (2 for the family, 2 for the provider) instead of 8:

<img width="1236" height="204" alt="Screenshot 2025-07-29 at 5 15 04 PM" src="https://github.com/user-attachments/assets/542b81c9-d2ee-4d47-bda3-6bc10a661dc4" />

(2 logging lines per file being sent!)

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
