### PR TITLE
[CCAP-1199] : Make remove and edit links unambiguous for screen reader users on gcc/providers-add screen

### DIFF
--- a/src/main/resources/templates/gcc/providers-add.html
+++ b/src/main/resources/templates/gcc/providers-add.html
@@ -40,11 +40,13 @@
                               <li class="text--small spacing-above-15 spacing-below-25 spacing-right-25">
                                 <a th:href="'/flow/' + ${flow} + '/providers-type/' + ${provider.uuid} + '/edit'"
                                    th:text="#{general.edit}"
-                                   class="subflow-delete padding-right-25"
+                                   class="subflow-edit padding-right-25"
+                                   th:attr="title=|#{general.edit} ${provider.familyIntendedProviderName}|,aria-label=|#{general.edit} ${provider.familyIntendedProviderName}|,"
                                    th:id="'edit-iteration-' + ${provider.uuid}"></a>
                                 <a th:href="'/flow/' + ${flow} + '/providers/' + ${provider.uuid} + '/deleteConfirmation'"
                                    th:text="#{general.remove}"
                                    class="subflow-delete padding-left-25"
+                                   th:attr="title=|#{general.remove} ${provider.familyIntendedProviderName}|,aria-label=|#{general.remove} ${provider.familyIntendedProviderName}|,"
                                    th:id="'delete-iteration-' + ${provider.uuid}"></a>
                               </li>
                             </ul>

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -348,6 +348,8 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
 
         //providers-add
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("providers-add.title"));
+        assertThat(testPage.findElementsByClass("subflow-edit").get(0).getAccessibleName()).isEqualTo("edit info ACME Daycare");
+        assertThat(testPage.findElementsByClass("subflow-edit").get(1).getAccessibleName()).isEqualTo("edit info Nope Test");
         testPage.clickButton(getEnMessage("providers-add.button.that-is-all"));
 
         //providers-info-confirm
@@ -637,7 +639,8 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
 
         //delete-provider -- actually delete!
         assertThat(testPage.findElementsByClass("spacing-below-0").get(4).getText()).isEqualTo("Nope Test");
-        testPage.findElementsByClass("subflow-delete").get(1).click();
+        assertThat(testPage.findElementsByClass("subflow-delete").get(1).getAccessibleName()).isEqualTo("remove Nope Test");
+        testPage.findElementsByClass("subflow-delete").get(0).click();
 
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("delete-confirmation.title"));
         testPage.clickButton(getEnMessage("delete-confirmation.yes"));


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1199

#### ✍️ Description
Each “edit details” link should be announced by the screen reader with the name of the provider in the list.
Each “remove” link should be announced by the screen reader with the name of the provider in the list.

#### 📷 Design reference
https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=18967-47776&t=2kWIOs4rKNIg5txD-4

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
