### PR TITLE
[CCAP-1201]- The “remove” links on the providerresponse/registration-household-add-person screen now announces the first and last name of the person.

### DIFF
--- a/src/main/resources/templates/providerresponse/registration-household-add-person.html
+++ b/src/main/resources/templates/providerresponse/registration-household-add-person.html
@@ -24,6 +24,7 @@
                       <span class="text--small spacing-below-0 spacing-right-25">
                         <a th:href="'/flow/' + ${flow} + '/providerHouseholdMembers/' + ${providerHouseholdMember.uuid} + '/deleteConfirmation'"
                            th:text="#{general.remove}"
+                           th:attr="aria-label=|#{general.remove} ${providerHouseholdMember.providerHouseholdMemberFirstName} ${providerHouseholdMember.providerHouseholdMemberLastName}|, title=|#{general.remove} ${providerHouseholdMember.providerHouseholdMemberFirstName} ${providerHouseholdMember.providerHouseholdMemberLastName}|"
                            class="subflow-delete"
                            th:id="'delete-iteration-' + ${providerHouseholdMember.uuid}"></a>
                       </span>

--- a/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderRegistrationJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/ProviderresponseProviderRegistrationJourneyTest.java
@@ -219,6 +219,7 @@ public class ProviderresponseProviderRegistrationJourneyTest extends AbstractBas
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("registration-household-add-person.title"));
 
         assertThat(testPage.findElementsByClass("m").get(1).getText()).isEqualTo("Tester Lastenson");
+        assertThat(testPage.findElementsByClass("subflow-delete").get(1).getAccessibleName()).isEqualTo("remove Tester Lastenson");
         testPage.findElementsByClass("subflow-delete").get(1).click();
 
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("registration-household-add-person-delete.title"));


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1201

#### ✍️ Description
The “remove” links on the providerresponse/registration-household-add-person screen now announces the first and last name of the person.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
