### PR TITLE
[CCAP-1209] Make sitemap discoverable with full URL in prod

### DIFF
--- a/src/main/java/org/ilgcc/app/RobotsController.java
+++ b/src/main/java/org/ilgcc/app/RobotsController.java
@@ -10,18 +10,21 @@ public class RobotsController {
 
     @Value("${spring.profiles.active:default}")
     private String activeProfile;
+    
+    @Value("${il-gcc.base-url}")
+    private String baseUrl;
 
     @GetMapping(value = "/robots.txt", produces = MediaType.TEXT_PLAIN_VALUE)
     public String getRobotsTxt() {
         if ("production".equalsIgnoreCase(activeProfile)) {
-            return """
+            return String.format("""
                 User-agent: *
                 Disallow: /
                 Allow: /$
                 Allow: /faq$
                 Allow: /privacy$
-                Sitemap: /sitemap.xml
-                """;
+                Sitemap: %s/sitemap.xml
+                """, baseUrl);
         } else {
             return """
                 User-agent: *

--- a/src/test/java/org/ilgcc/app/RobotsControllerTest.java
+++ b/src/test/java/org/ilgcc/app/RobotsControllerTest.java
@@ -1,0 +1,41 @@
+package org.ilgcc.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RobotsControllerUnitTest {
+
+    @Test
+    void productionProfile_returnsFullRobotsWithSitemap() {
+        RobotsController controller = new RobotsController();
+        ReflectionTestUtils.setField(controller, "activeProfile", "production");
+        ReflectionTestUtils.setField(controller, "baseUrl", "https://www.getchildcareil.org");
+
+        String body = controller.getRobotsTxt();
+
+        assertThat(body.lines().toList()).containsExactly(
+                "User-agent: *",
+                "Disallow: /",
+                "Allow: /$",
+                "Allow: /faq$",
+                "Allow: /privacy$",
+                "Sitemap: https://www.getchildcareil.org/sitemap.xml"
+        );
+    }
+
+    @Test
+    void nonProductionProfile_returnsDisallowAll() {
+        RobotsController controller = new RobotsController();
+        ReflectionTestUtils.setField(controller, "activeProfile", "qa");
+        ReflectionTestUtils.setField(controller, "baseUrl", "https://ignored.example");
+
+        String body = controller.getRobotsTxt();
+
+        assertThat(body.lines().toList()).containsExactly(
+                "User-agent: *",
+                "Disallow: /"
+        );
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1209

#### ✍️ Description
The search console will not accept the sitemap without being provided a full canonical URL in the robots.txt for crawling. This PR fixes that issue by providing the full canonical URL in the production environments robots.txt file where its needed.

#### Testing & Deployment
Adds one unit test each for prod and non prod environments. The unit tests set the active spring profile to 'production' and 'qa' to mimic prod and non prod results when calling `getRobotsTxt` in the RobotsController. The unit tests should be sufficient for local testing but ultimately this will need to be merged and released before CCAP-1209 can be completed by actually submitting the sitemap to the Google and Bing search consoles.

The above testing gives me confidence this should work in production but should it fail, we can create a bug ticket and prioritize as needed. The main consequence being a delay in search indexing. 



