### PR TITLE
[CCAP-1181] do not show no provider chosen option in schedules section when there is one child and all providers were chosen

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/UpdateCurrentChildcareProviderIfOneOrNoProviders.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/UpdateCurrentChildcareProviderIfOneOrNoProviders.java
@@ -8,7 +8,6 @@ import formflow.library.data.Submission;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -26,7 +25,7 @@ public class UpdateCurrentChildcareProviderIfOneOrNoProviders implements Action 
             if (hasNoProviders(inputData)) {
                 childcareProvidersForCurrentChild.add("NO_PROVIDER");
             }
-            if (providers.size() == 1 && allChildrenHaveProviders(inputData)) {
+            if (providers.size() == 1) {
                 childcareProvidersForCurrentChild.add(providers.getFirst().getOrDefault("uuid", "").toString());
             }
             formSubmission.getFormData().put("childcareProvidersForCurrentChild[]", childcareProvidersForCurrentChild);
@@ -35,9 +34,5 @@ public class UpdateCurrentChildcareProviderIfOneOrNoProviders implements Action 
 
     private boolean hasNoProviders(Map<String, Object> inputData)  {
         return inputData.getOrDefault("hasChosenProvider", "false").equals("false");
-    }
-
-    private boolean allChildrenHaveProviders(Map<String, Object> inputData) {
-        return inputData.getOrDefault("choseProviderForEveryChildInNeedOfCare", "false").equals("true");
     }
 }

--- a/src/main/resources/templates/gcc/schedules-start.html
+++ b/src/main/resources/templates/gcc/schedules-start.html
@@ -1,3 +1,4 @@
+<!--TODO: Modify hasMoreThanOneChildcareOption to only display checkbox fields correctly-->
 <th:block th:with="childName=${relatedSubflowIteration.get('childFirstName')},
                    hasProviders=${submission.getInputData().containsKey('providers')},
                    showNoProviderOption=${submission.getInputData().getOrDefault('choseProviderForEveryChildInNeedOfCare', 'false').equals('false')},

--- a/src/main/resources/templates/gcc/schedules-start.html
+++ b/src/main/resources/templates/gcc/schedules-start.html
@@ -1,7 +1,6 @@
-<!--TODO: Modify hasMoreThanOneChildcareOption to only display checkbox fields correctly-->
 <th:block th:with="childName=${relatedSubflowIteration.get('childFirstName')},
                    hasProviders=${submission.getInputData().containsKey('providers')},
-                   showNoProviderOption=${submission.getInputData().getOrDefault('choseProviderForEveryChildInNeedOfCare', 'false').equals('false')},
+                   showNoProviderOption=${submission.getInputData().getOrDefault('choseProviderForEveryChildInNeedOfCare', '').equals('false')},
                    hasMoreThanOneChildcareOption=${hasProviders && (submission.getInputData().get('providers').size() > 1 || showNoProviderOption)},
                    providersList=${submission.getInputData().get('providers')}">
   <th:block
@@ -37,5 +36,4 @@
       </th:block>
     </th:block>
   </th:block>
-</th:block>
 </th:block>

--- a/src/test/java/org/ilgcc/app/submission/actions/UpdateCurrentChildcareProviderIfOneOrNoProvidersTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/UpdateCurrentChildcareProviderIfOneOrNoProvidersTest.java
@@ -35,7 +35,7 @@ class UpdateCurrentChildcareProviderIfOneOrNoProvidersTest {
     setUpWhenNoFormDataIsPassed();
     submission = new SubmissionTestBuilder()
         .withProvider("TestProvider", "1")
-        .with("hasChosenProvider", "true").with("choseProviderForEveryChildInNeedOfCare", "true")
+        .with("hasChosenProvider", "true")
         .build();
     action.run(formSubmission, submission, "1");
     Map<String, Object> firstProvider = ((List<Map<String, Object>>) submission.getInputData().get("providers")).getFirst();
@@ -48,7 +48,6 @@ class UpdateCurrentChildcareProviderIfOneOrNoProvidersTest {
     submission = new SubmissionTestBuilder()
         .withProvider("TestProvider", "1")
         .with("hasChosenProvider", "true")
-        .with("choseProviderForEveryChildInNeedOfCare", "false")
         .build();
     Map<String, Object> firstProvider = ((List<Map<String, Object>>) submission.getInputData().get("providers")).getFirst();
     Map<String, Object> formData = new HashMap<>();


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1181

#### ✍️ Description
When a client has one child and they have chosen one child care provider, we are displaying the check box options for the childcare provider with a checkbox for no provider chosen.  We need to address several issues to fix this problem:  
1.  UpdateCurrentChildcareProviderIfOneOrNoProviders should only check if hasNoProviders or if the client has one provider.   In those scenarios we should not render the checkbox options
2. update the shoNoProviderOption to only display when `choseProviderForEveryChildInNeedOfCare` is false.  The checkbox `No Provider Chosen yet` should not be rendered otherwise.  
3. Test should only pass when one provider or no provider is chosen.  

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
