### PR TITLE
Potential fix for code scanning alert no. 1004: Log Injection

### DIFF
--- a/src/main/java/org/ilgcc/app/ProviderLinkController.java
+++ b/src/main/java/org/ilgcc/app/ProviderLinkController.java
@@ -51,7 +51,7 @@ public class ProviderLinkController {
 
         String sanitizedConfirmationCode = sanitize(confirmationCode);
 
-        log.info("Loading submission for code " + sanitizedConfirmationCode);
+        log.info("Loading submission for code '{}'", sanitizedConfirmationCode);
 
         if (sanitizedConfirmationCode != null) {
             Optional<Submission> familySubmission = submissionRepositoryService.findByShortCode(
@@ -61,7 +61,7 @@ public class ProviderLinkController {
                 setFamilySessionData(familySubmission.get(), newSession);
                 checkRefererValue(referer, newSession);
             } else {
-                log.debug("Unable to load submission for code " + sanitizedConfirmationCode);
+                log.debug("Unable to load submission for code '{}'", sanitizedConfirmationCode);
                 return "redirect:/error-invalid-code";
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/codeforamerica/il-gcc-form-flow/security/code-scanning/1004](https://github.com/codeforamerica/il-gcc-form-flow/security/code-scanning/1004)

To fix this vulnerability:
1. **Always use parameterized logging** with placeholders (`{}`) for user input, instead of string concatenation. This helps loggers treat the user input as a value (protecting against malformed formatting and making delimiters clearer).
2. **Clearly delimit the user input in log entry** (for example, surrounding with single quotes).
3. The existing `sanitize` method is already effective at removing control characters (such as newlines), but we will keep its use as a defense-in-depth measure.
4. Apply the same fix on any other log entries using the user input (for instance, the DEBUG line at 64, which also logs the code).
5. Changes required:
    - In `ProviderLinkController.java`, update both INFO and DEBUG log statements to use parameterized logging and delimit the input.
    - No need for changes in `TextUtilities.java` as the sanitizer suffices for log injection defense.
6. No changes to imports are needed as `log.info` already works with parameterized arguments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
