### PR TITLE
[CCAP-1252] Fix site administered application routing

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/SetResourceOrganization.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetResourceOrganization.java
@@ -1,19 +1,19 @@
 package org.ilgcc.app.submission.actions;
 
 import static org.ilgcc.app.utils.ProviderSubmissionUtilities.getFamilySubmissionId;
+import static org.ilgcc.app.utils.SubmissionUtilities.setProviderResourceOrgId;
 
 import formflow.library.config.submission.Action;
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.ilgcc.app.data.CCMSDataServiceImpl;
-import org.ilgcc.app.data.ResourceOrganization;
-import org.ilgcc.app.submission.router.ApplicationRouterService;
-import formflow.library.data.SubmissionRepositoryService;
 import lombok.extern.slf4j.Slf4j;
+import org.ilgcc.app.data.ResourceOrganization;
 import org.ilgcc.app.submission.router.ApplicationRoutingServiceImpl;
+import org.ilgcc.app.utils.SubmissionUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -23,13 +23,7 @@ public class SetResourceOrganization implements Action {
 
     @Autowired
     SubmissionRepositoryService submissionRepositoryService;
-
-    @Autowired
-    ApplicationRouterService applicationRouterService;
-
-    @Autowired
-    CCMSDataServiceImpl ccmsDataServiceImpl;
-
+    
     @Autowired
     ApplicationRoutingServiceImpl applicationRouterServiceImpl;
 
@@ -39,23 +33,33 @@ public class SetResourceOrganization implements Action {
 
     @Override
     public void run(Submission providerSubmission) {
-        Map<String, Object> inputData = providerSubmission.getInputData();
+        Map<String, Object> providerInputData = providerSubmission.getInputData();
 
         // Because of validation, providerResponseProviderNumber cannot be null or invalid
-        BigInteger providerId = new BigInteger(inputData.get(PROVIDER_NUMBER).toString());
-        Optional<ResourceOrganization> org = applicationRouterServiceImpl.getSiteAdministeredOrganizationByProviderId(
-                providerId);
+        BigInteger providerId = new BigInteger(providerInputData.get(PROVIDER_NUMBER).toString());
+        Optional<ResourceOrganization> org = applicationRouterServiceImpl.getSiteAdministeredOrganizationByProviderId(providerId);
 
         if (org.isPresent()) {
             Optional<UUID> familySubmissionId = getFamilySubmissionId(providerSubmission);
 
-            if(familySubmissionId.isPresent()){
-                Optional<Submission> familySubmission = submissionRepositoryService.findById(familySubmissionId.get());
-                if (familySubmission.isPresent()) {
-                    familySubmission.get().getInputData().put(ORGANIZATION_ID_INPUT, org.get().getResourceOrgId());
-                    familySubmission.get().getInputData().put("ccrrName", org.get().getName());
-                    familySubmission.get().getInputData().put("ccrrPhoneNumber", org.get().getPhone());
-                    submissionRepositoryService.save(familySubmission.get());
+            if (familySubmissionId.isPresent()) {
+                Optional<Submission> familySubmissionOptional = submissionRepositoryService.findById(familySubmissionId.get());
+                if (familySubmissionOptional.isPresent()) {
+                    Submission familySubmission = familySubmissionOptional.get();
+                    if (familySubmission.getInputData().containsKey("providers")) {
+                        setProviderResourceOrgId(
+                                familySubmission,
+                                providerInputData.getOrDefault("currentProviderUuid", "").toString(),
+                                org.get().getResourceOrgId().toString());
+                        submissionRepositoryService.save(familySubmission);
+                    }
+                    if (SubmissionUtilities.isPreMultiProviderApplicationWithSingleProvider(familySubmission) || 
+                            SubmissionUtilities.allProvidersBelongToTheSameSiteAdministeredResourceOrganization(familySubmission)) {
+                        familySubmission.getInputData().put(ORGANIZATION_ID_INPUT, org.get().getResourceOrgId());
+                        familySubmission.getInputData().put("ccrrName", org.get().getName());
+                        familySubmission.getInputData().put("ccrrPhoneNumber", org.get().getPhone());
+                        submissionRepositoryService.save(familySubmission);
+                    }
                 }
             }
         }

--- a/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ilgcc/app/utils/SubmissionUtilities.java
@@ -429,4 +429,57 @@ public class SubmissionUtilities {
         return !isPreMultiProviderApplicationWithSingleProvider(familySubmission) &&
                 !allChildcareSchedulesAreForTheSameProvider(familySubmission.getInputData());
     }
+
+    public static void setProviderResourceOrgId(Submission familySubmission, String providerIterationId, String resourceOrgId) {
+
+        List<Map<String, Object>> providers = (List<Map<String, Object>>) familySubmission.getInputData().get("providers");
+
+        for (int i = 0; i < providers.size(); i++) {
+            Map<String, Object> provider = providers.get(i);
+            if (providerIterationId.equals(provider.get("uuid").toString())) {
+                Map<String, Object> updatedProviderIteration = new HashMap<>(provider);
+                updatedProviderIteration.put("providerResourceOrgId", resourceOrgId);
+
+                List<Map<String, Object>> newProviders = new ArrayList<>(providers);
+                newProviders.set(i, updatedProviderIteration);
+
+                Map<String, Object> newInputData = new HashMap<>(familySubmission.getInputData());
+                newInputData.put("providers", newProviders);
+                familySubmission.setInputData(newInputData);
+            }
+        }
+    }
+
+
+    /**
+     * @param familySubmission the family submission to be checked against whose list of providers will be used for the check.
+     * @return true if all providers in the family submission belong to the same site administered resource organization otherwise 
+     * false.
+     */
+    public static boolean allProvidersBelongToTheSameSiteAdministeredResourceOrganization(Submission familySubmission) {
+        if (familySubmission.getInputData().containsKey("providers")) {
+            List<Map<String, Object>> providers = (List<Map<String, Object>>) familySubmission.getInputData().get("providers");
+            if (providers.isEmpty()) {
+                return false;
+            }
+            
+            String firstProviderResourceOrgId = null;
+            for (Map<String, Object> provider : providers) {
+                if (!provider.containsKey("providerResourceOrgId")) {
+                    // if we don't know the org we can't say they all the same
+                    return false;
+                }
+                String currentProviderResourceOrgId = provider.get("providerResourceOrgId").toString();
+                if (firstProviderResourceOrgId == null) {
+                    firstProviderResourceOrgId = currentProviderResourceOrgId;
+                } else if (!firstProviderResourceOrgId.equals(currentProviderResourceOrgId)) {
+                    return false;
+                }
+            }
+            // all resource orgs match
+            return true;
+        }
+        // if providers is empty, we can't say they all belong to the same org
+        return false;
+    }
 }

--- a/src/test/java/org/ilgcc/app/submission/actions/SetResourceOrganizationTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SetResourceOrganizationTest.java
@@ -8,10 +8,14 @@ import static org.ilgcc.app.data.importer.FakeProviderDataImporter.CURRENT_APPRO
 
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.ilgcc.app.data.ProviderRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,8 +43,14 @@ class SetResourceOrganizationTest {
 
     @BeforeEach
     void setUp() {
+        Map<String, Object> familyInputData = new HashMap<>();
+        familyInputData.put("organizationId", "testValue");
+        familyInputData.put("ccrrName", "CCRR Name");
+        familyInputData.put("ccrrPhoneNumber", "(123) 123-1234");
+        familyInputData.put("familyIntendedProviderName", "Test Provider");
+        
         familySubmission = Submission.builder()
-                .inputData(Map.of("organizationId", "testValue", "ccrrName", "CCRR Name", "ccrrPhoneNumber", "(123) 123-1234"))
+                .inputData(familyInputData)
                 .shortCode("testShortCode")
                 .build();
         submissionRepositoryService.save(familySubmission);
@@ -87,5 +97,60 @@ class SetResourceOrganizationTest {
         assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo("testValue");
         assertThat(familySubmission.getInputData().get("ccrrName")).isEqualTo("CCRR Name");
         assertThat(familySubmission.getInputData().get("ccrrPhoneNumber")).isEqualTo("(123) 123-1234");
+    }
+
+    @Nested
+    class MultiProviderTests {
+
+        @BeforeEach
+        void addProvidersToFamilySubmission() {
+            Map<String, Object> provider1 = new HashMap<>();
+            Map<String, Object> provider2 = new HashMap<>();
+
+            provider1.put("uuid", UUID.randomUUID().toString());
+            provider1.put("providerName", "First Provider");
+            provider1.put("providerResourceOrgId", "orgID");
+
+            provider2.put("uuid", UUID.randomUUID().toString());
+            provider2.put("providerName", "Second Provider");
+            provider2.put("providerResourceOrgId", "orgID");
+
+            familySubmission.getInputData().put("providers", new ArrayList<>(List.of(provider1, provider2)));
+            submissionRepositoryService.save(familySubmission);
+        }
+
+        @Test
+        void shouldChangeFamilyOrgIdWhenAllProvidersHaveTheSameOrgId() {
+            setResourceOrganization.run(providerSubmission);
+            familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();
+
+            assertThat(familySubmission.getInputData().get("organizationId"))
+                    .isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getResourceOrgId().intValue());
+            assertThat(familySubmission.getInputData().get("ccrrName"))
+                    .isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getName());
+            assertThat(familySubmission.getInputData().get("ccrrPhoneNumber"))
+                    .isEqualTo(ACTIVE_SITE_ADMIN_RESOURCE_ORG.getPhone());
+        }
+
+        @Test
+        void shouldNotChangeFamilyOrgIdWhenAllProvidersDoNotHaveTheSameOrgId() {
+            Map<String, Object> provider3 = new HashMap<>();
+
+            provider3.put("uuid", UUID.randomUUID().toString());
+            provider3.put("providerName", "Third Provider");
+            provider3.put("providerResourceOrgId", "someOtherOrdId");
+
+            familySubmission.getInputData().get("providers");
+            ((List<Map<String, Object>>) familySubmission.getInputData().get("providers")).add(provider3);
+
+            submissionRepositoryService.save(familySubmission);
+
+            setResourceOrganization.run(providerSubmission);
+            familySubmission = submissionRepositoryService.findById(familySubmission.getId()).orElseThrow();
+
+            assertThat(familySubmission.getInputData().get("organizationId")).isEqualTo("testValue");
+            assertThat(familySubmission.getInputData().get("ccrrName")).isEqualTo("CCRR Name");
+            assertThat(familySubmission.getInputData().get("ccrrPhoneNumber")).isEqualTo("(123) 123-1234");
+        }
     }
 }

--- a/src/test/java/org/ilgcc/app/utils/SubmissionUtilitiesTest.java
+++ b/src/test/java/org/ilgcc/app/utils/SubmissionUtilitiesTest.java
@@ -92,4 +92,126 @@ class SubmissionUtilitiesTest {
         boolean result = SubmissionUtilities.isPreMultiProviderApplicationWithSingleProvider(submission);
         assertThat(result).isFalse();
     }
+    
+    @Test
+    void allProvidersBelongToTheSameSiteAdministeredResourceOrganizationReturnsTrueWhenAllProvidersHaveSameResourceOrgId() {
+        Map<String, Object> provider1  = new HashMap<>();
+        Map<String, Object> provider2  = new HashMap<>();
+        provider1.put("uuid", UUID.randomUUID().toString());
+        provider1.put("providerName", "First Provider");
+        provider1.put("providerResourceOrgId", "orgID");
+
+        provider2.put("uuid", UUID.randomUUID().toString());
+        provider2.put("providerName", "Second Provider");
+        provider2.put("providerResourceOrgId", "orgID");
+        
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of(provider1, provider2))
+                .build();
+        boolean result = SubmissionUtilities.allProvidersBelongToTheSameSiteAdministeredResourceOrganization(submission);
+        assertThat(result).isTrue();
+    }
+    
+    @Test
+    void allProvidersBelongToTheSameSiteAdministeredResourceOrganizationReturnsFalseWhenProvidersHaveDifferentResourceOrgIds() {
+        Map<String, Object> provider1 = new HashMap<>();
+        Map<String, Object> provider2 = new HashMap<>();
+        provider1.put("uuid", UUID.randomUUID().toString());
+        provider1.put("providerName", "First Provider");
+        provider1.put("providerResourceOrgId", "orgID1");
+
+        provider2.put("uuid", UUID.randomUUID().toString());
+        provider2.put("providerName", "Second Provider");
+        provider2.put("providerResourceOrgId", "orgID2");
+
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of(provider1, provider2))
+                .build();
+        boolean result = SubmissionUtilities.allProvidersBelongToTheSameSiteAdministeredResourceOrganization(submission);
+        assertThat(result).isFalse();
+    }
+    
+    @Test
+    void allProvidersBelongToTheSameSiteAdministeredResourceOrganizationReturnsFalseWhenAProviderDoesNotHaveAResourceOrgId() {
+        Map<String, Object> provider1 = new HashMap<>();
+        Map<String, Object> provider2 = new HashMap<>();
+        provider1.put("uuid", UUID.randomUUID().toString());
+        provider1.put("providerName", "First Provider");
+        provider1.put("providerResourceOrgId", "orgID1");
+
+        provider2.put("uuid", UUID.randomUUID().toString());
+        provider2.put("providerName", "Second Provider");
+        // provider2 does not have a resource org id
+
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of(provider1, provider2))
+                .build();
+        boolean result = SubmissionUtilities.allProvidersBelongToTheSameSiteAdministeredResourceOrganization(submission);
+        assertThat(result).isFalse();
+    }
+    
+    @Test
+    void allProvidersBelongToTheSameSiteAdministeredResourceOrganizationReturnsTrueWhenThereIsOnlyOneProvider() {
+        Map<String, Object> provider1 = new HashMap<>();
+        provider1.put("uuid", UUID.randomUUID().toString());
+        provider1.put("providerName", "First Provider");
+        provider1.put("providerResourceOrgId", "orgID1");
+
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of(provider1))
+                .build();
+        boolean result = SubmissionUtilities.allProvidersBelongToTheSameSiteAdministeredResourceOrganization(submission);
+        assertThat(result).isTrue();
+    }
+    
+    @Test
+    void allProvidersBelongToTheSameSiteAdministeredResourceOrganizationReturnsFalseWhenProvidersIsEmpty() {
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of())
+                .build();
+        boolean result = SubmissionUtilities.allProvidersBelongToTheSameSiteAdministeredResourceOrganization(submission);
+        assertThat(result).isFalse();
+    }
+    
+    @Test
+    void setProviderResourceOrgIdCorrectlySetsTheResourceOrgIdForTheMatchingProvider() {
+        Map<String, Object> provider1 = new HashMap<>();
+        Map<String, Object> provider2 = new HashMap<>();
+        provider1.put("uuid", "provider-uuid-1");
+        provider1.put("providerName", "First Provider");
+
+        provider2.put("uuid", "provider-uuid-2");
+        provider2.put("providerName", "Second Provider");
+
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of(provider1, provider2))
+                .build();
+        
+        SubmissionUtilities.setProviderResourceOrgId(submission, "provider-uuid-2", "new-org-id");
+        
+        List<Map<String, Object>> providers = (List<Map<String, Object>>) submission.getInputData().get("providers");
+        assertThat(providers.get(0).get("providerResourceOrgId")).isNull();
+        assertThat(providers.get(1).get("providerResourceOrgId")).isEqualTo("new-org-id");
+    }
+    
+    @Test
+    void setProviderResourceOrgIdDoesNothingIfCurrentProviderPassedIsEmptyString() {
+        Map<String, Object> provider1 = new HashMap<>();
+        Map<String, Object> provider2 = new HashMap<>();
+        provider1.put("uuid", "provider-uuid-1");
+        provider1.put("providerName", "First Provider");
+
+        provider2.put("uuid", "provider-uuid-2");
+        provider2.put("providerName", "Second Provider");
+
+        Submission submission = new SubmissionTestBuilder()
+                .with("providers", List.of(provider1, provider2))
+                .build();
+        
+        SubmissionUtilities.setProviderResourceOrgId(submission, "", "new-org-id");
+        
+        List<Map<String, Object>> providers = (List<Map<String, Object>>) submission.getInputData().get("providers");
+        assertThat(providers.get(0).get("providerResourceOrgId")).isNull();
+        assertThat(providers.get(1).get("providerResourceOrgId")).isNull();
+    }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1252

#### ✍️ Description
Fixes an issue where applications were incorrectly being sent to site administered providers. 

Adds many tests to account for different scenarios which should be sufficient to show due diligence with regard to local testing.

#### Testing

Create a family application with two providers on it.

Respond for the first provider as site-administered provider Brightpoint (CCMS provider id: 276390015433000)

Respond for the second provider with any other non-site provider id, eg 12345678902

Check in the DB and see that the family submission DID not get routing to the site administered resource org / it's resource org ID never changed from the one that was set for the original family application. 

This was tested locally with the above process. 
