### PR TITLE
[CCAP-1263] Update ValidateBirthdate to throw null value errors

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateBirthdate.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateBirthdate.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 @Slf4j
 public class ValidateBirthdate extends VerifyDate {
-  private final MessageSource messageSource;
+  MessageSource messageSource;
   private final String inputName;
   private final String groupName;
 

--- a/src/main/java/org/ilgcc/app/submission/actions/ValidateBirthdate.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ValidateBirthdate.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.submission.actions;
 
 import formflow.library.data.FormSubmission;
 import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+@Slf4j
 public class ValidateBirthdate extends VerifyDate {
   private final MessageSource messageSource;
   private final String inputName;
@@ -28,11 +30,12 @@ public class ValidateBirthdate extends VerifyDate {
     String day = (String) inputData.get(inputName + "Day");
     String year = (String) inputData.get(inputName + "Year");
 
+    Locale locale = LocaleContextHolder.getLocale();
     if (month == null || day == null || year == null) {
-      throw new IllegalStateException("Missing date fields to run validation");
+      log.warn("All Fields Must Be Present. One or more fields are null.  Month: {}, Day: {}, Year: {}", month, day, year);
+      return Map.of(groupName, List.of(messageSource.getMessage("errors.provide-birthday", null, locale)));
     }
 
-    Locale locale = LocaleContextHolder.getLocale();
     if (month.isBlank() && day.isBlank() && year.isBlank()) {
       return Map.of(groupName, List.of(messageSource.getMessage("errors.provide-birthday", null, locale)));
     }

--- a/src/test/java/org/ilgcc/app/submission/actions/ValidateBirthdateTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/ValidateBirthdateTest.java
@@ -1,10 +1,128 @@
 package org.ilgcc.app.submission.actions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
 
+import formflow.library.data.FormSubmission;
+import formflow.library.data.Submission;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.context.MessageSource;
 
 class ValidateBirthdateTest {
-//  private final MessageSource messageSource;
+  @Mock
+  private MessageSource messageSource;
+  private ValidateBirthdate validator;
+  private AutoCloseable closeable;
+  private String groupName = "testBirth";
+  private String BIRTH_DATE = "testBirth";
+
+  @BeforeEach
+  public void setup() {
+    closeable = MockitoAnnotations.openMocks(this);
+    validator = new ValidateBirthdate(messageSource, groupName, BIRTH_DATE);
+    validator.messageSource = messageSource;
+    when(messageSource.getMessage("errors.provide-birthday", null, Locale.getDefault()))
+      .thenReturn("Enter a birthdate");
+    when(messageSource.getMessage("errors.invalid-birthdate-format", null, Locale.getDefault()))
+        .thenReturn("Make sure the birthdate you entered is in this format: mm/dd/yyyy");
+    when(messageSource.getMessage("errors.invalid-date-range", null, Locale.getDefault()))
+        .thenReturn("Make sure the date you entered is between 01/01/1901 and today");
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  public void shouldGenerateACrossFieldValidationErrorWhenYearFieldIsNull() {
+    Map<String, Object> formData = new HashMap<>();
+    formData.put(String.format("%s%s", BIRTH_DATE, "Day"), "01");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Month"), "01");
+    FormSubmission formSubmission = new FormSubmission(formData);
+    Submission submission = new Submission();
+
+    Map<String, List<String>> errors = validator.runValidation(formSubmission, submission);
+    Assertions.assertThat(errors).containsKey(BIRTH_DATE);
+    assertThat(errors.get("testBirth").getFirst()).isEqualTo( messageSource.getMessage("errors.provide-birthday", null, Locale.getDefault()));
+  }
+
+  @Test
+  public void shouldGenerateACrossFieldValidationErrorWhenMonthIsNull() {
+    Map<String, Object> formData = new HashMap<>();
+    formData.put(String.format("%s%s", BIRTH_DATE, "Day"), "01");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Year"), "2001");
+    FormSubmission formSubmission = new FormSubmission(formData);
+    Submission submission = new Submission();
+
+    Map<String, List<String>> errors = validator.runValidation(formSubmission, submission);
+    Assertions.assertThat(errors).containsKey(BIRTH_DATE);
+    assertThat(errors.get("testBirth").getFirst()).isEqualTo( messageSource.getMessage("errors.provide-birthday", null, Locale.getDefault()));
+  }
+
+  @Test
+  public void shouldGenerateACrossFieldValidationErrorWhenDayIsNull() {
+    Map<String, Object> formData = new HashMap<>();
+    formData.put(String.format("%s%s", BIRTH_DATE, "Month"), "01");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Year"), "2001");
+    FormSubmission formSubmission = new FormSubmission(formData);
+    Submission submission = new Submission();
+
+    Map<String, List<String>> errors = validator.runValidation(formSubmission, submission);
+    Assertions.assertThat(errors).containsKey(BIRTH_DATE);
+    assertThat(errors.get("testBirth").getFirst()).isEqualTo( messageSource.getMessage("errors.provide-birthday", null, Locale.getDefault()));
+  }
+
+  @Test
+  public void shouldNotGenerateErrorIfDateIncludesAllRequiredFieldsAndIsValid() {
+    Map<String, Object> formData = new HashMap<>();
+    formData.put(String.format("%s%s", BIRTH_DATE, "Day"), "12");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Month"), "01");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Year"), "2021");
+    FormSubmission formSubmission = new FormSubmission(formData);
+    Submission submission = new Submission();
+
+    Map<String, List<String>> errors = validator.runValidation(formSubmission, submission);
+    Assertions.assertThat(errors).doesNotContainKey(BIRTH_DATE);
+  }
+
+  @Test
+  public void shouldThrowAnErrorIfBirthDateIsInvalid() {
+    Map<String, Object> formData = new HashMap<>();
+    formData.put(String.format("%s%s", BIRTH_DATE, "Day"), "14");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Month"), "15");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Year"), "2021");
+
+    FormSubmission formSubmission = new FormSubmission(formData);
+    Submission submission = new Submission();
+
+    Map<String, List<String>> errors = validator.runValidation(formSubmission, submission);
+    Assertions.assertThat(errors).containsKey(BIRTH_DATE);
+    assertThat(errors.get("testBirth").getFirst()).isEqualTo( messageSource.getMessage("errors.invalid-birthdate-format", null, Locale.getDefault()));
+  }
+  @Test
+  public void shouldThrowAnErrorIfBirthDateIsBeforeMinDate() {
+    Map<String, Object> formData = new HashMap<>();
+    formData.put(String.format("%s%s", BIRTH_DATE, "Month"), "12");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Day"), "29");
+    formData.put(String.format("%s%s", BIRTH_DATE, "Year"), "1809");
+
+    FormSubmission formSubmission = new FormSubmission(formData);
+    Submission submission = new Submission();
+
+    Map<String, List<String>> errors = validator.runValidation(formSubmission, submission);
+    Assertions.assertThat(errors).containsKey(BIRTH_DATE);
+    assertThat(errors.get("testBirth").getFirst()).isEqualTo( messageSource.getMessage("errors.invalid-date-range", null, Locale.getDefault()));
+  }
+
 
 }

--- a/src/test/java/org/ilgcc/app/submission/actions/ValidateBirthdateTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/ValidateBirthdateTest.java
@@ -1,0 +1,10 @@
+package org.ilgcc.app.submission.actions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.springframework.context.MessageSource;
+
+class ValidateBirthdateTest {
+//  private final MessageSource messageSource;
+
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1263

#### ✍️ Description
Prevent `null` values from being passed into Birthdates.  

#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
