### PR TITLE
[CCAP-1234] Updates FamilyApplicationTransmittedConfirmationEmailTemp…

### DIFF
--- a/src/main/java/org/ilgcc/app/email/templates/AutomatedProviderOutreachEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/AutomatedProviderOutreachEmailTemplate.java
@@ -36,7 +36,7 @@ public class AutomatedProviderOutreachEmailTemplate {
     }
 
     private String setSubject() {
-        return messageSource.getMessage("email.automated-provider-outreach.subject", null,
+        return messageSource.getMessage("email.automated-provider-outreach.subject", new Object[]{emailData.get("confirmationCode")},
                 locale);
     }
 

--- a/src/main/java/org/ilgcc/app/email/templates/FamilyApplicationTransmittedConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyApplicationTransmittedConfirmationEmailTemplate.java
@@ -41,7 +41,7 @@ public class FamilyApplicationTransmittedConfirmationEmailTemplate {
     }
 
     private String setSubject() {
-        return messageSource.getMessage("email.family-application-transmitted-confirmation-email.subject", null,
+        return messageSource.getMessage("email.family-application-transmitted-confirmation-email.subject", new Object[]{emailData.get("confirmationCode")},
                 locale);
     }
 

--- a/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyConfirmationEmailTemplate.java
@@ -40,7 +40,7 @@ public class FamilyConfirmationEmailTemplate {
     }
 
     private String setSubject(Map<String, Object> emailData) {
-        return messageSource.getMessage("email.general.subject.confirmation-code",
+        return messageSource.getMessage("email.family-confirmation.subject",
                 new Object[]{emailData.get("confirmationCode")},
                 locale);
     }

--- a/src/main/java/org/ilgcc/app/email/templates/NewProviderAgreesToCareFamilyConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/NewProviderAgreesToCareFamilyConfirmationEmailTemplate.java
@@ -41,7 +41,7 @@ public class NewProviderAgreesToCareFamilyConfirmationEmailTemplate {
     }
 
     private String setSubject() {
-        return messageSource.getMessage("email.response-email-for-family.provider-agrees.subject", null, locale);
+        return messageSource.getMessage("email.response-email-for-family.provider-agrees.subject", new Object[]{emailData.get("confirmationCode")}, locale);
     }
 
     private String setBodyCopy(Map<String, Object> emailData) {

--- a/src/main/java/org/ilgcc/app/email/templates/ProviderAgreesToCareFamilyConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/ProviderAgreesToCareFamilyConfirmationEmailTemplate.java
@@ -41,7 +41,7 @@ public class ProviderAgreesToCareFamilyConfirmationEmailTemplate {
     }
 
     private String setSubject() {
-        return messageSource.getMessage("email.provider-agrees-to-care.subject", null, locale);
+        return messageSource.getMessage("email.provider-agrees-to-care.subject", new Object[]{emailData.get("confirmationCode")}, locale);
     }
 
     private String setBodyCopy(Map<String, Object> emailData) {

--- a/src/main/java/org/ilgcc/app/email/templates/ProviderDeclinesCareFamilyConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/ProviderDeclinesCareFamilyConfirmationEmailTemplate.java
@@ -41,7 +41,7 @@ public class ProviderDeclinesCareFamilyConfirmationEmailTemplate {
     }
 
     private String setSubject(Map<String, Object> emailData) {
-        return messageSource.getMessage("email.response-email-for-family.provider-declines.subject", null, locale);
+        return messageSource.getMessage("email.response-email-for-family.provider-declines.subject", new Object[]{emailData.get("confirmationCode")}, locale);
     }
 
 

--- a/src/main/java/org/ilgcc/app/email/templates/ProviderDidNotRespondToFamilyEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/ProviderDidNotRespondToFamilyEmailTemplate.java
@@ -36,7 +36,7 @@ public class ProviderDidNotRespondToFamilyEmailTemplate {
     }
 
     private String setSubject(Map<String, Object> emailData) {
-        return messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", null, locale);
+        return messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", new Object[]{emailData.get("confirmationCode")}, locale);
     }
 
     private String setBodyCopy(Map<String, Object> emailData) {

--- a/src/main/java/org/ilgcc/app/email/templates/UnidentifiedProviderConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/UnidentifiedProviderConfirmationEmailTemplate.java
@@ -36,7 +36,7 @@ public class UnidentifiedProviderConfirmationEmailTemplate {
     }
 
     private String setSubject() {
-        return messageSource.getMessage("email.unidentified-provider-confirmation.subject", null, locale);
+        return messageSource.getMessage("email.unidentified-provider-confirmation.subject", new Object[]{emailData.get("confirmationCode")}, locale);
     }
 
     private String setBodyCopy(Map<String, Object> emailData) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -222,7 +222,7 @@ email.response-email-for-family.provider-did-not-respond.p4=<p>A staff member at
 email.response-email-for-family.provider-did-not-respond.p5=<p>Within 13-15 business days, you'll receive a letter or email from your CCR&R stating their initial decision for your application.</p>
 
 # UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL
-email.unidentified-provider-confirmation.subject=[Action Required] Call to respond to child care request
+email.unidentified-provider-confirmation.subject=[Action Required] Call to respond to CCAP application {0}
 email.unidentified-provider-confirmation.p1=<p>Hello,</p>
 email.unidentified-provider-confirmation.p2=<p>The family application you''ve been listed on was submitted for processing without your complete information. You need to call your CCR&R, <strong>{0}</strong>, to get more details about the family''s child care request in order to respond.</p>
 email.unidentified-provider-confirmation.p3=<p><strong>Next steps:</strong> Call <strong>{0}</strong>: <strong><a href="tel:{1}">{1}</a></strong> to complete your part of the application.</p>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -184,7 +184,7 @@ email.family-application-transmitted-provider-confirmation-email.p4=<p><strong>C
 email.family-application-transmitted-provider-confirmation-email.p5=<p><strong>Next steps:</strong> Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application.</p><p>If you have questions, call <strong>{0}: <a href="tel:{1}">{1}</a></strong>.</p>
 
 # PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
-email.provider-agrees-to-care.subject=[CCAP update] A provider agreed to care
+email.provider-agrees-to-care.subject=[CCAP update] Your provider agreed to care, application {CONFIRMATION_CODE}
 email.provider-agrees-to-care.p1=<p>Hi {0},</p>
 email.provider-agrees-to-care.p2-individual=<p>Your child care provider {0} just filled out their part of your CCAP application! (For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>
 email.provider-agrees-to-care.p2-program=<p>Your child care provider {0} just filled out their part of your CCAP application!</p>
@@ -193,7 +193,7 @@ email.provider-agrees-to-care.p4=<p><strong>Confirmation code:</strong> {0}</p>
 email.provider-agrees-to-care.p5=<p><strong>Next steps:</strong> Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application.</p><p>If you have questions, call <strong>{0}: <a href="tel:{1}">{1}</a></strong>.</p>
 
 # NEW_PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
-email.response-email-for-family.provider-agrees.subject=[CCAP update] A provider agreed to care
+email.response-email-for-family.provider-agrees.subject=[CCAP update] Your provider agreed to care, application {CONFIRMATION_CODE}
 email.response-email-for-family.provider-agrees.p1=<p>Hi {0},</p>
 email.response-email-for-family.provider-agrees.p2-program=<p>Your child care provider, {0}, just completed their part of your CCAP application!</p>
 email.response-email-for-family.provider-agrees.p2-individual=<p>Your child care provider, {0}, just completed their part of your CCAP application! (For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>
@@ -203,7 +203,7 @@ email.response-email-for-family.provider-agrees.p5=<p><strong>Next steps:</stron
 email.response-email-for-family.new-provider-agrees.note=<p><strong>Note about provider:</strong> The child care provider you picked is new to our system. They might need to do a few extra steps to finish their registration. <strong>Don't worry, this won't change when your child care starts.</strong></p>
 
 # PROVIDER_DECLINES_CARE_FAMILY_EMAIL
-email.response-email-for-family.provider-declines.subject=[CCAP update] A provider did not agree to care
+email.response-email-for-family.provider-declines.subject=[CCAP update] Your provider did not agree to care, application {CONFIRMATION_CODE}
 email.response-email-for-family.provider-declines.p1=<p>Hi {0},</p>
 email.response-email-for-family.provider-declines.p2-program=<p>Your child care provider, {0}, responded to your application, but <strong>did not agree to care.</strong></p>
 email.response-email-for-family.provider-declines.p2-individual=<p>Your child care provider {0} responded their part of your application, but <strong>did not agree to care.</strong>(For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>
@@ -213,7 +213,7 @@ email.response-email-for-family.provider-declines.p5=<p><strong>Next steps:</str
 email.response-email-for-family.provider-declines.p6=<p>Within 13-15 business days, you'll receive a letter or email from your CCR&R stating their initial decision for your application.</p>
 
 # PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL
-email.response-email-for-family.provider-did-not-respond.subject=[CCAP update] A provider did not respond
+email.response-email-for-family.provider-did-not-respond.subject=[CCAP update] Your provider did not respond to application {CONFIRMATION_CODE}
 email.response-email-for-family.provider-did-not-respond.p1=<p>Hi {0},</p>
 email.response-email-for-family.provider-did-not-respond.p2-program=<p>Your child care provider {0} did not complete their part of your Child Care Assistance application within 3 days.</p>
 email.response-email-for-family.provider-did-not-respond.p2-individual=<p>Your child care provider {0} did not complete their part of your Child Care Assistance application within 3 days. (For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -125,6 +125,7 @@ email.general.footer.cfa=<p>Sent by Code for America on behalf of the Illinois D
 email.general.subject.confirmation-code=Your CCAP confirmation code: {0}
 
 # FAMILY_CONFIRMATION_EMAIL
+email.family-confirmation.subject=Your application {0} has been sent for processing
 email.family-confirmation.p1=<p>Hi {0},</p>
 email.family-confirmation.p2=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
 
@@ -165,7 +166,7 @@ email.automated-provider-outreach.email-preview.body.pt3=<strong>Click this secu
 
 # FAMILY_CONFIRMATION_EMAIL
 # FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL
-email.family-application-transmitted-confirmation-email.subject=[CCAP] Your application has been sent for processing
+email.family-application-transmitted-confirmation-email.subject=Your application {0} has been sent for processing
 email.family-application-transmitted-confirmation-email.p1=<p>Hi {0},</p>
 email.family-application-transmitted-confirmation-email.p2=<p>All of your child care providers have completed their parts of your Child Care Assistance application! Your application has now been sent to {0} for processing.</p>
 email.family-application-transmitted-confirmation-email.li-agreed-to-care=<li><strong>{0} agreed to care</strong> for {1} with a start date of {2}.</li>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -166,7 +166,7 @@ email.automated-provider-outreach.email-preview.body.pt3=<strong>Click this secu
 
 # FAMILY_CONFIRMATION_EMAIL
 # FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL
-email.family-application-transmitted-confirmation-email.subject=Your application {0} has been sent for processing
+email.family-application-transmitted-confirmation-email.subject=[CCAP update] Your application {0} has been sent for processing
 email.family-application-transmitted-confirmation-email.p1=<p>Hi {0},</p>
 email.family-application-transmitted-confirmation-email.p2=<p>All of your child care providers have completed their parts of your Child Care Assistance application! Your application has now been sent to {0} for processing.</p>
 email.family-application-transmitted-confirmation-email.li-agreed-to-care=<li><strong>{0} agreed to care</strong> for {1} with a start date of {2}.</li>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -125,7 +125,7 @@ email.general.footer.cfa=<p>Sent by Code for America on behalf of the Illinois D
 email.general.subject.confirmation-code=Your CCAP confirmation code: {0}
 
 # FAMILY_CONFIRMATION_EMAIL
-email.family-confirmation.subject=Your application {0} has been sent for processing
+email.family-confirmation.subject=[CCAP update] Your application {0} has been sent for processing
 email.family-confirmation.p1=<p>Hi {0},</p>
 email.family-confirmation.p2=<p>You completed the online Child Care Assistance Program (CCAP) application!</p>
 
@@ -184,7 +184,7 @@ email.family-application-transmitted-provider-confirmation-email.p4=<p><strong>C
 email.family-application-transmitted-provider-confirmation-email.p5=<p><strong>Next steps:</strong> Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application.</p><p>If you have questions, call <strong>{0}: <a href="tel:{1}">{1}</a></strong>.</p>
 
 # PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
-email.provider-agrees-to-care.subject=[CCAP update] Your provider agreed to care, application {CONFIRMATION_CODE}
+email.provider-agrees-to-care.subject=[CCAP update] Your provider agreed to care, application {0}
 email.provider-agrees-to-care.p1=<p>Hi {0},</p>
 email.provider-agrees-to-care.p2-individual=<p>Your child care provider {0} just filled out their part of your CCAP application! (For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>
 email.provider-agrees-to-care.p2-program=<p>Your child care provider {0} just filled out their part of your CCAP application!</p>
@@ -193,7 +193,7 @@ email.provider-agrees-to-care.p4=<p><strong>Confirmation code:</strong> {0}</p>
 email.provider-agrees-to-care.p5=<p><strong>Next steps:</strong> Within 13-15 business days, you''ll receive a letter or email from your CCR&R stating their initial decision for your application.</p><p>If you have questions, call <strong>{0}: <a href="tel:{1}">{1}</a></strong>.</p>
 
 # NEW_PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
-email.response-email-for-family.provider-agrees.subject=[CCAP update] Your provider agreed to care, application {CONFIRMATION_CODE}
+email.response-email-for-family.provider-agrees.subject=[CCAP update] Your provider agreed to care, application {0}
 email.response-email-for-family.provider-agrees.p1=<p>Hi {0},</p>
 email.response-email-for-family.provider-agrees.p2-program=<p>Your child care provider, {0}, just completed their part of your CCAP application!</p>
 email.response-email-for-family.provider-agrees.p2-individual=<p>Your child care provider, {0}, just completed their part of your CCAP application! (For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>
@@ -203,7 +203,7 @@ email.response-email-for-family.provider-agrees.p5=<p><strong>Next steps:</stron
 email.response-email-for-family.new-provider-agrees.note=<p><strong>Note about provider:</strong> The child care provider you picked is new to our system. They might need to do a few extra steps to finish their registration. <strong>Don't worry, this won't change when your child care starts.</strong></p>
 
 # PROVIDER_DECLINES_CARE_FAMILY_EMAIL
-email.response-email-for-family.provider-declines.subject=[CCAP update] Your provider did not agree to care, application {CONFIRMATION_CODE}
+email.response-email-for-family.provider-declines.subject=[CCAP update] Your provider did not agree to care, application {0}
 email.response-email-for-family.provider-declines.p1=<p>Hi {0},</p>
 email.response-email-for-family.provider-declines.p2-program=<p>Your child care provider, {0}, responded to your application, but <strong>did not agree to care.</strong></p>
 email.response-email-for-family.provider-declines.p2-individual=<p>Your child care provider {0} responded their part of your application, but <strong>did not agree to care.</strong>(For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>
@@ -213,7 +213,7 @@ email.response-email-for-family.provider-declines.p5=<p><strong>Next steps:</str
 email.response-email-for-family.provider-declines.p6=<p>Within 13-15 business days, you'll receive a letter or email from your CCR&R stating their initial decision for your application.</p>
 
 # PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL
-email.response-email-for-family.provider-did-not-respond.subject=[CCAP update] Your provider did not respond to application {CONFIRMATION_CODE}
+email.response-email-for-family.provider-did-not-respond.subject=[CCAP update] Your provider did not respond to application {0}
 email.response-email-for-family.provider-did-not-respond.p1=<p>Hi {0},</p>
 email.response-email-for-family.provider-did-not-respond.p2-program=<p>Your child care provider {0} did not complete their part of your Child Care Assistance application within 3 days.</p>
 email.response-email-for-family.provider-did-not-respond.p2-individual=<p>Your child care provider {0} did not complete their part of your Child Care Assistance application within 3 days. (For privacy reasons, names of individuals are shown as initials only, with the rest hidden.)</p>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -151,7 +151,7 @@ email.family-confirmation.no-provider.p6=<p>Within 13-15 business, you'll receiv
 email.family-confirmation.some-providers.did-not-choose=<p><strong>You didn''t chose a child care provider for at least one child. </strong> A staff member at your Child Care Resource and Referral (CCR&R) Agency can help you find a provider that has space for your child or children. Contact <strong>{0}: <a href="tel:{1}">{1}</a></p>
 
 # AUTOMATED_PROVIDER_OUTREACH_EMAIL
-email.automated-provider-outreach.subject=[Action Required] New CCAP application
+email.automated-provider-outreach.subject=[Action Required] New CCAP application {0}
 email.automated-provider-outreach.p1=<p>Hello,</p>
 email.automated-provider-outreach.p2=<p>A family just submitted a Child Care Assistance Program (CCAP) application online and listed you as their child care provider. The confirmation code is: {0}</p>
 email.automated-provider-outreach.p3=<p><strong>Click this secure link to view child care details and complete your part of the application within 3 business days: <a href="{0}" target="_blank">{0}</a></p></strong>

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -1440,7 +1440,7 @@ provider-response.mailing-address.same-as-home-address=La misma donde tengo regi
 #contact-info
 provider-response-contact-info.title=Información de contacto
 provider-response-contact-info.header=¿Cuál es la información de contacto de su proveedor?
-provider-response-contact-info.subtext=Deberá ingresar por lo menos un medio de contacto. 
+provider-response-contact-info.subtext=Deberá ingresar por lo menos un medio de contacto.
 provider-response-contact-info.email=¿Cuál es su dirección de correo electrónico?
 provider-response-contact-info.email-help=Al compartir su correo electrónico, le da su consentimiento a Code for America, al Departamento de Servicios Humanos de Illinois (Illinois Department of Human Services, IDHS), y a las agencias de Recursos y Referencias del Cuidado de Niños (CCR&R, por sus siglas en inglés) de su condado para que le envíen correos electrónicos sobre su solicitud.
 provider-response-contact-info.phone=¿Cuál es su número de teléfono?

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -125,6 +125,7 @@ email.general.footer.cfa=<p>Enviado por Code for America en nombre del Departame
 email.general.subject.confirmation-code=Su código de confirmación de CCAP: {0}
 
 # FAMILY_CONFIRMATION_EMAIL
+email.family-confirmation.subject=[Actualización de CCAP] Su solicitud {0} ha sido enviada para su procesamiento
 email.family-confirmation.p1=<p>Hola {0},</p>
 email.family-confirmation.p2=<p>¡Ha completado la solicitud en línea del Programa de Asistencia para el Cuidado de Niños (CCAP)!</p>
 
@@ -150,7 +151,7 @@ email.family-confirmation.no-provider.p6=<p>En un plazo de 13 a 15 días hábiles,
 email.family-confirmation.some-providers.did-not-choose=<p><strong>No eligió un proveedor de cuidado de niños para al menos uno de los niños.</strong> Alguien del personal de su Agencia de Recursos y Referencias para el Cuidado de Niños (CCR&R) puede ayudarle a encontrar un proveedor que tenga espacio disponible para su hijo. Comuníquese con <strong>{0}: <a href="tel:{1}">{1}</a></strong></p>
 
 # AUTOMATED_PROVIDER_OUTREACH_EMAIL
-email.automated-provider-outreach.subject=[Acción requerida] Nueva aplicación CCAP
+email.automated-provider-outreach.subject=[Acción requerida] Nueva solicitud de CCAP {0}
 email.automated-provider-outreach.p1=Hola,
 email.automated-provider-outreach.p2=<p>Una familia acaba de enviar una solicitud en línea para el Programa de Asistencia para el Cuidado de Niños (CCAP) y lo ha incluído como su proveedor de cuidado infantil. El código de confirmación es: {0}</p>
 email.automated-provider-outreach.p3=<p><strong>Haga clic en este enlace para ver los detalles del requerimiento de cuidado de niños y completar su parte de la aplicación en los próximos 3 días hábiles: <a href="{0}" target="_blank">{0}</a></p></strong>
@@ -165,7 +166,7 @@ email.automated-provider-outreach.email-preview.body.pt3=<p><strong>Haga clic en
 
 # FAMILY_CONFIRMATION_EMAIL
 # FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL
-email.family-application-transmitted-confirmation-email.subject=Su solicitud ha sido enviada para ser procesada
+email.family-application-transmitted-confirmation-email.subject=[Actualización de CCAP] Su solicitud {0} ha sido enviada para su procesamiento
 email.family-application-transmitted-confirmation-email.p1=<p>Hola {0},</p>
 email.family-application-transmitted-confirmation-email.p2=<p>¡Todos sus proveedores de cuidados de niños han completado la parte que les correspondía de la aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)! Su aplicación ha sido enviada a {0} para ser procesada.</p>
 email.family-application-transmitted-confirmation-email.li-agreed-to-care=<li><strong>{0} aceptó cuidar </strong> a {1} con fecha de comienzo {2}.</li>
@@ -183,7 +184,7 @@ email.family-application-transmitted-provider-confirmation-email.p4=<p><strong>C
 email.family-application-transmitted-provider-confirmation-email.p5=<p><strong>Siguientes pasos:</strong> Entre 13 y 15 días hábiles, recibirá una carta o correo electrónico con información de su CCR&R indicando la decision inicial sobre su solicitud. Si tiene preguntas, llame a {0}: <a href="tel:{1}">{1}</a>.</p>
 
 # PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
-email.provider-agrees-to-care.subject=[Actualización de CCAP] Un proveedor aceptó cuidar a su hijo/a
+email.provider-agrees-to-care.subject=[Actualización de CCAP] Su proveedor aceptó brindar atención, solicitud {0}
 email.provider-agrees-to-care.p1=<p>Hola {0},</p>
 email.provider-agrees-to-care.p2-individual=<p>¡Su proveedor de cuidado de niños {0} acaba de completar la parte que le correspondía de su aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)!  (Por razones de privacidad, sólo demuestran las iniciales de estas personas, con el resto oculto.)</p>
 email.provider-agrees-to-care.p2-program=<p>¡Su proveedor de cuidados de niños, {0}, acaba de completar la parte que le correspondía de su aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)! </p>
@@ -192,7 +193,7 @@ email.provider-agrees-to-care.p4=<p><strong>Código de confirmación:</strong> {0}
 email.provider-agrees-to-care.p5=<p><strong>Siguientes pasos:</strong> Entre 13 y 15 días hábiles, recibirá una carta o correo electrónico con información de su CCR&R indicando la decision inicial sobre su solicitud. Si tiene preguntas, llame a {0}: <a href="tel:{1}">{1}</a>.</p>
 
 # NEW_PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL
-email.response-email-for-family.provider-agrees.subject=[Actualización de CCAP] Un proveedor aceptó cuidar a su hijo/a
+email.response-email-for-family.provider-agrees.subject=[Actualización de CCAP] Su proveedor aceptó brindar atención, solicitud {0}
 email.response-email-for-family.provider-agrees.p1=<p>Hola {0},</p>
 email.response-email-for-family.provider-agrees.p2-program=<p>¡Su proveedor de cuidados de niños, {0}, acaba de completar la parte que le correspondía de su aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)! </p>
 email.response-email-for-family.provider-agrees.p2-individual=<p>¡Su proveedor de cuidado de niños {0} acaba de completar la parte que le correspondía de su aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)!  (Por razones de privacidad, sólo demuestran las iniciales de estas personas, con el resto oculto.)</p>
@@ -202,7 +203,7 @@ email.response-email-for-family.provider-agrees.p5=<p><strong>Siguientes pasos:<
 email.response-email-for-family.new-provider-agrees.note=<p><strong>Nota sobre el proveedor:</strong> El proveedor de cuidado de niños que seleccionó es nuevo en nuestro sistema. Es posible que necesite realizar algunos pasos adicionales para completar su registro. <strong>No se preocupe, esto no afectará la fecha de inicio del cuidado de niños.</strong></p>
 
 # PROVIDER_DECLINES_CARE_FAMILY_EMAIL
-email.response-email-for-family.provider-declines.subject=[Actualización de CCAP] Un proveedor no aceptó cuidar a su hijo/a
+email.response-email-for-family.provider-declines.subject=[Actualización de CCAP] Su proveedor no aceptó la atención, solicitud {0}
 email.response-email-for-family.provider-declines.p1=<p>Hola {0},</p>
 email.response-email-for-family.provider-declines.p2-program=<p>Su proveedor de cuidado infantil, {0}, ha respondido a su solicitud pero <strong>no acepto proveer el cuidado para los niño(s)/a(s).</strong></p>
 email.response-email-for-family.provider-declines.p2-individual=<p>Su proveedor de cuidado de niños, {0}, completó la parte que le correspondía de su solicitud al Programa de Asistencia para el Cuidado de Niños (CCAP), pero <strong>no aceptó proveer el cuidado para los niño(s)/a(s).</strong> (Por motivos de privacidad, los nombres de las personas se muestran solo con sus iniciales; el resto está oculto.)</p>
@@ -212,7 +213,7 @@ email.response-email-for-family.provider-declines.p5=<p><strong>Proximos pasos:<
 email.response-email-for-family.provider-declines.p6=<p>En un plazo de 13 a 15 días hábiles, recibirá una carta o un correo electrónico de su CCR&R indicando la decisión inicial sobre su solicitud.</p>
 
 # PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL
-email.response-email-for-family.provider-did-not-respond.subject=[Actualización de CCAP] Un proveedor no respondió
+email.response-email-for-family.provider-did-not-respond.subject=[Actualización de CCAP] Su proveedor no respondió a la solicitud {0}
 email.response-email-for-family.provider-did-not-respond.p1=<p>Hola {0},</p>
 email.response-email-for-family.provider-did-not-respond.p2-program=<p>Su proveedor de cuidado de niños {0} no completó la parte que le correspondía de su solicitud de Asistencia para el Cuidado de Niños en 3 días.</p>
 email.response-email-for-family.provider-did-not-respond.p2-individual=<p>Su proveedor de cuidado de niños {0} no completó la parte que le correspondía de su solicitud de Asistencia para el Cuidado de Niños en 3 días. (Por razones de privacidad,  sólo de muestran las iniciales de estas personas, con el resto oculto.)</p>
@@ -221,7 +222,7 @@ email.response-email-for-family.provider-did-not-respond.p4=<p>Un miembro del pe
 email.response-email-for-family.provider-did-not-respond.p5=<p>En un plazo de 13 a 15 días hábiles, recibirá una carta o un correo electrónico de su CCR&R indicando la decisión inicial sobre su solicitud.</p>
 
 # UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL
-email.unidentified-provider-confirmation.subject=[Acción requerida] Llame para responder a la solicitud de cuidado de niños
+email.unidentified-provider-confirmation.subject=[Acción requerida] Llamada para responder a la solicitud de CCAP {0}
 email.unidentified-provider-confirmation.p1=Hola,
 email.unidentified-provider-confirmation.p2=<p>Una solicitud en la que usted fue incluido fue enviada para ser procesada pero su información está incompleta. Necesita llamar a su CCR&R, <strong>{0}</strong>, para obtener más detalles sobre la solicitud de cuidado de niños y poder responder.</p>
 email.unidentified-provider-confirmation.p3=<p><strong>Próximos pasos: </strong>Llame a <strong>{0}</strong>: <strong><a href="tel:{1}">{1}</a></strong> para completar su parte de la solicitud.</p>
@@ -292,6 +293,7 @@ errors.invalid-dollar-amount=Asegúrese de ingresar una cantidad válida en dólare
 errors.general-banner-warning=<strong>Lo sentimos,</strong> ha omitido una pregunta obligatoria o proporcionado información en un formato incorrecto. Revise sus respuestas para continuar.
 errors.general-title=Revise sus respuestas
 errors.select-provider=Seleccione un proveedor.
+errors.out-of-state-zip=Ingrese un código postal válido de Illinois
 
 
 
@@ -345,6 +347,19 @@ onboarding-county.link=Prefiero ingresar el código postal.
 onboarding-zipcode.title=código postal
 onboarding-zipcode.header=Ingrese el código postal donde vive
 onboarding-zipcode.link=Prefiero seleccionar el condado.
+
+#parent-county
+parent-county.title=Condado
+parent-county.header=Elige el condado donde te hospedarás
+parent-county.subtext=Su solicitud se enviará a la oficina de Recursos y Referencias de Cuidado Infantil (CCR&R) o al proveedor administrado por su sitio en este condado.
+parent-county.placeholder-text=Seleccione su condado
+parent-county.link=Prefiero ingresar el código postal.
+
+#parent-zipcode
+parent-zipcode.title=Código postal
+parent-zipcode.header=Introduce el código postal donde te encuentras hospedado
+parent-zipcode.subtext=Su solicitud se enviará a la oficina de Recursos y Referencias de Cuidado Infantil (CCR&R) o al proveedor administrado por su sitio en este código postal.
+parent-zipcode.link=Prefiero seleccionar el condado.
 
 #
 onboarding-getting-started.title=Cómo empezar

--- a/src/test/java/org/ilgcc/app/email/DailyNewApplicationsProviderEmailTemplateTest.java
+++ b/src/test/java/org/ilgcc/app/email/DailyNewApplicationsProviderEmailTemplateTest.java
@@ -1,0 +1,156 @@
+package org.ilgcc.app.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+
+import com.sendgrid.helpers.mail.objects.Email;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
+import formflow.library.data.SubmissionRepositoryService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.ilgcc.jobs.SendEmailJob;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.MessageSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class DailyNewApplicationsProviderEmailTemplateTest {
+
+    @MockitoSpyBean
+    SendEmailJob sendEmailJob;
+
+    @Autowired
+    SubmissionRepositoryService submissionRepositoryService;
+
+    @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
+    MessageSource messageSource;
+
+    private Submission familySubmission;
+
+    private SendAutomatedProviderOutreachEmail sendEmailClass;
+
+    private final Locale locale = Locale.ENGLISH;
+
+    private static final String CONFIRMATION_CODE = "ABC123";
+
+    @BeforeEach
+    void setUp() {
+        familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
+                .withFlow("gcc")
+                .with("parentFirstName", "FirstName").withChild("First", "Child", "true").withChild("Second", "Child", "true")
+                .withSubmittedAtDate(OffsetDateTime.of(2022, 10, 11, 0, 0, 0, 0, ZoneOffset.ofTotalSeconds(0)))
+                .withCCRR()
+                .with("parentContactEmail", "familyemail@test.com")
+                .with("familyIntendedProviderEmail", "provideremail@test.com")
+                .with("shareableLink", "tempEmailLink")
+                .withShortCode(CONFIRMATION_CODE)
+                .build());
+
+        sendEmailClass = new SendAutomatedProviderOutreachEmail(sendEmailJob, messageSource, submissionRepositoryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        submissionRepository.deleteAll();
+    }
+
+    @Test
+    void correctlySetsEmailRecipient() {
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+        Map<String, Object> emailData = emailDataOptional.get();
+
+        assertThat(sendEmailClass.getRecipientEmail(emailData)).isEqualTo("provideremail@test.com");
+    }
+
+    @Test
+    void correctlySetsEmailData() {
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+
+        assertThat(emailDataOptional.isPresent()).isTrue();
+
+        Map<String, Object> emailData = emailDataOptional.get();
+
+        assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
+        assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
+        assertThat(emailData.get("familyIntendedProviderEmail")).isEqualTo("provideremail@test.com");
+        assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
+        assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
+        assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
+        assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
+        assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
+        assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
+    }
+
+    @Test
+    void correctlySetsEmailTemplateData() {
+        Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
+        ILGCCEmailTemplate emailTemplate = sendEmailClass.emailTemplate(emailDataOptional.get());
+
+        assertThat(emailTemplate.getSenderEmail()).isEqualTo(
+                new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
+        assertThat(emailTemplate.getSubject()).isEqualTo(
+                messageSource.getMessage("email.automated-provider-outreach.subject", new Object[]{CONFIRMATION_CODE}, locale));
+
+        String emailCopy = emailTemplate.getBody().getValue();
+
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p1", null, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p2", new Object[]{CONFIRMATION_CODE}, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p3", new Object[]{"tempEmailLink"},
+                        locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p4", null,
+                        locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.automated-provider-outreach.p5",
+                new Object[]{"Sample Test CCRR"}, locale));
+        assertThat(emailCopy).contains(
+                messageSource.getMessage("email.automated-provider-outreach.p6", null,
+                        locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
+        assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));
+    }
+
+    @Test
+    void correctlyUpdatesEmailSendStatus() {
+        assertThat(familySubmission.getInputData().containsKey("providerOutreachEmailSent")).isFalse();
+        sendEmailClass.send(familySubmission);
+
+        assertThat(familySubmission.getInputData().containsKey("providerOutreachEmailSent")).isTrue();
+        assertThat(familySubmission.getInputData().get("providerOutreachEmailSent")).isEqualTo("true");
+    }
+
+    @Test
+    void correctlySkipsEmailSendWhenEmailStatusIsTrue() {
+        assertThat(sendEmailClass.skipEmailSend(familySubmission.getInputData())).isFalse();
+
+        familySubmission.getInputData().put("providerOutreachEmailSent", "true");
+        assertThat(sendEmailClass.skipEmailSend(familySubmission.getInputData())).isTrue();
+    }
+
+    @Test
+    void correctlyEnqueuesSendEmailJob() {
+        sendEmailClass.send(familySubmission);
+        verify(sendEmailJob).enqueueSendSubmissionEmailJob(any(ILGCCEmail.class), any(Integer.class));
+    }
+
+}

--- a/src/test/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendAutomatedProviderOutreachEmailTest.java
@@ -49,6 +49,8 @@ public class SendAutomatedProviderOutreachEmailTest {
 
     private final Locale locale = Locale.ENGLISH;
 
+    private static final String CONFIRMATION_CODE = "ABC123";
+
     @BeforeEach
     void setUp() {
         familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -59,7 +61,7 @@ public class SendAutomatedProviderOutreachEmailTest {
                 .with("parentContactEmail", "familyemail@test.com")
                 .with("familyIntendedProviderEmail", "provideremail@test.com")
                 .with("shareableLink", "tempEmailLink")
-                .withShortCode("ABC123")
+                .withShortCode(CONFIRMATION_CODE)
                 .build());
 
         sendEmailClass = new SendAutomatedProviderOutreachEmail(sendEmailJob, messageSource, submissionRepositoryService);
@@ -92,7 +94,7 @@ public class SendAutomatedProviderOutreachEmailTest {
         assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
         assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
         assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+        assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
         assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
         assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
     }
@@ -105,14 +107,14 @@ public class SendAutomatedProviderOutreachEmailTest {
         assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                 new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
         assertThat(emailTemplate.getSubject()).isEqualTo(
-                messageSource.getMessage("email.automated-provider-outreach.subject", null, locale));
+                messageSource.getMessage("email.automated-provider-outreach.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
         String emailCopy = emailTemplate.getBody().getValue();
 
         assertThat(emailCopy).contains(
                 messageSource.getMessage("email.automated-provider-outreach.p1", null, locale));
         assertThat(emailCopy).contains(
-                messageSource.getMessage("email.automated-provider-outreach.p2", new Object[]{"ABC123"}, locale));
+                messageSource.getMessage("email.automated-provider-outreach.p2", new Object[]{CONFIRMATION_CODE}, locale));
         assertThat(emailCopy).contains(
                 messageSource.getMessage("email.automated-provider-outreach.p3", new Object[]{"tempEmailLink"},
                         locale));

--- a/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyApplicationTransmittedConfirmationEmailTest.java
@@ -66,6 +66,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
     private static Map<String, Object> child2 = new HashMap<>();
 
     private static Map<String, Object> emailData = new HashMap<>();
+    private static final String CONFIRMATION_CODE = "ABC123";
 
     @BeforeAll
     public static void setUpOnce() {
@@ -142,7 +143,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
                                 noResponseProvider.get("uuid").toString()))
                 .withSubmittedAtDate(OffsetDateTime.now())
                 .withCCRR()
-                .withShortCode("ABC123")
+                .withShortCode(CONFIRMATION_CODE)
                 .build());
 
         individualProviderSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -196,7 +197,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
         assertThat(emailData.get("parentFirstName")).isEqualTo("FirstName");
         assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
         assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
-        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+        assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
         assertThat(emailData.get("familyPreferredLanguage")).isEqualTo("English");
         assertThat(emailData.get("providersData")).isNotNull();
 
@@ -276,7 +277,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
         assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                 new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
         assertThat(emailTemplate.getSubject()).isEqualTo(
-                messageSource.getMessage("email.family-application-transmitted-confirmation-email.subject", null, locale));
+                messageSource.getMessage("email.family-application-transmitted-confirmation-email.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
         String emailCopy = emailTemplate.getBody().getValue();
 
@@ -288,7 +289,7 @@ public class SendFamilyApplicationTransmittedConfirmationEmailTest {
                 new Object[]{"Sample Test CCRR"}, locale));
 
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-application-transmitted-confirmation-email.p3",
-                new Object[]{"ABC123"}, locale));
+                new Object[]{CONFIRMATION_CODE}, locale));
 
         assertThat(emailCopy).contains(messageSource.getMessage("email.family-application-transmitted-confirmation-email.p4",
                 new Object[]{"Sample Test CCRR", "(603) 555-1244"},

--- a/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendFamilyConfirmationEmailTest.java
@@ -60,6 +60,7 @@ public class SendFamilyConfirmationEmailTest {
 
     private final Locale locale = Locale.ENGLISH;
 
+    private static final String CONFIRMATION_CODE = "ABC123";
 
     @BeforeEach
     void setUp() {
@@ -70,7 +71,7 @@ public class SendFamilyConfirmationEmailTest {
                 .withCCRR()
                 .with("parentContactEmail", "familyemail@test.com")
                 .with("shareableLink", "tempEmailLink")
-                .withShortCode("ABC123")
+                .withShortCode(CONFIRMATION_CODE)
                 .build());
 
         sendEmailClass = new SendFamilyConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
@@ -128,7 +129,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
             assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
             assertThat(emailData.get("hasMultipleProviders")).isEqualTo(false);
@@ -142,7 +143,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+                    messageSource.getMessage("email.family-confirmation.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -160,7 +161,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
-                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+                    new Object[]{CONFIRMATION_CODE, "October 10, 2022"}, locale));
             assertThat(emailCopy).contains(
                     messageSource.getMessage("email.family-confirmation.p8", null, locale));
             assertThat(emailCopy).contains(
@@ -207,7 +208,7 @@ public class SendFamilyConfirmationEmailTest {
                     .with("providers", List.of(individualProvider, programProvider))
                     .with("parentContactEmail", "familyemail@test.com")
                     .with("shareableLink", "tempEmailLink")
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             sendEmailClass = new SendFamilyConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
@@ -222,7 +223,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
             assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
             assertThat(emailData.get("hasMultipleProviders")).isEqualTo(true);
@@ -235,7 +236,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+                    messageSource.getMessage("email.family-confirmation.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -253,7 +254,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
-                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+                    new Object[]{CONFIRMATION_CODE, "October 10, 2022"}, locale));
             assertThat(emailCopy).contains(
                     messageSource.getMessage("email.family-confirmation.p8", null, locale));
             assertThat(emailCopy).contains(
@@ -290,7 +291,7 @@ public class SendFamilyConfirmationEmailTest {
                     .with("providers", List.of(individualProvider))
                     .with("parentContactEmail", "familyemail@test.com")
                     .with("shareableLink", "tempEmailLink")
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             sendEmailClass = new SendFamilyConfirmationEmail(sendEmailJob, messageSource, submissionRepositoryService);
@@ -305,7 +306,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
             assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
             assertThat(emailData.get("hasMultipleProviders")).isEqualTo(false);
@@ -318,7 +319,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+                    messageSource.getMessage("email.family-confirmation.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -336,7 +337,7 @@ public class SendFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
-                    new Object[]{"ABC123", "October 10, 2022"}, locale));
+                    new Object[]{CONFIRMATION_CODE, "October 10, 2022"}, locale));
             assertThat(emailCopy).contains(
                     messageSource.getMessage("email.family-confirmation.p8", null, locale));
             assertThat(emailCopy).contains(
@@ -397,7 +398,7 @@ public class SendFamilyConfirmationEmailTest {
                                 List.of(programProvider.get("uuid").toString(), "NO_PROVIDER", individualProvider.get("uuid").toString()))
                         .with("parentContactEmail", "familyemail@test.com")
                         .with("shareableLink", "tempEmailLink")
-                        .withShortCode("ABC123")
+                        .withShortCode(CONFIRMATION_CODE)
                         .build());
 
                 Optional<Map<String, Object>> emailDataOptional = sendEmailClass.getEmailData(familySubmission);
@@ -411,7 +412,7 @@ public class SendFamilyConfirmationEmailTest {
                 assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
                 assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
                 assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
-                assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+                assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
                 assertThat(emailData.get("submittedDate")).isEqualTo("October 10, 2022");
                 assertThat(emailData.get("shareableLink")).isEqualTo("tempEmailLink");
                 assertThat(emailData.get("hasMultipleProviders")).isEqualTo(true);
@@ -425,7 +426,7 @@ public class SendFamilyConfirmationEmailTest {
                 assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                         new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
                 assertThat(emailTemplate.getSubject()).isEqualTo(
-                        messageSource.getMessage("email.general.subject.confirmation-code", new Object[]{"ABC123"}, locale));
+                        messageSource.getMessage("email.family-confirmation.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
                 String emailCopy = emailTemplate.getBody().getValue();
 
@@ -447,7 +448,7 @@ public class SendFamilyConfirmationEmailTest {
                 assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p6",
                         new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
                 assertThat(emailCopy).contains(messageSource.getMessage("email.family-confirmation.p7",
-                        new Object[]{"ABC123", "October 10, 2022"}, locale));
+                        new Object[]{CONFIRMATION_CODE, "October 10, 2022"}, locale));
                 assertThat(emailCopy).contains(
                         messageSource.getMessage("email.family-confirmation.p8", null, locale));
                 assertThat(emailCopy).contains(

--- a/src/test/java/org/ilgcc/app/email/SendNewProviderAgreesToCareFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendNewProviderAgreesToCareFamilyConfirmationEmailTest.java
@@ -47,7 +47,9 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
     private SendNewProviderAgreesToCareFamilyConfirmationEmail sendEmailClass;
 
     private final Locale locale = Locale.ENGLISH;
-    
+
+    private static final String CONFIRMATION_CODE = "ABC123";
+
     @Nested
     class whenProviderDoesNotEnterBusinessName {
         Map<String, Object> provider;
@@ -93,7 +95,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
                     .withMultipleChildcareSchedulesForProvider(List.of(child1.get("uuid").toString(), child2.get("uuid").toString()), provider.get("uuid").toString())
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -128,7 +130,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-agrees.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-agrees.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -142,7 +144,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-agrees.p3",
                     new Object[]{"F.C. and S.C.", "January 10, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-agrees.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-agrees.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));
@@ -199,7 +201,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
                     .withMultipleChildcareSchedulesForProvider(List.of(child1.get("uuid").toString(), child2.get("uuid").toString()), provider.get("uuid").toString())
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -235,7 +237,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-agrees.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-agrees.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -249,7 +251,7 @@ public class SendNewProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-agrees.p3",
                     new Object[]{"F.C. and S.C.", "January 10, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-agrees.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-agrees.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));

--- a/src/test/java/org/ilgcc/app/email/SendProviderAgreesToCareFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendProviderAgreesToCareFamilyConfirmationEmailTest.java
@@ -62,6 +62,8 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
 
     private static Map<String, Object> child2 = new HashMap<>();
 
+    private static final String CONFIRMATION_CODE = "ABC123";
+
     @BeforeAll
     public static void setUpOnce() {
         individualProvider.put("uuid", UUID.randomUUID().toString());
@@ -123,7 +125,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
                     .withChildcareScheduleForProvider(child1.get("uuid").toString(), individualProvider.get("uuid").toString())
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -170,7 +172,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("ccapStartDate")).isEqualTo("May 10, 2025");
             assertThat(emailData.get("familyPreferredLanguage")).isEqualTo("English");
             assertThat(emailData.get("providerType")).isEqualTo("Individual");
@@ -185,7 +187,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.provider-agrees-to-care.subject", null, locale));
+                    messageSource.getMessage("email.provider-agrees-to-care.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -198,7 +200,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.provider-agrees-to-care.p3",
                     new Object[]{"F.C.", "May 10, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.provider-agrees-to-care.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.provider-agrees-to-care.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));
@@ -245,7 +247,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
                     .withChildcareScheduleForProvider(child1.get("uuid").toString(), programProvider.get("uuid").toString())
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -289,7 +291,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("providerName")).isEqualTo("BusinessName");
             assertThat(emailData.get("ccapStartDate")).isEqualTo("January 10, 2025");
             assertThat(emailData.get("familyPreferredLanguage")).isEqualTo("English");
@@ -306,7 +308,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.provider-agrees-to-care.subject", null, locale));
+                    messageSource.getMessage("email.provider-agrees-to-care.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -319,7 +321,7 @@ public class SendProviderAgreesToCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.provider-agrees-to-care.p3",
                     new Object[]{"F.C.", "January 10, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.provider-agrees-to-care.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.provider-agrees-to-care.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));

--- a/src/test/java/org/ilgcc/app/email/SendProviderDeclinesCareFamilyConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendProviderDeclinesCareFamilyConfirmationEmailTest.java
@@ -62,6 +62,8 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
 
     private static Map<String, Object> child2 = new HashMap<>();
 
+    private static final String CONFIRMATION_CODE = "ABC123";
+
     @BeforeAll
     public static void setUpOnce() {
         individualProvider.put("uuid", UUID.randomUUID().toString());
@@ -124,7 +126,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
                     .with("earliestChildcareStartDate", "01/10/2025")
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -161,7 +163,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("familyIntendedProviderName")).isEqualTo("BusinessName");
             assertThat(emailData.get("ccapStartDate")).isEqualTo("June 16, 2025");
             assertThat(emailData.get("familyPreferredLanguage")).isEqualTo("English");
@@ -178,7 +180,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-declines.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-declines.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -192,7 +194,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p3",
                     new Object[]{"F.C. and S.C.", "June 16, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));
@@ -244,7 +246,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
                     .withChildcareScheduleForProvider(child1.get("uuid").toString(), individualProvider.get("uuid").toString())
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -286,7 +288,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
 
             assertThat(emailData.get("providerName")).isEqualTo("ProviderFirst");
             assertThat(emailData.get("ccapStartDate")).isEqualTo("May 10, 2025");
@@ -304,7 +306,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-declines.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-declines.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -319,7 +321,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p3",
                     new Object[]{"F.C.", "May 10, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));
@@ -369,7 +371,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
                     .withChildcareScheduleForProvider(child2.get("uuid").toString(), programProvider.get("uuid").toString())
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
 
             providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -409,7 +411,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
             assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
             assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("S.C."));
-            assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+            assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
             assertThat(emailData.get("providerName")).isEqualTo("BusinessName");
             assertThat(emailData.get("ccapStartDate")).isEqualTo("January 10, 2025");
             assertThat(emailData.get("familyPreferredLanguage")).isEqualTo("English");
@@ -426,7 +428,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-declines.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-declines.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -440,7 +442,7 @@ public class SendProviderDeclinesCareFamilyConfirmationEmailTest {
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p3",
                     new Object[]{"S.C.", "January 10, 2025"}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p4",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-declines.p5",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));

--- a/src/test/java/org/ilgcc/app/email/SendProviderDidNotRespondToFamilyEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendProviderDidNotRespondToFamilyEmailTest.java
@@ -50,6 +50,8 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
 
     private final Locale locale = Locale.ENGLISH;
 
+    private static final String CONFIRMATION_CODE = "ABC123";
+
     @BeforeEach
     void setUp() {
         familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder()
@@ -60,7 +62,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                 .with("familyIntendedProviderName", "Intended Provider")
                 .withSubmittedAtDate(OffsetDateTime.now())
                 .withCCRR()
-                .withShortCode("ABC123")
+                .withShortCode(CONFIRMATION_CODE)
                 .build());
 
         sendEmailClass = new SendProviderDidNotRespondToFamilyEmail(sendEmailJob, messageSource, submissionRepositoryService);
@@ -91,7 +93,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
         assertThat(emailData.get("parentContactEmail")).isEqualTo("familyemail@test.com");
         assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
         assertThat(emailData.get("ccrrPhoneNumber")).isEqualTo("(603) 555-1244");
-        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+        assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
         assertThat(emailData.get("familyIntendedProviderName")).isEqualTo("Intended Provider");
     }
 
@@ -103,7 +105,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
         assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                 new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
         assertThat(emailTemplate.getSubject()).isEqualTo(
-                messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", null, locale));
+                messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
         String emailCopy = emailTemplate.getBody().getValue();
 
@@ -115,7 +117,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                         new Object[]{emailDataOptional.get().get("familyIntendedProviderName").toString()},
                         locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.p3",
-                new Object[]{"ABC123"}, locale));
+                new Object[]{CONFIRMATION_CODE}, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.p4",
                 new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                 locale));
@@ -196,7 +198,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                     .withChildcareScheduleForProvider("child-1-uuid", "first-provider-uuid")
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
             sendEmailClass = new SendProviderDidNotRespondToFamilyEmail(sendEmailJob, messageSource, submissionRepositoryService);
         }
@@ -209,7 +211,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -220,7 +222,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                             new Object[]{emailDataOptional.get().get("childCareProviderInitials").toString()},
                             locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.p3",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.p4",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));
@@ -280,7 +282,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                     .withChildcareScheduleForProvider("child-1-uuid", "first-provider-uuid")
                     .withSubmittedAtDate(OffsetDateTime.now())
                     .withCCRR()
-                    .withShortCode("ABC123")
+                    .withShortCode(CONFIRMATION_CODE)
                     .build());
             sendEmailClass = new SendProviderDidNotRespondToFamilyEmail(sendEmailJob, messageSource, submissionRepositoryService);
         }
@@ -293,7 +295,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
             assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                     new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
             assertThat(emailTemplate.getSubject()).isEqualTo(
-                    messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", null, locale));
+                    messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
             String emailCopy = emailTemplate.getBody().getValue();
 
@@ -304,7 +306,7 @@ public class SendProviderDidNotRespondToFamilyEmailTest {
                             new Object[]{emailDataOptional.get().get("childCareProgramName").toString()},
                             locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.p3",
-                    new Object[]{"ABC123"}, locale));
+                    new Object[]{CONFIRMATION_CODE}, locale));
             assertThat(emailCopy).contains(messageSource.getMessage("email.response-email-for-family.provider-did-not-respond.p4",
                     new Object[]{"Sample Test CCRR", "(603) 555-1244"},
                     locale));

--- a/src/test/java/org/ilgcc/app/email/SendUnidentifiedProviderConfirmationEmailTest.java
+++ b/src/test/java/org/ilgcc/app/email/SendUnidentifiedProviderConfirmationEmailTest.java
@@ -48,12 +48,13 @@ public class SendUnidentifiedProviderConfirmationEmailTest {
 
     private final Locale locale = Locale.ENGLISH;
 
+    private static final String CONFIRMATION_CODE = "ABC123";
 
     @BeforeEach
     void setUp() {
         Submission familySubmission = submissionRepositoryService.save(new SubmissionTestBuilder().withFlow("gcc").with("parentPreferredName", "FirstName")
                 .withChild("First", "Child", "true").withChild("Second", "Child", "true")
-                .withSubmittedAtDate(OffsetDateTime.now()).withCCRR().withShortCode("ABC123").build());
+                .withSubmittedAtDate(OffsetDateTime.now()).withCCRR().withShortCode(CONFIRMATION_CODE).build());
 
         providerSubmission = submissionRepositoryService.save(new SubmissionTestBuilder().withFlow("providerresponse")
                 .with("familySubmissionId", familySubmission.getId().toString())
@@ -85,7 +86,7 @@ public class SendUnidentifiedProviderConfirmationEmailTest {
 
         Map<String, Object> emailData = emailDataOptional.get();
 
-        assertThat(emailData.get("confirmationCode")).isEqualTo("ABC123");
+        assertThat(emailData.get("confirmationCode")).isEqualTo(CONFIRMATION_CODE);
         assertThat(emailData.get("childrenInitialsList")).isEqualTo(List.of("F.C.", "S.C."));
         assertThat(emailData.get("providerName")).isEqualTo("BusinessName");
         assertThat(emailData.get("ccrrName")).isEqualTo("Sample Test CCRR");
@@ -102,7 +103,7 @@ public class SendUnidentifiedProviderConfirmationEmailTest {
         assertThat(emailTemplate.getSenderEmail()).isEqualTo(
                 new Email(FROM_ADDRESS, messageSource.getMessage(ILGCCEmail.EMAIL_SENDER_KEY, null, locale)));
         assertThat(emailTemplate.getSubject()).isEqualTo(
-                messageSource.getMessage("email.unidentified-provider-confirmation.subject", null, locale));
+                messageSource.getMessage("email.unidentified-provider-confirmation.subject", new Object[]{CONFIRMATION_CODE}, locale));
 
         String emailCopy = emailTemplate.getBody().getValue();
 
@@ -113,7 +114,7 @@ public class SendUnidentifiedProviderConfirmationEmailTest {
         assertThat(emailCopy).contains(messageSource.getMessage("email.unidentified-provider-confirmation.p3",
                 new Object[]{"Sample Test CCRR", "(603) 555-1244"}, locale));
         assertThat(emailCopy).contains(
-                messageSource.getMessage("email.unidentified-provider-confirmation.p4", new Object[]{"ABC123"}, locale));
+                messageSource.getMessage("email.unidentified-provider-confirmation.p4", new Object[]{CONFIRMATION_CODE}, locale));
 
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.automated-response", null, locale));
         assertThat(emailCopy).contains(messageSource.getMessage("email.general.footer.cfa", null, locale));


### PR DESCRIPTION
…late and FamilyConfirmationEmailTemplate

#### 🔗 Jira ticket
CCAP-1234

#### ✍️ Description
- [x] FAMILY_CONFIRMATION_EMAIL & FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL 
  - Currently: “[CCAP] Your application has been sent for processing” 
  - Suggested: “[CCAP update] Your application {CONFIRMATION_CODE} has been sent for processing” 
- [x] PROVIDER_DID_NOT_RESPOND_FAMILY_EMAIL 
  - Currently: “[CCAP update] A provider did not respond” 
  - Suggested: “[CCAP update] Your provider did not respond to application {CONFIRMATION_CODE}” 
- [x] PROVIDER_DECLINES_CARE_FAMILY_EMAIL 
  - Currently: “[CCAP update] A provider did not agree to care” 
  - Suggested: “[CCAP update] Your provider did not agree to care, application {CONFIRMATION_CODE}” 
- [x] PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL & NEW_PROVIDER_AGREES_TO_CARE_FAMILY_EMAIL 
  - Currently: “[CCAP update] A provider agreed to care” 
  - Suggested: “[CCAP update] Your provider agreed to care, application {CONFIRMATION_CODE}” 
#### For providers:

- [x] AUTOMATED_PROVIDER_OUTREACH_EMAIL
  - Currently: “[Action Required] New CCAP application” 
  - Suggested: “[Action Required] New CCAP application  {CONFIRMATION_CODE}”

- [x] UNIDENTIFIED_PROVIDER_CONFIRMATION_EMAIL
  - Currently: “[Action Required] Call to respond to child care request”
  - Suggested: “[Action Required] Call to respond to CCAP application {CONFIRMATION_CODE}”

## Implementation Plan
1. Changes messages.properties, updating each email subject to new copy
2. Update templates and subjects where necessary
3. Update tests where necessary

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
