### PR TITLE
[CCAP-997] - send email to provider when application is transmitted

### DIFF
--- a/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
+++ b/src/main/java/org/ilgcc/app/email/ILGCCEmail.java
@@ -111,6 +111,7 @@ public class ILGCCEmail implements Serializable {
         PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL("Provider Did Not Respond Family Email"),
         NEW_PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL("New Provider Agrees to Care Family Email"),
         AUTOMATED_PROVIDER_OUTREACH_EMAIL("Automated Provider Outreach Email"),
+        FAMILY_APPLICATION_TRANSMITTED_PROVIDER_CONFIRMATION_EMAIL("Family Application Transmitted Email to Provider"),
         DAILY_NEW_APPLICATIONS_PROVIDER_EMAIL("Automated Email going to Processing Organizations Daily"),
         FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL("Family Application Transmitted Email");
 

--- a/src/main/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedProviderConfirmationEmail.java
+++ b/src/main/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedProviderConfirmationEmail.java
@@ -1,0 +1,59 @@
+package org.ilgcc.app.email;
+
+import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getCombinedDataForEmails;
+
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.email.ILGCCEmail.EmailType;
+import org.ilgcc.app.email.templates.FamilyApplicationTransmittedProviderConfirmationTemplate;
+import org.ilgcc.app.utils.SubmissionUtilities;
+import org.ilgcc.jobs.SendEmailJob;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SendFamilyApplicationTransmittedProviderConfirmationEmail extends SendEmail {
+
+    @Autowired
+    public SendFamilyApplicationTransmittedProviderConfirmationEmail(SendEmailJob sendEmailJob, MessageSource messageSource,
+            SubmissionRepositoryService submissionRepositoryService) {
+        super(sendEmailJob, messageSource, submissionRepositoryService, "applicationTransmittedConfirmationEmailSent",
+                "providerResponseContactEmail");
+    }
+
+    @Override
+    protected ILGCCEmailTemplate emailTemplate(Map<String, Object> emailData) {
+        return new FamilyApplicationTransmittedProviderConfirmationTemplate(emailData, messageSource, locale).createTemplate();
+    }
+
+    @Override
+    protected Optional<Map<String, Object>> getEmailData(Submission providerSubmission, Map<String, Object> subflowData) {
+        Optional<Submission> familySubmission = getFamilyApplication(providerSubmission);
+        if (familySubmission.isPresent()) {
+            String currentProviderUuid = (String) providerSubmission.getInputData().getOrDefault("currentProviderUuid", "");
+            Map<String, Object> currentProvider = SubmissionUtilities.getCurrentProvider(familySubmission.get().getInputData(),
+                    currentProviderUuid);
+            // todo: Remove when productizing ENABLE_MULTIPLE_PROVIDERS. Having no current provider would be an error when
+            //  ENABLE_MULTIPLE_PROVIDERS feature flag is on.
+            if (!currentProvider.isEmpty()) {
+                return Optional.of(getCombinedDataForEmails(providerSubmission, familySubmission.get(), currentProvider));
+            } else {
+                return Optional.of(getCombinedDataForEmails(providerSubmission, familySubmission.get()));
+            }
+
+        } else {
+            log.warn(
+                    "{}: Skipping email send because there is no family submission associated with the provider submission with ID : {}",
+                    EmailType.FAMILY_APPLICATION_TRANSMITTED_PROVIDER_CONFIRMATION_EMAIL.getDescription(), providerSubmission.getId());
+            return Optional.empty();
+        }
+    }
+
+}
+

--- a/src/main/java/org/ilgcc/app/email/templates/FamilyApplicationTransmittedProviderConfirmationTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyApplicationTransmittedProviderConfirmationTemplate.java
@@ -1,0 +1,62 @@
+package org.ilgcc.app.email.templates;
+
+import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+import static org.ilgcc.app.utils.ProviderSubmissionUtilities.formatListIntoReadableString;
+
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.ilgcc.app.email.ILGCCEmail;
+import org.ilgcc.app.email.ILGCCEmail.EmailType;
+import org.ilgcc.app.email.ILGCCEmailTemplate;
+import org.springframework.context.MessageSource;
+
+@Getter
+@Setter
+public class FamilyApplicationTransmittedProviderConfirmationTemplate {
+
+    private Map<String, Object> emailData;
+    private MessageSource messageSource;
+    private Locale locale;
+
+   public FamilyApplicationTransmittedProviderConfirmationTemplate(Map<String, Object> emailData, MessageSource messageSource, Locale locale) {
+       this.emailData = emailData;
+       this.messageSource = messageSource;
+       this.locale = locale;
+
+   }
+   public ILGCCEmailTemplate createTemplate(){
+       return new ILGCCEmailTemplate(senderEmail(), setSubject(emailData), new Content("text/html", setBodyCopy(emailData)),
+               EmailType.FAMILY_APPLICATION_TRANSMITTED_PROVIDER_CONFIRMATION_EMAIL);
+   }
+
+    private Email senderEmail() {
+        return  new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale));
+    }
+
+    private String setSubject(Map<String, Object> emailData) {
+        return messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.subject",
+                null,
+                locale);
+    }
+
+    private String setBodyCopy(Map<String, Object> emailData) {
+        String p1 = messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p1", null, locale);
+        String p2 = messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p2", new Object[]{emailData.get("ccrrName")}, locale);
+        String p3 = messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p3", new Object[]{
+                formatListIntoReadableString((List<String>) emailData.get("childrenInitialsList"),
+                        messageSource.getMessage("general.and", null, locale)), emailData.get("ccapStartDate")}, locale);
+        String p4 = messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p4", new Object[]{emailData.get("confirmationCode")},
+                locale);
+        String p5 = messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p5",
+                new Object[]{emailData.get("ccrrName"), emailData.get("ccrrPhoneNumber")}, locale);
+        String p6 = messageSource.getMessage("email.general.footer.automated-response", null, locale);
+        String p7 = messageSource.getMessage("email.general.footer.cfa", null, locale);
+        return p1 + p2 + p3 + p4 + p5 + p6 + p7;
+    }
+
+}

--- a/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
+++ b/src/main/java/org/ilgcc/app/inputs/Providerresponse.java
@@ -184,5 +184,7 @@ public class Providerresponse extends FlowInputs {
 
     private String providerConfirmationEmailSent;
 
+    private String applicationTransmittedConfirmationEmailSent;
+
     private String providerHasFEIN;
 }

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -171,7 +171,7 @@ public class ProviderSubmissionUtilities {
         // get earliest date from family application
         applicationData.put("ccapStartDate",
                 DateUtilities.convertDateToFullWordMonthPattern(earliestDate));
-        applicationData.put("hasMutipleProviders", hasMoreThan1Provider(familySubmission.getInputData()));
+        applicationData.put("hasMultipleProviders", hasMoreThan1Provider(familySubmission.getInputData()));
         applicationData.put("hasProviderAndNoProvider",
                 SubmissionUtilities.hasSelectedAProviderAndNoProvider(familySubmission.getInputData()));
         applicationData.put("hasMultipleProvidersWithChildcareSchedules", String.valueOf(!SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(familySubmission.getInputData())));

--- a/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/ProviderSubmissionUtilities.java
@@ -119,11 +119,13 @@ public class ProviderSubmissionUtilities {
         applicationData.putAll(getFamilySubmissionDataForEmails(familySubmission, subflowData));
         applicationData.putAll(getProviderSubmissionDataForEmails(providerSubmission));
 
-        String earliestDate = (String) familySubmission.getInputData()
-                .getOrDefault("earliestChildcareStartDate", "");
-        applicationData.put("ccapStartDate",
-                ProviderSubmissionUtilities.getCCAPStartDateFromProviderOrFamilyChildcareStartDate(earliestDate,
-                        Optional.of(providerSubmission)));
+        String providerCareStartDate = (String) providerSubmission.getInputData()
+                .getOrDefault("providerCareStartDate", "");
+
+        if (!providerCareStartDate.isBlank()) {
+            applicationData.put("ccapStartDate",
+                    DateUtilities.convertDateToFullWordMonthPattern(providerCareStartDate));
+        }
 
         return applicationData;
     }
@@ -166,10 +168,10 @@ public class ProviderSubmissionUtilities {
         applicationData.put("submittedDate", SubmissionUtilities.getFormattedSubmittedAtDate(familySubmission));
         String earliestDate = (String) familySubmission.getInputData()
                 .getOrDefault("earliestChildcareStartDate", "");
+        // get earliest date from family application
         applicationData.put("ccapStartDate",
-                ProviderSubmissionUtilities.getCCAPStartDateFromProviderOrFamilyChildcareStartDate(earliestDate,
-                        Optional.empty()));
-        applicationData.put("hasMultipleProviders", hasMoreThan1Provider(familySubmission.getInputData()));
+                DateUtilities.convertDateToFullWordMonthPattern(earliestDate));
+        applicationData.put("hasMutipleProviders", hasMoreThan1Provider(familySubmission.getInputData()));
         applicationData.put("hasProviderAndNoProvider",
                 SubmissionUtilities.hasSelectedAProviderAndNoProvider(familySubmission.getInputData()));
         applicationData.put("hasMultipleProvidersWithChildcareSchedules", String.valueOf(!SubmissionUtilities.allChildcareSchedulesAreForTheSameProvider(familySubmission.getInputData())));
@@ -188,6 +190,14 @@ public class ProviderSubmissionUtilities {
                     SchedulePreparerUtility.getRelatedChildrenSchedulesForEachProvider(familySubmission.getInputData());
             applicationData.put("childrenInitialsList",
                     ProviderSubmissionUtilities.getChildrenInitialsList(mergedChildrenAndSchedules.get(data.get("uuid"))));
+            if (subflowIteration.containsKey("uuid")) {
+                String earliestCCAPDate = DateUtilities.getEarliestDate(mergedChildrenAndSchedules.get(subflowIteration.get(
+                        "uuid")).stream().map(s -> s.getOrDefault(
+                        "ccapStartDate", "").toString()).toList());
+
+                applicationData.put("ccapStartDate",
+                        DateUtilities.convertDateToFullWordMonthPattern(earliestCCAPDate));
+            }
 
         }
 

--- a/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
+++ b/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
@@ -313,8 +313,10 @@ public class CCMSSubmissionPayloadTransactionJob {
                 Map<String, Object> providerObject = SubmissionUtilities.getCurrentProvider(familySubmission.getInputData(),
                         providerId);
                 String providerResponseSubmissionId = providerObject.get("providerResponseSubmissionId").toString();
-                Optional<Submission> providerSubmission = submissionRepositoryService.findById(UUID.fromString(providerResponseSubmissionId));
-                if (providerSubmission.isPresent()) {
+                Optional<Submission> providerSubmission = submissionRepositoryService.findById(
+                        UUID.fromString(providerResponseSubmissionId));
+                if (providerSubmission.isPresent() && providerSubmission.get().getInputData().getOrDefault(
+                        "providerResponseAgreeToCare", "false").equals("true")) {
                     sendFamilyApplicationTransmittedProviderConfirmationEmail.send(providerSubmission.get());
                 }
             }
@@ -324,7 +326,8 @@ public class CCMSSubmissionPayloadTransactionJob {
             Optional<Submission> providerSubmission =
                     submissionRepositoryService.findById(UUID.fromString(familySubmission.getInputData().get(
                             "providerResponseSubmissionId").toString()));
-            if (providerSubmission.isPresent()) {
+            if (providerSubmission.isPresent() && providerSubmission.get().getInputData().getOrDefault(
+                    "providerResponseAgreeToCare", "false").equals("true")) {
                 sendFamilyApplicationTransmittedProviderConfirmationEmail.send(providerSubmission.get());
             }
         }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -174,6 +174,14 @@ email.family-application-transmitted-confirmation-email.li-did-not-complete-appl
 email.family-application-transmitted-confirmation-email.p3=<p><strong>Confirmation code:</strong> {0}</p>
 email.family-application-transmitted-confirmation-email.p4=<p><strong>Next steps:</strong> Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application.</p><p>If you have questions, call <strong>{0}: <a href="tel:{1}">{1}</a></strong>.</p>
 
+# FAMILY_APPLICATION_TRANSMITTED_PROVIDER_CONFIRMATION_EMAIL
+email.family-application-transmitted-provider-confirmation-email.subject=[CCAP] Your application has been sent for processing
+email.family-application-transmitted-provider-confirmation-email.p1=<p>Hello,</p>
+email.family-application-transmitted-provider-confirmation-email.p2=<p>Your application has now been sent to {0} for processing.</p>
+email.family-application-transmitted-provider-confirmation-email.p3=<p><strong>Response:</strong> You agreed to care for {0} with a start date of {1} or pending approval of eligibility.
+email.family-application-transmitted-provider-confirmation-email.p4=<p><strong>Confirmation code:</strong> {0}</p>
+email.family-application-transmitted-provider-confirmation-email.p5=<p><strong>Next steps:</strong> Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application.</p><p>If you have questions, call <strong>{0}: <a href="tel:{1}">{1}</a></strong>.</p>
+
 # PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
 email.provider-agrees-to-care.subject=[CCAP update] A provider agreed to care
 email.provider-agrees-to-care.p1=<p>Hi {0},</p>

--- a/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedProviderConfirmationTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedProviderConfirmationTest.java
@@ -1,0 +1,362 @@
+package org.ilgcc.app.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+
+import com.sendgrid.helpers.mail.objects.Email;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
+import formflow.library.data.SubmissionRepositoryService;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.ilgcc.app.utils.enums.SubmissionStatus;
+import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.MessageSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class SendFamilyApplicationTransmittedProviderConfirmationTest {
+
+    @MockitoSpyBean
+    SendEmailJob sendEmailJob;
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+
+    @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
+    MessageSource messageSource;
+
+    private Submission providerSubmission;
+
+    private SendFamilyApplicationTransmittedProviderConfirmationEmail sendEmailClass;
+
+    private final Locale locale = Locale.ENGLISH;
+
+    private Submission familySubmission;
+
+    private static Map<String, Object> individualProvider = new HashMap<>();
+
+    private static Map<String, Object> programProvider = new HashMap<>();
+
+    private static Map<String, Object> noResponseProvider = new HashMap<>();
+
+    private Submission programProviderSubmission;
+
+    private Submission individualProviderSubmission;
+    private static Map<String, Object> child1 = new HashMap<>();
+
+    private static Map<String, Object> child2 = new HashMap<>();
+
+    private static Map<String, Object> emailData = new HashMap<>();
+
+    @BeforeAll
+    public static void setUpOnce() {
+        individualProvider.put("uuid", UUID.randomUUID().toString());
+        individualProvider.put("iterationIsComplete", true);
+        individualProvider.put("providerFirstName", "FirstName");
+        individualProvider.put("providerLastName", "LastName");
+        individualProvider.put("familyIntendedProviderEmail", "firstLast@mail.com");
+        individualProvider.put("familyIntendedProviderPhoneNumber", "(999) 123-1234");
+        individualProvider.put("familyIntendedProviderAddress", "123 Main St.");
+        individualProvider.put("familyIntendedProviderCity", "Chicago");
+        individualProvider.put("familyIntendedProviderState", "IL");
+        individualProvider.put("providerType", "Individual");
+        individualProvider.put("providerApplicationResponseStatus", SubmissionStatus.ACTIVE.name());
+
+        programProvider.put("uuid", UUID.randomUUID().toString());
+        programProvider.put("iterationIsComplete", true);
+        programProvider.put("childCareProgramName", "Child Care Program Name");
+        programProvider.put("familyIntendedProviderEmail", "ccpn@mail.com");
+        programProvider.put("familyIntendedProviderPhoneNumber", "(123) 123-1234");
+        programProvider.put("familyIntendedProviderAddress", "456 Main St.");
+        programProvider.put("familyIntendedProviderCity", "Chicago");
+        programProvider.put("familyIntendedProviderState", "IL");
+        programProvider.put("providerType", "Care Program");
+        programProvider.put("providerApplicationResponseStatus", SubmissionStatus.ACTIVE.name());
+
+        noResponseProvider.put("uuid", UUID.randomUUID().toString());
+        noResponseProvider.put("iterationIsComplete", true);
+        noResponseProvider.put("childCareProgramName", "Great Care Child Care");
+        noResponseProvider.put("familyIntendedProviderEmail", "ccpn@mail.com");
+        noResponseProvider.put("familyIntendedProviderPhoneNumber", "(123) 123-1234");
+        noResponseProvider.put("familyIntendedProviderAddress", "456 Main St.");
+        noResponseProvider.put("familyIntendedProviderCity", "Chicago");
+        noResponseProvider.put("familyIntendedProviderState", "IL");
+        noResponseProvider.put("providerType", "Care Program");
+        noResponseProvider.put("providerApplicationResponseStatus", SubmissionStatus.ACTIVE.name());
+
+        child1.put("uuid", UUID.randomUUID().toString());
+        child1.put("childFirstName", "First");
+        child1.put("childLastName", "Child");
+        child1.put("childInCare", "true");
+        child1.put("childDateOfBirthMonth", "10");
+        child1.put("childDateOfBirthDay", "11");
+        child1.put("childDateOfBirthYear", "2020");
+        child1.put("needFinancialAssistanceForChild", true);
+        child1.put("childIsUsCitizen", "Yes");
+        child1.put("ccapStartDate", "01/10/2025");
+
+        child2.put("uuid", UUID.randomUUID().toString());
+        child2.put("childFirstName", "Second");
+        child2.put("childLastName", "Child");
+        child2.put("childInCare", "true");
+        child2.put("childDateOfBirthMonth", "12");
+        child2.put("childDateOfBirthDay", "11");
+        child2.put("childDateOfBirthYear", "2021");
+        child2.put("needFinancialAssistanceForChild", true);
+        child2.put("childIsUsCitizen", "Yes");
+        child2.put("ccapStartDate", "12/10/2025");
+    }
+
+    @Nested
+    class whenSingleProvider {
+
+        @BeforeEach
+        void setUp() {
+            Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("gcc")
+                    .with("parentPreferredName", "FirstName").withChild("First", "Child", "true")
+                    .withChild("Second", "Child", "true")
+                    .withSubmittedAtDate(OffsetDateTime.now())
+                    .with("earliestChildcareStartDate", "01/10/2025")
+                    .withCCRR()
+                    .withShortCode("ABC123")
+                    .build());
+
+            providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("providerresponse")
+                    .with("familySubmissionId", familySubmission.getId().toString())
+                    .with("providerResponseContactEmail", "provideremail@test.com")
+                    .with("providerResponseFirstName", "ProviderFirst")
+                    .with("providerResponseLastName", "ProviderLast")
+                    .with("providerResponseBusinessName", "BusinessName")
+                    .with("providerResponseAgreeToCare", "true")
+                    .build());
+
+            sendEmailClass = new SendFamilyApplicationTransmittedProviderConfirmationEmail(sendEmailJob, messageSource,
+                    submissionRepositoryService);
+
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(providerSubmission);
+            emailData = emailDataOptional.get();
+        }
+
+        @AfterEach
+        void tearDown() {
+            submissionRepository.deleteAll();
+        }
+
+        @Test
+        void correctlySetsEmailRecipient() {
+            assertThat(sendEmailClass.getRecipientEmail(emailData)).isEqualTo("provideremail@test.com");
+        }
+
+        @Test
+        void correctlySetsEmailData() {
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+            assertThat(emailData.get("providerName")).isEqualTo("BusinessName");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("ccapStartDate")).isEqualTo("January 10, 2025");
+            assertThat(emailData.get("providerResponseContactEmail")).isEqualTo("provideremail@test.com");
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailData);
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                    new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.subject", null,
+                            locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p1", null,
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p2",
+                            new Object[]{"Sample Test CCRR"},
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p3",
+                            new Object[]{"F.C. and S.C.", "January 10, 2025"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p4",
+                            new Object[]{"ABC123"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p5",
+                            new Object[]{"Sample Test CCRR", "(603) 555-1244"},
+                            locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
+
+
+        @Test
+        void correctlyUpdatesEmailSendStatus() {
+            assertThat(providerSubmission.getInputData().containsKey("applicationTransmittedConfirmationEmailSent")).isFalse();
+            sendEmailClass.send(providerSubmission);
+
+            assertThat(providerSubmission.getInputData().containsKey("applicationTransmittedConfirmationEmailSent")).isTrue();
+            assertThat(providerSubmission.getInputData().get("applicationTransmittedConfirmationEmailSent")).isEqualTo("true");
+        }
+
+        @Test
+        void correctlySkipsEmailSendWhenEmailStatusIsTrue() {
+            assertThat(sendEmailClass.skipEmailSend(providerSubmission.getInputData())).isFalse();
+
+            providerSubmission.getInputData().put("applicationTransmittedConfirmationEmailSent", "true");
+            assertThat(sendEmailClass.skipEmailSend(providerSubmission.getInputData())).isTrue();
+        }
+
+        @Test
+        void correctlyEnqueuesSendEmailJob() {
+            sendEmailClass.send(providerSubmission);
+            verify(sendEmailJob).enqueueSendSubmissionEmailJob(any(ILGCCEmail.class), any(Integer.class));
+        }
+    }
+
+    @Nested
+    class whenMultipleProviders {
+
+        @BeforeEach
+        void setUp() {
+            familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("gcc")
+                    .with("parentFirstName", "FirstName")
+                    .with("parentContactEmail", "familyemail@test.com")
+                    .with("languageRead", "English")
+                    .with("providers", List.of(individualProvider, programProvider, noResponseProvider))
+                    .with("children", List.of(child1, child2))
+                    .withMultipleChildcareSchedules(List.of(child1.get("uuid").toString(), child2.get("uuid").toString(),
+                                    child1.get("uuid").toString(), child2.get("uuid").toString()),
+                            List.of(individualProvider.get("uuid").toString(),
+                                    individualProvider.get("uuid").toString(), programProvider.get("uuid").toString(),
+                                    noResponseProvider.get("uuid").toString()))
+                    .withSubmittedAtDate(OffsetDateTime.now())
+                    .withCCRR()
+                    .withShortCode("ABC123")
+                    .build());
+
+            providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                    .withFlow("providerresponse")
+                    .with("familySubmissionId", familySubmission.getId().toString())
+                    .with("currentProviderUuid", programProvider.get("uuid"))
+                    .with("providerResponseContactEmail", "provideremail@test.com")
+                    .with("providerResponseFirstName", "ProviderFirst")
+                    .with("providerResponseLastName", "ProviderLast")
+                    .with("providerResponseBusinessName", "BusinessName")
+                    .with("providerResponseAgreeToCare", "true")
+                    .build());
+
+            sendEmailClass = new SendFamilyApplicationTransmittedProviderConfirmationEmail(sendEmailJob, messageSource,
+                    submissionRepositoryService);
+
+            Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(providerSubmission);
+            emailData = emailDataOptional.get();
+        }
+
+        @AfterEach
+        void tearDown() {
+            submissionRepository.deleteAll();
+        }
+
+        @Test
+        void correctlySetsEmailRecipient() {
+            assertThat(sendEmailClass.getRecipientEmail(emailData)).isEqualTo("provideremail@test.com");
+        }
+
+        @Test
+        void correctlySetsEmailData() {
+            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C."));
+            assertThat(emailData.get("providerName")).isEqualTo("BusinessName");
+            assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+            assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+            assertThat(emailData.get("ccapStartDate")).isEqualTo("January 10, 2025");
+            assertThat(emailData.get("providerResponseContactEmail")).isEqualTo("provideremail@test.com");
+        }
+
+        @Test
+        void correctlySetsEmailTemplateData() {
+            ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailData);
+
+            assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                    new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+            assertThat(emailTemplate.getSubject()).isEqualTo(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.subject", null,
+                            locale));
+
+            String emailCopy = emailTemplate.getBody().getValue();
+
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p1", null,
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p2",
+                            new Object[]{"Sample Test CCRR"},
+                            locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p3",
+                            new Object[]{"F.C.", "January 10, 2025"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p4",
+                            new Object[]{"ABC123"}, locale));
+            assertThat(emailCopy).contains(
+                    messageSource.getMessage("email.family-application-transmitted-provider-confirmation-email.p5",
+                            new Object[]{"Sample Test CCRR", "(603) 555-1244"},
+                            locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+            assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+        }
+
+
+        @Test
+        void correctlyUpdatesEmailSendStatus() {
+            assertThat(providerSubmission.getInputData().containsKey("applicationTransmittedConfirmationEmailSent")).isFalse();
+            sendEmailClass.send(providerSubmission);
+
+            assertThat(providerSubmission.getInputData().containsKey("applicationTransmittedConfirmationEmailSent")).isTrue();
+            assertThat(providerSubmission.getInputData().get("applicationTransmittedConfirmationEmailSent")).isEqualTo("true");
+        }
+
+        @Test
+        void correctlySkipsEmailSendWhenEmailStatusIsTrue() {
+            assertThat(sendEmailClass.skipEmailSend(providerSubmission.getInputData())).isFalse();
+
+            providerSubmission.getInputData().put("applicationTransmittedConfirmationEmailSent", "true");
+            assertThat(sendEmailClass.skipEmailSend(providerSubmission.getInputData())).isTrue();
+        }
+
+        @Test
+        void correctlyEnqueuesSendEmailJob() {
+            sendEmailClass.send(providerSubmission);
+            verify(sendEmailJob).enqueueSendSubmissionEmailJob(any(ILGCCEmail.class), any(Integer.class));
+        }
+    }
+
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[CCAP-997](https://codeforamerica.atlassian.net/browse/CCAP-997)

#### ✍️ Description
- When an application has been transmitted, email the providers to let them know the application has been transmitted
- Adds Tests

Link to test scenarios: https://codeforamerica.atlassian.net/browse/CCAP-997?focusedCommentId=20251

#### 📷 Design reference

Emails when Multiple providers
<img width="1104" height="650" alt="Screenshot 2025-08-11 at 3 22 44 PM" src="https://github.com/user-attachments/assets/410184c5-35bc-4ae2-97b3-d4eba65cdea9" />

Emails when Single Provider
<img width="847" height="709" alt="Screenshot 2025-08-12 at 3 43 14 PM" src="https://github.com/user-attachments/assets/cbefbc15-1a30-498a-bbd8-680a0b395b87" />


#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-997]: https://codeforamerica.atlassian.net/browse/CCAP-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ