### PR TITLE
Removing extra space from logging statement

### DIFF
--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSApiClient.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSApiClient.java
@@ -45,7 +45,7 @@ public class CCMSApiClient {
                         .onStatus(status -> !status.is2xxSuccessful(), resp ->
                                 resp.createException()
                                         .doOnNext(ex -> log.error(
-                                                "Received an error response from CCMS when sending submission  with ID: {}. Status: {}, Body: {}",
+                                                "Received an error response from CCMS when sending submission with ID: {}. Status: {}, Body: {}",
                                                 requestBody.getSubmissionId(),
                                                 ex.getStatusCode(),
                                                 ex.getResponseBodyAsString()))


### PR DESCRIPTION
Removing a single extra space from a logging statement, mostly to test some hotfix stuff and needing a branch to do so.