### PR TITLE
Fix JobRetriesFailedFilter and log all retryable job failures

### DIFF
--- a/src/main/java/org/ilgcc/app/config/JobrunrConfig.java
+++ b/src/main/java/org/ilgcc/app/config/JobrunrConfig.java
@@ -1,22 +1,19 @@
 package org.ilgcc.app.config;
 
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.jobrunr.jobs.filters.JobFilter;
 import org.jobrunr.server.BackgroundJobServer;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Profile("!test")
-@ConditionalOnProperty(
-        name = {"il-gcc.ccms-integration-enabled", "il-gcc.jobrunr.background-job-server.enabled"},
-        havingValue = "true",
-        matchIfMissing = false
-)
+@Slf4j
 public class JobrunrConfig {
     // This is how you register a JobFilter bean with the application context without JobRunr PRO
     JobrunrConfig(BackgroundJobServer backgroundJobServer, List<? extends JobFilter> jobFilters) {
+        log.info("Registering {} JobRunr filters: {}", jobFilters.size(), jobFilters);;
         backgroundJobServer.getJobFilters().addAll(jobFilters);
     }
 }

--- a/src/main/java/org/ilgcc/jobs/JobRetriesFailedFilter.java
+++ b/src/main/java/org/ilgcc/jobs/JobRetriesFailedFilter.java
@@ -3,7 +3,6 @@ package org.ilgcc.jobs;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.ilgcc.app.data.Transaction;
 import org.jetbrains.annotations.NotNull;
 import org.jobrunr.jobs.Job;
 import org.jobrunr.jobs.JobParameter;
@@ -19,18 +18,7 @@ public class JobRetriesFailedFilter implements JobServerFilter {
         String exceptionMessage = getExceptionMessage(job);
         List<JobParameter> jobParameters = job.getJobDetails().getJobParameters();
 
-        if ("Lookup Work Item ID for Transaction".equals(job.getJobName())) {
-
-            if (jobParameters.isEmpty() || !jobParameters.getFirst().getClassName().equals(Transaction.class.getName())) {
-                log.error("Work item lookup job with ID {} failed and was unable to recover the Transaction parameter. Exception: {}",
-                        job.getId(), exceptionMessage);
-                return;
-            }
-
-            Transaction transaction = (Transaction) jobParameters.getFirst().getObject();
-            log.error("Work item lookup job with ID {} failed for Transaction ID {} after all retries exhausted. Exception: {}",
-                    job.getId(), transaction.getTransactionId(), exceptionMessage);
-        } else if ("Send CCMS Submission Payload".equals(job.getJobName())) {
+        if ("Send CCMS Submission Payload".equals(job.getJobName())) {
 
             if (jobParameters.isEmpty() || !jobParameters.getFirst().getClassName().equals(UUID.class.getName())) {
                 log.error("CCMS Submission job with ID {} failed and was unable to recover the UUID parameter. Exception: {}",
@@ -41,6 +29,13 @@ public class JobRetriesFailedFilter implements JobServerFilter {
             UUID submissionId = (UUID) jobParameters.getFirst().getObject();
             log.error("CCMS Submission job with ID {} failed for Submission {} after all retries exhausted. Exception: {}",
                     job.getId(), submissionId, exceptionMessage);
+        } else if ("Send Email Request".equals(job.getJobName())) {
+
+            log.error("Email job with ID {} failed after all retries exhausted. Exception: {}",
+                    job.getId(), exceptionMessage);
+        } else {
+            log.error("Job with ID {} and name '{}' failed after all retries exhausted. Exception: {}",
+                    job.getId(), job.getJobName(), exceptionMessage);
         }
     }
 


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-991

#### ✍️ Description
The JobRetriesFailedFilter is meant to catch scenarios where all retries have failed for a given job so we can log when that happens and setup datadog monitoring based on that logging. 

It was broken because loading the bean was dependant on configuration properties we removed being set via @ConditionalOnProperty. Removing that annotation resolved the issue. 

I've also updated the filter to stop including the no longer used work item look up job, and to now include the send email job. 

Screenshots of the filter running as expected below:
#### CCMS Job
<img width="2321" height="297" alt="Screenshot 2025-08-14 at 11 07 34 AM" src="https://github.com/user-attachments/assets/2a2726d6-3e55-4f78-91b7-1c2b8fb56434" />

#### Email Job
<img width="1684" height="295" alt="Screenshot 2025-08-14 at 10 58 39 AM" src="https://github.com/user-attachments/assets/07ab7ba9-0d28-429f-8008-4bcfd4548fb5" />

#### Monitors
**CCMS Job Retry Failures**
https://app.datadoghq.com/monitors/165102938

**Send Email Retry Failures**
https://app.datadoghq.com/monitors/180905507

#### Testing
The screen shots provided should prove the filter is working as expected, however, testing in prod and staging would require figuring out how to cause the associated jobs to fail all retries in those environments. 

I'm not sure how best to test the datadog monitors. 

