### PR TITLE
[CCAP-1262]- Add an Image on /unearned-income-source

### DIFF
--- a/src/main/resources/templates/gcc/unearned-income-source.html
+++ b/src/main/resources/templates/gcc/unearned-income-source.html
@@ -3,6 +3,7 @@
           screenWithOneInput(
             title=#{unearned-income-source.title},
             header=#{unearned-income-source.header},
+            iconFragment=~{fragments/gcc-icons :: income},
             subtext=#{unearned-income-source.header.help},
             required='true',
             buttonLabel=#{'general.inputs.continue'},


### PR DESCRIPTION
 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1262?

✍️ Description
On gcc/unearned-income-source, the page should include the icon as it appears in this design:

 📷 Design reference
<img width="1164" height="990" alt="Screenshot 2025-08-25 135047" src="https://github.com/user-attachments/assets/f1c808f8-9856-4b64-a196-72ff969cb1ef" />

 ✅ Completion tasks

