### PR TITLE
Ignoring jobrunr, enabling amazon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "com.amazonaws:aws-java-sdk-s3"
+      - dependency-name: "org.jobrunr:jobrunr-spring-boot-3-starter"
         update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This Amazon sdk isn't used any more, and this will make sure we don't accidentally upgrade Jobrunr.