### PR TITLE
[CCAP-1296] Update how we get childcare schedules

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/LocalizeSameScreenProviderSchedules.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/LocalizeSameScreenProviderSchedules.java
@@ -34,7 +34,7 @@ public class LocalizeSameScreenProviderSchedules implements Action {
             repeatForIterationUuid);
         String currentProviderUuidOrNoProvider = (String) currentProviderSchedule.get("repeatForValue");
 
-        List<Map<String, Object>> childCareSchedulesWithMatchingProvider = SubmissionUtilities.getAnyChildcareSchedulesWithTheSameProvider(childcareSchedules,currentProviderUuidOrNoProvider, currentChildcareSchedule);
+        List<Map<String, Object>> childCareSchedulesWithMatchingProvider = SubmissionUtilities.getRemainingChildcareSchedulesWithTheSameProvider(childcareSchedules,currentProviderUuidOrNoProvider, currentChildcareSchedule);
 
         childCareSchedulesWithMatchingProvider.forEach(childCareScheduleMatch -> {
             List<Map<String, Object>> providerSchedules = (List<Map<String, Object>>) childCareScheduleMatch.getOrDefault("providerSchedules", Collections.emptyList());

--- a/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/DisplaySchedulesSameScreen.java
@@ -26,7 +26,7 @@ public class DisplaySchedulesSameScreen extends EnableMultipleProviders implemen
             Map<String, Object> currentProviderSchedule = relatedSubflowIterationData(currentChildcareSchedule, "providerSchedules",
         repeatForIterationUuid);
             String currentProviderUuidOrNoProvider = (String) currentProviderSchedule.get("repeatForValue");
-            List<Map<String, Object>> childcareSchedulesWithTheSameProvider = SubmissionUtilities.getAnyChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider, currentChildcareSchedule);
+            List<Map<String, Object>> childcareSchedulesWithTheSameProvider = SubmissionUtilities.getRemainingChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider, currentChildcareSchedule);
             return super.run(submission) && (!childcareSchedulesWithTheSameProvider.isEmpty() &&
                hasOnlyOneProviderScheduleForTheSameProvider(childcareSchedulesWithTheSameProvider, currentProviderUuidOrNoProvider));
         }

--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -342,16 +342,23 @@ public class SubmissionUtilities {
         return String.format("%s.%s", prefix, suffix);
     }
 
-    public static List<Map<String, Object>> getAnyChildcareSchedulesWithTheSameProvider(
+    public static List<Map<String, Object>> getRemainingChildcareSchedulesWithTheSameProvider(
             List<Map<String, Object>> childcareSchedules, String currentProviderUuidOrNoProvider,
             Map<String, Object> currentChildcareSchedule) {
-        List<Map<String, Object>> remainingChildcareSchedules = childcareSchedules.stream()
-                .filter(childcareSchedule -> !childcareSchedule.equals(currentChildcareSchedule))
-                .toList();
-        return remainingChildcareSchedules.stream()
-                .filter(childcareSchedule -> childcareScheduleIncludesThisProvider(childcareSchedule,
-                        currentProviderUuidOrNoProvider)).toList();
+        return getAllChildcareSchedulesWithTheSameProvider(childcareSchedules, currentProviderUuidOrNoProvider).stream()
+                .filter(childcareSchedule -> !childcareSchedule.equals(currentChildcareSchedule)).toList();
     }
+
+    public static List<Map<String, Object>> getAllChildcareSchedulesWithTheSameProvider(List<Map<String, Object>> childcareSchedules, String currentProviderUuidOrNoProvider){
+        return childcareSchedules.stream().filter(childcareSchedule -> childcareScheduleIncludesThisProvider(childcareSchedule, currentProviderUuidOrNoProvider)).toList();
+    }
+
+    //TODO: GENERATE A SET OF CHILDCARE SCHEDULES GROUPED BY PROVIDERUUID
+//    public static Map<String, List<Map<String, Object>>> getAllChildcareSchedulesGroupedByProviderOrNoProvider(List<Map<String, Object>> providers, List<Map<String, Object>> childcareSchedules){
+//
+//
+//    }
+
 
     private static boolean childcareScheduleIncludesThisProvider(Map<String, Object> childcareSchedule,
             String providerUuidOrNoProvider) {


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1296

#### ✍️ Description
### When
- there are providers on the application 
- no provider on the application has a schedule 
- then display a warning on the schedules-review screen

### When
- there are providers on the application, and 
- one or more providers has a schedule associated with them, and 
- one or more providers has no schedule associated with them 
- then display a warning on the schedules-review screen 

- [ ] If there is more than one provider with no schedule, list the provider names, separated by a comma, with the word ‘and’ preceding the final item in the list. 
- [ ] If there should be both a warning about a provider and a warning about children on the application on this screen (CCAP-1151) then stack the warnings with the provider warning coming first.

## Execution
1. Create a notice block at the bottom of the schedule-review screen 
2. Use/create utility functions that finds any and all providers that do not have schedules attached to them  
3. Add messages.properties to screen
4. Add test to multiprovider to account for the two scenarios where provider information is missing

#### 📷 Design reference

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
