### PR TITLE
[CCAP-1260] - update transmission confirmation email to have differen…

### DIFF
--- a/src/main/java/org/ilgcc/app/email/templates/FamilyApplicationTransmittedConfirmationEmailTemplate.java
+++ b/src/main/java/org/ilgcc/app/email/templates/FamilyApplicationTransmittedConfirmationEmailTemplate.java
@@ -2,6 +2,7 @@ package org.ilgcc.app.email.templates;
 
 import static org.ilgcc.app.email.ILGCCEmail.FROM_ADDRESS;
 import static org.ilgcc.app.utils.ProviderSubmissionUtilities.formatListIntoReadableString;
+import static org.ilgcc.app.utils.SubmissionUtilities.haveAllProvidersResponded;
 
 import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Email;
@@ -49,10 +50,17 @@ public class FamilyApplicationTransmittedConfirmationEmailTemplate {
         String p1 = messageSource.getMessage("email.family-application-transmitted-confirmation-email.p1",
                 new Object[]{emailData.get("parentFirstName")},
                 locale);
-        String p2 = messageSource.getMessage("email.family-application-transmitted-confirmation-email.p2",
-                new Object[]{emailData.get("ccrrName")}, locale);
+        String p2 = "";
 
         List<Map<String, Object>> providers = (List) emailData.getOrDefault("providersData", List.of());
+
+        if (haveAllProvidersResponded(providers)) {
+            p2 = messageSource.getMessage("email.family-application-transmitted-confirmation-email.p2.all-responded",
+                    new Object[]{emailData.get("ccrrName")}, locale);
+        } else {
+            p2 = messageSource.getMessage("email.family-application-transmitted-confirmation-email.p2.mixed-response",
+                    new Object[]{emailData.get("ccrrName")}, locale);
+        }
 
         for (Map<String, Object> provider : providers) {
             p2 += getProviderResponseString(provider, messageSource, locale);

--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -401,6 +401,10 @@ public class SubmissionUtilities {
         return SubmissionStatus.RESPONDED.name().equals(familySubmission.getInputData().get("providerApplicationResponseStatus"));
     }
 
+    public static boolean haveAllProvidersResponded(List<Map<String, Object>> providers) {
+        return providers.stream().allMatch(p -> p.getOrDefault("providerApplicationResponseStatus", "false").equals(SubmissionStatus.RESPONDED.name()));
+    }
+
     public static boolean allChildcareSchedulesAreForTheSameProvider(Map<String, Object> inputData) {
 
         Map<String, List<Map<String, Object>>> relatedChildrenSchedulesByProvider = getRelatedChildrenSchedulesForEachProvider(

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -167,7 +167,8 @@ email.automated-provider-outreach.email-preview.body.pt3=<strong>Click this secu
 # FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL
 email.family-application-transmitted-confirmation-email.subject=[CCAP] Your application has been sent for processing
 email.family-application-transmitted-confirmation-email.p1=<p>Hi {0},</p>
-email.family-application-transmitted-confirmation-email.p2=<p>All of your child care providers have completed their parts of your Child Care Assistance application! Your application has now been sent to {0} for processing.</p>
+email.family-application-transmitted-confirmation-email.p2.mixed-response=<p>Your application has now been sent to {0} for processing.</p>
+email.family-application-transmitted-confirmation-email.p2.all-responded=<p>All of your child care providers have completed their parts of your Child Care Assistance application! Your application has now been sent to {0} for processing.</p>
 email.family-application-transmitted-confirmation-email.li-agreed-to-care=<li><strong>{0} agreed to care</strong> for {1} with a start date of {2}.</li>
 email.family-application-transmitted-confirmation-email.li-did-not-agree-to-care=<li><strong>{0} did not agree to care</strong> for {1}.</li>
 email.family-application-transmitted-confirmation-email.li-did-not-complete-application-in-three-days=<li><strong>{0} did not complete their part of your application</strong> within 3 days</li>

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -167,7 +167,8 @@ email.automated-provider-outreach.email-preview.body.pt3=<p><strong>Haga clic en
 # FAMILY_APPLICATION_TRANSMITTED_CONFIRMATION_EMAIL
 email.family-application-transmitted-confirmation-email.subject=Su solicitud ha sido enviada para ser procesada
 email.family-application-transmitted-confirmation-email.p1=<p>Hola {0},</p>
-email.family-application-transmitted-confirmation-email.p2=<p>¡Todos sus proveedores de cuidados de niños han completado la parte que les correspondía de la aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)! Su aplicación ha sido enviada a {0} para ser procesada.</p>
+email.family-application-transmitted-confirmation-email.p2.mixed-response=<p>Su solicitud ha sido enviada a {0} para ser procesada.</p>
+email.family-application-transmitted-confirmation-email.p2.all-responded=<p>¡Todos sus proveedores de cuidados de niños han completado la parte que les correspondía de la aplicación al Programa de Asistencia para el Cuidado de Niños (CCAP)! Su aplicación ha sido enviada a {0} para ser procesada.</p>
 email.family-application-transmitted-confirmation-email.li-agreed-to-care=<li><strong>{0} aceptó cuidar </strong> a {1} con fecha de comienzo {2}.</li>
 email.family-application-transmitted-confirmation-email.li-did-not-agree-to-care=<li><strong>{0} no aceptó cuidar </strong> a {1}.</li>
 email.family-application-transmitted-confirmation-email.li-did-not-complete-application-in-three-days=<li><strong>{0} no completó la parte que le correspondía de su solicitud de Asistencia para el Cuidado de Niños</strong> en 3 días.</li>
@@ -1439,7 +1440,7 @@ provider-response.mailing-address.same-as-home-address=La misma donde tengo regi
 #contact-info
 provider-response-contact-info.title=Información de contacto
 provider-response-contact-info.header=¿Cuál es la información de contacto de su proveedor?
-provider-response-contact-info.subtext=Deberá ingresar por lo menos un medio de contacto. 
+provider-response-contact-info.subtext=Deberá ingresar por lo menos un medio de contacto.
 provider-response-contact-info.email=¿Cuál es su dirección de correo electrónico?
 provider-response-contact-info.email-help=Al compartir su correo electrónico, le da su consentimiento a Code for America, al Departamento de Servicios Humanos de Illinois (Illinois Department of Human Services, IDHS), y a las agencias de Recursos y Referencias del Cuidado de Niños (CCR&R, por sus siglas en inglés) de su condado para que le envíen correos electrónicos sobre su solicitud.
 provider-response-contact-info.phone=¿Cuál es su número de teléfono?


### PR DESCRIPTION
…t copy when all respond and when not

#### 🔗 Jira ticket
[CCAP-1260](https://codeforamerica.atlassian.net/browse/CCAP-1260)

#### ✍️ Description
When all providers respond, include message about providers responding
1. When it includes a No provider + 2 Providers
<img width="699" height="352" alt="Screenshot 2025-08-25 at 3 37 41 PM" src="https://github.com/user-attachments/assets/7e36080e-ceca-48d3-b42b-15acb186446e" />

2. When it includes 3 providers but only 2 have schedules OR it includes 2 Providers only
<img width="718" height="315" alt="Screenshot 2025-08-25 at 3 49 34 PM" src="https://github.com/user-attachments/assets/75585314-32cc-4187-a87f-25ff9fc237c3" />


If all providers did not respond, exclude the message
1.  When it includes 2 Providers only
<img width="714" height="425" alt="Screenshot 2025-08-25 at 4 02 16 PM" src="https://github.com/user-attachments/assets/80cd3225-eccb-438e-afa5-f3a7803884fb" />

2. When it includes a No provider + 2 Providers
<img width="929" height="323" alt="Screenshot 2025-08-26 at 8 59 16 AM" src="https://github.com/user-attachments/assets/226267a0-9c44-4821-9e15-22cf2e7698e3" />


#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria


[CCAP-1260]: https://codeforamerica.atlassian.net/browse/CCAP-1260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ