### PR TITLE
[CCAP-1249] Provider with no schedule not treated properly in response flow

### DIFF
--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -380,8 +380,9 @@ public class SubmissionUtilities {
                 provider.put("providerApplicationResponseStatus", SubmissionStatus.RESPONDED.name());
                 provider.put("providerResponseAgreeToCare", providerResponseAgreeToCare);
                 provider.put("providerResponseName", ProviderSubmissionUtilities.getProviderResponseName(providerSubmission));
-            } else if (!provider.containsKey("providerApplicationResponseStatus") || !SubmissionStatus.RESPONDED.name()
-                    .equals(provider.get("providerApplicationResponseStatus").toString())) {
+            } else if (!provider.containsKey("providerApplicationResponseStatus") ||
+                    !(SubmissionStatus.RESPONDED.name().equals(provider.get("providerApplicationResponseStatus").toString()) ||
+                    SubmissionStatus.INACTIVE.name().equals(provider.get("providerApplicationResponseStatus").toString()))) {
                 allProvidersResponded = false;
             }
         }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1249

#### ✍️ Description
We already set a provider that is not assigned to a schedule at all to INACTIVE [here in GenerateShortLinkAndStoreProviderApplicationStatus](https://github.com/codeforamerica/il-gcc-form-flow/blob/main/src/main/java/org/ilgcc/app/submission/actions/GenerateShortLinkAndStoreProviderApplicationStatus.java#L81). 

This change basically just means that, as each provider responds, we handle INACTIVE the same as RESPONDED. If all providers are RESPONDED _or_ INACTIVE, we just need to then mark the entire application as done vs leaving it open for responses because 1 or more providers are INACTIVE.

I'm not quite sure how to prove this works with the PR itself, but here's a json blob showing 2 RESPONDED and 1 INACTIVE:

<img width="487" height="711" alt="Screenshot 2025-08-15 at 12 45 29 PM" src="https://github.com/user-attachments/assets/52640d24-88cc-402a-8525-b2bf5562cfea" />

And here's an email to the family that shows only the 2 providers after the CCMS transmission:

<img width="636" height="504" alt="Screenshot 2025-08-15 at 12 44 05 PM" src="https://github.com/user-attachments/assets/70ef2756-0a98-4271-ae75-896153d1e601" />

And here's the two emails to the family as each provider responded:

[
<img width="865" height="642" alt="Screenshot 2025-08-15 at 12 45 52 PM" src="https://github.com/user-attachments/assets/ec311e92-8292-4a11-8590-6398ee9d9470" />
](url)

And here's what happens if I try to use the confirmation code a third time:

<img width="613" height="564" alt="Screenshot 2025-08-15 at 12 49 23 PM" src="https://github.com/user-attachments/assets/1f8cd943-3c9f-475b-8f79-736f6fcf6544" />


#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
