### PR TITLE
[CCAP-1169] Wrong version of the provider submit confirmation page is…

### DIFF
--- a/src/main/resources/templates/providerresponse/submit-confirmation.html
+++ b/src/main/resources/templates/providerresponse/submit-confirmation.html
@@ -4,16 +4,17 @@
                         inputData.get('providerResponseProviderNumber') == null && 
                         inputData.get('providerIdentityCheckSSN') == null &&
                         inputData.get('providerTaxIdEIN') == null},
-                   declinedCare=${inputData.get('providerResponseAgreeToCare') != null && inputData.get('providerResponseAgreeToCare').equals('false')}">
+                   declinedCare=${inputData.get('providerResponseAgreeToCare') != null && inputData.get('providerResponseAgreeToCare').equals('false')},
+                   showDenied=${declinedCare or existingProviderCannotBeIdentified}">
     <th:block th:replace="~{fragments/screens/submit-confirmation ::
       screen(
-        title=${existingProviderCannotBeIdentified || declinedCare ? 
+        title=${showDenied ?
             #messages.msg('submit-confirmation.title') :
             (isExistingProvider ? 
                 #messages.msg('submit-confirmation.title') :
                 #messages.msg('submit-confirmation.new-provider-registration.title')
             )},
-        header=${existingProviderCannotBeIdentified || declinedCare ? 
+        header=${showDenied ?
             #messages.msg('submit-confirmation.denied-care-or-unidentifiable.header') : 
             (isExistingProvider ? 
                 #messages.msg('submit-confirmation.existing-provider.header') : 


### PR DESCRIPTION
Wrong version of the provider submit confirmation page is displayed

 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1169

 ✍️ Description
1. Update confirmation page for provider response flow:  
2. If an existing provider cannot be identified (missing provider ID or FEIN), show the message “The family application has been submitted” instead of “Done! You are now listed as a childcare provider for this family.”  
3.This ensures providers see accurate status when their identity is not verified.

✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
