### PR TITLE
[CCAP-1197] Make remove links unambiguous for screen reader users on activities "add-jobs" screens

### DIFF
--- a/src/main/resources/templates/gcc/activities-add-jobs.html
+++ b/src/main/resources/templates/gcc/activities-add-jobs.html
@@ -38,8 +38,10 @@
                       <span class="text--small spacing-below-0 spacing-right-25">
                         <a th:href="'/flow/' + ${flow} + '/jobs/' + ${job.uuid} + '/deleteConfirmation'"
                            th:text="#{general.remove}"
+                           th:attr="aria-label=|#{general.remove} ${job.companyName}|, title=|#{general.remove} ${job.companyName}|"
                            class="subflow-delete"
-                           th:id="'delete-iteration-' + ${job.uuid}"></a>
+                           th:id="'delete-iteration-' + ${job.uuid}">
+                        </a>
                       </span>
                     </span>
                       </li>

--- a/src/main/resources/templates/gcc/activities-partner-add-job.html
+++ b/src/main/resources/templates/gcc/activities-partner-add-job.html
@@ -37,8 +37,10 @@
                       <span class="text--small spacing-below-0 spacing-right-25">
                         <a th:href="'/flow/' + ${flow} + '/partnerJobs/' + ${job.uuid} + '/deleteConfirmation'"
                            th:text="#{general.remove}"
+                           th:attr="aria-label=|#{general.remove} ${job.partnerCompanyName}|, title=|#{general.remove} ${job.partnerCompanyName}|"
                            class="subflow-delete"
-                           th:id="'delete-iteration-' + ${job.uuid}"></a>
+                           th:id="'delete-iteration-' + ${job.uuid}">
+                        </a>
                       </span>
                     </span>
                     </li>

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -200,6 +200,8 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
 
         //activities-add-jobs (list)
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("activities-add-jobs.title"));
+        assertThat(testPage.findElementsByClass("subflow-delete").get(0).getAccessibleName())
+                .isEqualTo(String.format("%s %s", getEnMessage("general.remove"), "testCompany"));
         testPage.clickButton(getEnMessage("activities-add-jobs.this-is-all-my-jobs"));
 
         //children-info-intro

--- a/src/test/java/org/ilgcc/app/journeys/GccSingleProviderJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccSingleProviderJourneyTest.java
@@ -414,6 +414,8 @@ public class GccSingleProviderJourneyTest extends AbstractBasePageTest {
 
         //activities-add-jobs (list)
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("activities-add-jobs.title"));
+        assertThat(testPage.findElementsByClass("subflow-delete").get(0).getAccessibleName())
+                .isEqualTo(String.format("%s %s", getEnMessage("general.remove"), "testCompany"));
 
         List.of("2", "3").forEach(el -> {
             // Add 2nd, 3rd, 4th job
@@ -604,6 +606,8 @@ public class GccSingleProviderJourneyTest extends AbstractBasePageTest {
 
         //activities-partner-add-job
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("activities-partner-add-jobs.title"));
+        assertThat(testPage.findElementsByClass("subflow-delete").get(0).getAccessibleName())
+                .isEqualTo(String.format("%s %s", getEnMessage("general.remove"), "testPartnerCompany"));
 
         List.of("2", "3").forEach(el -> {
             // Add a 2nd, 3rd job


### PR DESCRIPTION

🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1197?

 ✍️ Description
Make remove links unambiguous for screen reader users on activities "add-jobs" screens

📷 Design reference
1)With NVDA enabled, Navigate to gcc/activities-add-jobs-list & gcc/activities-partner-add-jobs-list
2) Tab to the remove link for any listed job
3)Screen reader should announce 'Remove [Company Name]'.
 For example “remove Code for America”.
 
<img width="1847" height="1030" alt="activities add job list screen" src="https://github.com/user-attachments/assets/8e5f767e-f391-4665-8afc-5c83cd0020a3" />

<img width="1852" height="1045" alt="Partneradd job list screen " src="https://github.com/user-attachments/assets/e0329e2d-2108-4076-b4a8-6d7841b5f586" />






