### PR TITLE
[CCAP-1198]- The “remove” links on the gcc/children-add  screen annou…

### DIFF
--- a/src/main/resources/templates/gcc/children-add.html
+++ b/src/main/resources/templates/gcc/children-add.html
@@ -38,6 +38,7 @@
                                                   <span class="text--small spacing-below-0 spacing-right-25">
                                                     <a th:href="'/flow/' + ${flow} + '/children/' + ${child.uuid} + '/deleteConfirmation'"
                                                        th:text="#{general.remove}"
+                                                       th:attr="aria-label='Remove ' + ${child.childFirstName} + ' ' + ${child.childLastName}"
                                                        class="subflow-delete"
                                                        th:id="'delete-iteration-' + ${child.uuid}"></a>
                                                   </span>
@@ -63,10 +64,11 @@
                                                       <span class="child-name"
                                                             th:text="|${child.childFirstName} ${child.childLastName}|"/>
                                                       <span class="text--small spacing-below-0 spacing-right-25">
-                                                        <a th:href="'/flow/' + ${flow} + '/children/' + ${child.uuid} + '/deleteConfirmation'"
-                                                           th:text="#{general.remove}"
-                                                           class="subflow-delete"
-                                                           th:id="'delete-iteration-' + ${child.uuid}"></a>
+                                                       <a th:href="'/flow/' + ${flow} + '/children/' + ${child.uuid} + '/deleteConfirmation'"
+                                                          th:text="#{general.remove}"
+                                                          th:attr="aria-label='Remove ' + ${child.childFirstName} + ' ' + ${child.childLastName}"
+                                                          class="subflow-delete"
+                                                          th:id="'delete-iteration-' + ${child.uuid}"></a>
                                                       </span>
                                                     </span>
                                                 </li>

--- a/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccMultiProviderFlowJourneyTest.java
@@ -245,6 +245,12 @@ public class GccMultiProviderFlowJourneyTest extends AbstractBasePageTest {
 
         //children-add
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("children-add.title"));
+
+        // ARIA-LABEL ASSERTION FOR "child mcchild"
+        List<org.openqa.selenium.WebElement> removeLinks = testPage.findElementsByClass("subflow-delete");
+        boolean foundCorrectAriaLabel = removeLinks.stream()
+                .anyMatch(link -> "Remove child mcchild".equals(link.getAttribute("aria-label")));
+        assertThat(foundCorrectAriaLabel).isTrue();
         testPage.clickButton(getEnMessage("children-add.thats-all"));
 
         //providers-intro

--- a/src/test/java/org/ilgcc/app/journeys/GccSingleProviderJourneyTest.java
+++ b/src/test/java/org/ilgcc/app/journeys/GccSingleProviderJourneyTest.java
@@ -12,6 +12,7 @@ import org.ilgcc.app.utils.AbstractBasePageTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 @Slf4j
 public class GccSingleProviderJourneyTest extends AbstractBasePageTest {
@@ -224,6 +225,7 @@ public class GccSingleProviderJourneyTest extends AbstractBasePageTest {
         testPage.enter("childDateOfBirthYear", "2018");
         testPage.selectFromDropdown("childRelationship", getEnMessage("general.relationship-option.foster-child"));
         testPage.clickContinue();
+
         //children-info-assistance
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("children-info-assistance.title"));
         testPage.clickYes();
@@ -287,6 +289,11 @@ public class GccSingleProviderJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
         //children-add (with children listed)
         assertThat(testPage.getTitle()).isEqualTo(getEnMessage("children-add.title"));
+        // Aria-label accessibility check for child remove links
+        List<WebElement> deletes = testPage.findElementsByClass("subflow-delete");
+        assertThat(deletes).isNotEmpty();
+        assertThat(deletes.get(0).getAccessibleName()).isEqualTo("Remove child mcchild");
+        assertThat(deletes.get(1).getAccessibleName()).isEqualTo("Remove mugully glopklin");
         // Add an incomplete iteration and assert that it is removed
         testPage.clickButton(getEnMessage("children-add.add-button"));
         testPage.enter("childFirstName", "ShouldBe");


### PR DESCRIPTION
 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1198?
✍️ Description
The “remove” links on the gcc/children-add screen announce the list item that the links refers to.

#### ✅ Completion tasks
Use NVDA at page /gcc/children-add of your Application.
Use Tab button from your keyboard till it reaches Remove button, you can hear 'Remove Children name'
example: 'Remove Under taker'
 📷 Design reference
<img width="1889" height="999" alt="Screenshot 2025-08-20 095422" src="https://github.com/user-attachments/assets/6ed178ec-a1ad-4e2b-972c-35ada28a290e" />

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
