### PR TITLE
[CCAP-1318, CCAP-1319] Fix fieldset and legend ordering and ensure unique IDs for fields

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/PartnerSetJobWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/PartnerSetJobWeeklyScheduleGroup.java
@@ -17,52 +17,55 @@ import org.springframework.stereotype.Component;
 @Component
 public class PartnerSetJobWeeklyScheduleGroup implements Action {
 
-  private final MessageSource messageSource;
+    private final MessageSource messageSource;
 
-  public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+    public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+            "Sunday");
 
-  public static final String DISPLAY_LABEL = "displayWeeklySchedule";
+    public static final String DISPLAY_LABEL = "displayWeeklySchedule";
 
-  public PartnerSetJobWeeklyScheduleGroup(MessageSource messageSource) {
-    this.messageSource = messageSource;
-  }
-
-  @Override
-  public void run(Submission submission, String id) {
-
-    Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("partnerJobs", id);
-    if (!subflowEntry.containsKey("activitiesJobWeeklySchedule[]")) {
-      return;
+    public PartnerSetJobWeeklyScheduleGroup(MessageSource messageSource) {
+        this.messageSource = messageSource;
     }
 
-    var weeklySchedule = new ArrayList<>((List<String>) subflowEntry.get("activitiesJobWeeklySchedule[]"));
-    var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
-    String firstDay = null, lastDay = null;
-    Locale locale = LocaleContextHolder.getLocale();
+    @Override
+    public void run(Submission submission, String id) {
 
-    Iterator<String> iter = WEEKDAYS.iterator();
-    while (iter.hasNext() && !weeklySchedule.isEmpty()) {
-      String day = iter.next();
-      if (weeklySchedule.remove(day)) {
-        if (firstDay == null) {
-          firstDay = messageSource.getMessage("general.week." + day, null, locale);
-        } else {
-          lastDay = messageSource.getMessage("general.week." + day, null, locale);
+        Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("partnerJobs", id);
+        if (!subflowEntry.containsKey("activitiesJobWeeklySchedule[]")) {
+            return;
         }
-      } else if (firstDay != null) {
-        var displayDays = formatWeekdaysSeparated(sortedDays, locale);
-        subflowEntry.put(DISPLAY_LABEL, displayDays);
-        return;
-      }
+
+        var weeklySchedule = new ArrayList<>((List<String>) subflowEntry.get("activitiesJobWeeklySchedule[]"));
+        var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
+        String firstDay = null, lastDay = null;
+        Locale locale = LocaleContextHolder.getLocale();
+
+        Iterator<String> iter = WEEKDAYS.iterator();
+        while (iter.hasNext() && !weeklySchedule.isEmpty()) {
+            String day = iter.next();
+            if (weeklySchedule.remove(day)) {
+                if (firstDay == null) {
+                    firstDay = messageSource.getMessage("general.week." + day, null, locale);
+                } else {
+                    lastDay = messageSource.getMessage("general.week." + day, null, locale);
+                }
+            } else if (firstDay != null) {
+                var displayDays = formatWeekdaysSeparated(sortedDays, locale);
+                subflowEntry.put(DISPLAY_LABEL, displayDays);
+                return;
+            }
+        }
+
+        subflowEntry.put(DISPLAY_LABEL, lastDay == null ? firstDay
+                : messageSource.getMessage("general.week.day-range", new Object[]{firstDay, lastDay},
+                        LocaleContextHolder.getLocale()));
+
     }
 
-    subflowEntry.put(DISPLAY_LABEL, lastDay == null ? firstDay : "%s-%s".formatted(firstDay, lastDay));
-
-  }
-
-  private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
-    return sortedDays.stream()
-        .map(d -> messageSource.getMessage("general.week." + d, null, locale))
-        .collect(Collectors.joining(", "));
-  }
+    private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
+        return sortedDays.stream()
+                .map(d -> messageSource.getMessage("general.week." + d, null, locale))
+                .collect(Collectors.joining(", "));
+    }
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/SetJobWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetJobWeeklyScheduleGroup.java
@@ -14,52 +14,55 @@ import java.util.stream.Collectors;
 @Component
 public class SetJobWeeklyScheduleGroup implements Action {
 
-  private final MessageSource messageSource;
+    private final MessageSource messageSource;
 
-  public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
+    public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+            "Sunday");
 
-  public static final String DISPLAY_LABEL = "displayWeeklySchedule";
+    public static final String DISPLAY_LABEL = "displayWeeklySchedule";
 
-  public SetJobWeeklyScheduleGroup(MessageSource messageSource) {
-    this.messageSource = messageSource;
-  }
-
-  @Override
-  public void run(Submission submission, String id) {
-
-    Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("jobs", id);
-    if (!subflowEntry.containsKey("activitiesJobWeeklySchedule[]")) {
-      return;
+    public SetJobWeeklyScheduleGroup(MessageSource messageSource) {
+        this.messageSource = messageSource;
     }
 
-    var weeklySchedule = new ArrayList<>((List<String>) subflowEntry.get("activitiesJobWeeklySchedule[]"));
-    var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
-    String firstDay = null, lastDay = null;
-    Locale locale = LocaleContextHolder.getLocale();
+    @Override
+    public void run(Submission submission, String id) {
 
-    Iterator<String> iter = WEEKDAYS.iterator();
-    while (iter.hasNext() && !weeklySchedule.isEmpty()) {
-      String day = iter.next();
-      if (weeklySchedule.remove(day)) {
-        if (firstDay == null) {
-          firstDay = messageSource.getMessage("general.week." + day, null, locale);
-        } else {
-          lastDay = messageSource.getMessage("general.week." + day, null, locale);
+        Map<String, Object> subflowEntry = submission.getSubflowEntryByUuid("jobs", id);
+        if (!subflowEntry.containsKey("activitiesJobWeeklySchedule[]")) {
+            return;
         }
-      } else if (firstDay != null) {
-        var displayDays = formatWeekdaysSeparated(sortedDays, locale);
-        subflowEntry.put(DISPLAY_LABEL, displayDays);
-        return;
-      }
+
+        var weeklySchedule = new ArrayList<>((List<String>) subflowEntry.get("activitiesJobWeeklySchedule[]"));
+        var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
+        String firstDay = null, lastDay = null;
+        Locale locale = LocaleContextHolder.getLocale();
+
+        Iterator<String> iter = WEEKDAYS.iterator();
+        while (iter.hasNext() && !weeklySchedule.isEmpty()) {
+            String day = iter.next();
+            if (weeklySchedule.remove(day)) {
+                if (firstDay == null) {
+                    firstDay = messageSource.getMessage("general.week." + day, null, locale);
+                } else {
+                    lastDay = messageSource.getMessage("general.week." + day, null, locale);
+                }
+            } else if (firstDay != null) {
+                var displayDays = formatWeekdaysSeparated(sortedDays, locale);
+                subflowEntry.put(DISPLAY_LABEL, displayDays);
+                return;
+            }
+        }
+
+        subflowEntry.put(DISPLAY_LABEL, lastDay == null ? firstDay
+                : messageSource.getMessage("general.week.day-range", new Object[]{firstDay, lastDay},
+                        LocaleContextHolder.getLocale()));
+
     }
 
-    subflowEntry.put(DISPLAY_LABEL, lastDay == null ? firstDay : "%s-%s".formatted(firstDay, lastDay));
-
-  }
-
-  private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
-    return sortedDays.stream()
-        .map(d -> messageSource.getMessage("general.week." + d, null, locale))
-        .collect(Collectors.joining(", "));
-  }
+    private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
+        return sortedDays.stream()
+                .map(d -> messageSource.getMessage("general.week." + d, null, locale))
+                .collect(Collectors.joining(", "));
+    }
 }

--- a/src/main/java/org/ilgcc/app/submission/actions/SetSubflowWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetSubflowWeeklyScheduleGroup.java
@@ -9,7 +9,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
@@ -71,7 +70,9 @@ public class SetSubflowWeeklyScheduleGroup implements Action {
             }
         }
 
-        iterationData.put(DISPLAY_LABEL, lastDay == null ? firstDay : "%s-%s".formatted(firstDay, lastDay));
+        iterationData.put(DISPLAY_LABEL, lastDay == null ? firstDay
+                : messageSource.getMessage("general.week.day-range", new Object[]{firstDay, lastDay},
+                        LocaleContextHolder.getLocale()));
     }
 
     private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {

--- a/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/SetWeeklyScheduleGroup.java
@@ -15,62 +15,65 @@ import java.util.stream.Collectors;
 @Slf4j
 public abstract class SetWeeklyScheduleGroup implements Action {
 
-  public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday");
-  public static final String DISPLAY_LABEL = "displayWeeklySchedule";
-  private final MessageSource messageSource;
+    public static final List<String> WEEKDAYS = List.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+            "Sunday");
+    public static final String DISPLAY_LABEL = "displayWeeklySchedule";
+    private final MessageSource messageSource;
 
-  public SetWeeklyScheduleGroup(MessageSource messageSource) {
-    this.messageSource = messageSource;
-  }
-
-  protected abstract List<String> getWeeklySchedule(Submission submission);
-
-  protected abstract List<String> getWeeklySchedule(Submission submission, String id);
-
-  @Override
-  public void run(Submission submission) {
-    var weeklySchedule = getWeeklySchedule(submission);
-    setFormattedDisplayGroup(submission, weeklySchedule);
-  }
-
-  @Override
-  public void run(Submission submission, String id) {
-    var weeklySchedule = getWeeklySchedule(submission, id);
-    setFormattedDisplayGroup(submission, weeklySchedule);
-  }
-
-  private void setFormattedDisplayGroup(Submission submission, List<String> weeklySchedule) {
-    if (weeklySchedule == null) {
-      return;
+    public SetWeeklyScheduleGroup(MessageSource messageSource) {
+        this.messageSource = messageSource;
     }
 
-    Map<String, Object> inputData = submission.getInputData();
-    var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
-    String firstDay = null, lastDay = null;
-    Locale locale = LocaleContextHolder.getLocale();
+    protected abstract List<String> getWeeklySchedule(Submission submission);
 
-    Iterator<String> iter = WEEKDAYS.iterator();
-    while (iter.hasNext() && !weeklySchedule.isEmpty()) {
-      String day = iter.next();
-      if (weeklySchedule.remove(day)) {
-        if (firstDay == null) {
-          firstDay = messageSource.getMessage("general.week." + day, null, locale);
-        } else {
-          lastDay = messageSource.getMessage("general.week." + day, null, locale);
+    protected abstract List<String> getWeeklySchedule(Submission submission, String id);
+
+    @Override
+    public void run(Submission submission) {
+        var weeklySchedule = getWeeklySchedule(submission);
+        setFormattedDisplayGroup(submission, weeklySchedule);
+    }
+
+    @Override
+    public void run(Submission submission, String id) {
+        var weeklySchedule = getWeeklySchedule(submission, id);
+        setFormattedDisplayGroup(submission, weeklySchedule);
+    }
+
+    private void setFormattedDisplayGroup(Submission submission, List<String> weeklySchedule) {
+        if (weeklySchedule == null) {
+            return;
         }
-      } else if (firstDay != null) {
-        var displayDays = formatWeekdaysSeparated(sortedDays, locale);
-        inputData.put(DISPLAY_LABEL, displayDays);
-        return;
-      }
+
+        Map<String, Object> inputData = submission.getInputData();
+        var sortedDays = WEEKDAYS.stream().filter(weeklySchedule::contains).toList();
+        String firstDay = null, lastDay = null;
+        Locale locale = LocaleContextHolder.getLocale();
+
+        Iterator<String> iter = WEEKDAYS.iterator();
+        while (iter.hasNext() && !weeklySchedule.isEmpty()) {
+            String day = iter.next();
+            if (weeklySchedule.remove(day)) {
+                if (firstDay == null) {
+                    firstDay = messageSource.getMessage("general.week." + day, null, locale);
+                } else {
+                    lastDay = messageSource.getMessage("general.week." + day, null, locale);
+                }
+            } else if (firstDay != null) {
+                var displayDays = formatWeekdaysSeparated(sortedDays, locale);
+                inputData.put(DISPLAY_LABEL, displayDays);
+                return;
+            }
+        }
+
+        inputData.put(DISPLAY_LABEL, lastDay == null ? firstDay
+                : messageSource.getMessage("general.week.day-range", new Object[]{firstDay, lastDay},
+                        LocaleContextHolder.getLocale()));
     }
 
-    inputData.put(DISPLAY_LABEL, lastDay == null ? firstDay : "%s-%s".formatted(firstDay, lastDay));
-  }
-
-  private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
-    return sortedDays.stream()
-        .map(d -> messageSource.getMessage("general.week." + d, null, locale))
-        .collect(Collectors.joining(", "));
-  }
+    private String formatWeekdaysSeparated(List<String> sortedDays, Locale locale) {
+        return sortedDays.stream()
+                .map(d -> messageSource.getMessage("general.week." + d, null, locale))
+                .collect(Collectors.joining(", "));
+    }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -82,6 +82,7 @@ general.week.Friday=Friday
 general.week.Saturday=Saturday
 general.week.Sunday=Sunday
 general.week.All=All days
+general.week.day-range={0} through {1}
 
 general.hours.0.minutes=0 minutes
 general.hours.30.minutes=30 minutes

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -74,15 +74,15 @@ general.question.their-first-name=¿Cuál es su nombre?
 general.question.their-last-name=¿Cuál es su apellido?
 general.question.their-date-of-birth=¿Cuál es su fecha de nacimiento?
 
-general.week.Monday=Lunes
-general.week.Tuesday=Martes
-general.week.Wednesday=Miércoles
-general.week.Thursday=Jueves
-general.week.Friday=Viernes
-general.week.Saturday=Sábado
-general.week.Sunday=Domingo
+general.week.Monday=lunes
+general.week.Tuesday=martes
+general.week.Wednesday=miércoles
+general.week.Thursday=jueves
+general.week.Friday=viernes
+general.week.Saturday=sábado
+general.week.Sunday=domingo
 general.week.All=Todos los días
-general.week.day-range={0} a {1}
+general.week.day-range=De {0} a {1}
 
 general.hours.0.minutes=0 minutos
 general.hours.30.minutes=30 minutos

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -74,14 +74,16 @@ general.question.their-first-name=¿Cuál es su nombre?
 general.question.their-last-name=¿Cuál es su apellido?
 general.question.their-date-of-birth=¿Cuál es su fecha de nacimiento?
 
-general.week.Monday=lunes
-general.week.Tuesday=martes
-general.week.Wednesday=miércoles
-general.week.Thursday=jueves
-general.week.Friday=viernes
-general.week.Saturday=sábado
-general.week.Sunday=domingo
+general.week.Monday=Lunes
+general.week.Tuesday=Martes
+general.week.Wednesday=Miércoles
+general.week.Thursday=Jueves
+general.week.Friday=Viernes
+general.week.Saturday=Sábado
+general.week.Sunday=Domingo
 general.week.All=Todos los días
+general.week.day-range={0} a {1}
+
 
 general.hours.0.minutes=0 minutos
 general.hours.30.minutes=30 minutos
@@ -95,8 +97,8 @@ general.language.tagalog=Tagalog
 general.language.polish=Polski
 general.other=Otro
 
-general.hour=hora
-general.minute=minuto
+general.hour=Hora
+general.minute=Minuto
 general.amOrPM=AM o PM
 general.locked-submission=Esta solicitud ya se ha enviado. Para proteger sus datos, no podrá regresar o editar su información.
 

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -84,7 +84,6 @@ general.week.Sunday=Domingo
 general.week.All=Todos los días
 general.week.day-range={0} a {1}
 
-
 general.hours.0.minutes=0 minutos
 general.hours.30.minutes=30 minutos
 general.hours.1.hour=1 hora
@@ -2038,7 +2037,8 @@ schedules-review.title=Detalles del cuidado
 schedules-review.header=Detalles del cuidado
 schedules-review.body=<p><strong>Revise con atención y asegúrese de que la información ingresada sea correcta.</strong> Verifique los horarios de atención de su(s) proveedor(es).</p><p>El horario que aparece a continuación se enviará a su(s) proveedor(es) de cuidado de niños como parte de su solicitud.</p>
 schedules-review.start-date=Fecha de inicio: {0}
-schedules-review.edit=Editar detalles
+schedules-review.edit-schedule=Editar el horario
+schedules-review.edit-providers=Aggregar/borrar proveedores
 
 schedules-review.no-provider.body=<p><strong>Revise con atención y asegúrese de que la información que ingresó sea correcta.</strong>El horario que aparece a continuación se enviará junto con su solicitud.</p>
 schedules-review.no-provider=Proveedor no seleccionado

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -705,7 +705,7 @@ ul.list--bulleted ul.list--bulleted.list--sublist li {
 .bottom-border {
   border-bottom: #AAAAAA;
   border-bottom-style: solid;
-  padding-top: 30px;
+  padding-top: 15px;
 }
 
 .form-question-stack {

--- a/src/main/resources/templates/fragments/inputs/timeRange.html
+++ b/src/main/resources/templates/fragments/inputs/timeRange.html
@@ -2,7 +2,7 @@
         th:fragment="timeRange"
         th:with="
     hasHelpText=${!#strings.isEmpty(helpText)},
-    dayLegendId=${startInputName + '-legend'},
+    dayLegendId=${startInputName + '-day-legend'},
     hasLabel=${!#strings.isEmpty(label)},
     hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
     requiredInputsForFlow=${requiredInputs.get(flow)},
@@ -16,7 +16,7 @@
                   th:text="#{general.required-field}"></span>
         </legend>
 
-        <fieldset th:with="startTimeLegendId=${startInputName + '-legend'}">
+        <fieldset th:with="startTimeLegendId=${startInputName + '-start-time-legend'}">
             <legend th:id="${startTimeLegendId}"
                    th:text="#{general.inputs.time.range.start}"
                    class="form-question"></legend>
@@ -25,10 +25,10 @@
                     th:replace="~{fragments/inputError :: validationError(inputName=${startInputName})}"></th:block>
             <th:block th:replace="~{fragments/inputs/timeSelect :: timeSelect(
                               inputGroupName=${startInputName},
-                              ariaDescribedBy=${startTimeLegendId + ' ' + dayLegendId})}"></th:block>
+                              ariaDescribedBy=${dayLegendId + ' ' + startTimeLegendId})}"></th:block>
         </fieldset>
 
-        <fieldset th:with="endTimeLegendId=${endInputName + '-legend'}">
+        <fieldset th:with="endTimeLegendId=${endInputName + '-end-time-legend'}">
             <legend th:id="${endTimeLegendId}"
                    th:text="#{general.inputs.time.range.end}"
                    class="form-question"></legend>
@@ -37,7 +37,7 @@
                     th:replace="~{fragments/inputError :: validationError(inputName=${endInputName})}"></th:block>
             <th:block th:replace="~{fragments/inputs/timeSelect :: timeSelect(
                               inputGroupName=${endInputName},
-                              ariaDescribedBy=${endTimeLegendId + ' ' + dayLegendId})}"></th:block>
+                              ariaDescribedBy=${dayLegendId + ' ' + endTimeLegendId})}"></th:block>
         </fieldset>
     </fieldset>
 </th:block>

--- a/src/main/resources/templates/fragments/inputs/timeRange.html
+++ b/src/main/resources/templates/fragments/inputs/timeRange.html
@@ -1,38 +1,43 @@
 <th:block
         th:fragment="timeRange"
         th:with="
-          hasHelpText=${!#strings.isEmpty(helpText)},
-          dayLabelId=${startInputName + '-legend'},
-          hasLabel=${!#strings.isEmpty(label)},
-          hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
-            requiredInputsForFlow=${requiredInputs.get(flow)},
-            isRequiredInput=${(requiredInputsForFlow != null && inputName != null && requiredInputsForFlow.getOrDefault(inputName, false)) || (required != null && required)}"
+    hasHelpText=${!#strings.isEmpty(helpText)},
+    dayLegendId=${startInputName + '-legend'},
+    hasLabel=${!#strings.isEmpty(label)},
+    hasAriaLabel=${!#strings.isEmpty(ariaLabel)},
+    requiredInputsForFlow=${requiredInputs.get(flow)},
+    isRequiredInput=${(requiredInputsForFlow != null && inputName != null && requiredInputsForFlow.getOrDefault(inputName, false)) || (required != null && required)}"
         th:assert="${!#strings.isEmpty(startInputName)},${!#strings.isEmpty(endInputName)}, ${hasLabel || hasAriaLabel}">
-    <div th:class="'form-group bottom-border'">
-        <legend class="heading-35 spacing-below-15"
-                th:id="${dayLabelId}"
-                th:inline="text">
+
+    <fieldset class="form-group bottom-border" th:attr="aria-labelledby=${dayLegendId}">
+        <legend class="heading-35 spacing-below-0" th:id="${dayLegendId}" th:inline="text">
             <span th:text="${label}"></span>
             <span th:if="${isRequiredInput && !hasAriaLabel}" class="required-input"
                   th:text="#{general.required-field}"></span>
         </legend>
-        <div th:with="startTimeLabelId=${startInputName + '-label'}">
-            <label th:for="${startInputName}" th:id="${startTimeLabelId}"
+
+        <fieldset th:with="startTimeLegendId=${startInputName + '-legend'}">
+            <legend th:id="${startTimeLegendId}"
                    th:text="#{general.inputs.time.range.start}"
-                   class="form-question"/>
+                   class="form-question"></legend>
+
             <th:block
                     th:replace="~{fragments/inputError :: validationError(inputName=${startInputName})}"></th:block>
-            <th:block
-                    th:replace="~{fragments/inputs/timeSelect :: timeSelect(inputGroupName=${startInputName}, ariaDescribedBy=${startTimeLabelId+' ' + dayLabelId})}"/>
-        </div>
-        <div th:with="endTimeLabelId=${endInputName + '-label'}">
-            <label th:for="${endInputName}" th:id="${endTimeLabelId}"
+            <th:block th:replace="~{fragments/inputs/timeSelect :: timeSelect(
+                              inputGroupName=${startInputName},
+                              ariaDescribedBy=${startTimeLegendId + ' ' + dayLegendId})}"></th:block>
+        </fieldset>
+
+        <fieldset th:with="endTimeLegendId=${endInputName + '-legend'}">
+            <legend th:id="${endTimeLegendId}"
                    th:text="#{general.inputs.time.range.end}"
-                   class="form-question"/>
+                   class="form-question"></legend>
+
             <th:block
                     th:replace="~{fragments/inputError :: validationError(inputName=${endInputName})}"></th:block>
-            <th:block
-                    th:replace="~{fragments/inputs/timeSelect :: timeSelect(inputGroupName=${endInputName}, ariaDescribedBy=${endTimeLabelId+' ' + dayLabelId})}"/>
-        </div>
-    </div>
+            <th:block th:replace="~{fragments/inputs/timeSelect :: timeSelect(
+                              inputGroupName=${endInputName},
+                              ariaDescribedBy=${endTimeLegendId + ' ' + dayLegendId})}"></th:block>
+        </fieldset>
+    </fieldset>
 </th:block>

--- a/src/main/resources/templates/fragments/inputs/timeSelect.html
+++ b/src/main/resources/templates/fragments/inputs/timeSelect.html
@@ -12,14 +12,14 @@
                 <div class="steps-box spacing-below-35">
                     <div class="form-question-stack">
                         <div class="form-question-vertical-align">
-                            <label th:for="${hourInputName}"
+                            <label th:for="${hourInputName + '-select'}"
                                    th:text="#{'general.hour'}"
-                                   th:id="${hourInputName}"
+                                   th:id="${hourInputName + '-label'}"
                                    th:class="spacing-below-5"
                             ></label>
                             <div class="select">
                                 <select class="select__element"
-                                        th:id="${hourInputName}"
+                                        th:id="${hourInputName + '-select'}"
                                         th:name="${hourInputName}"
                                         th:attr="aria-describedby=${hasAriaDescribedByLabel ? hourInputName + ' ' + ariaDescribedBy : 'hourInputName'}">
                                     <option value="" selected disabled hidden></option>
@@ -34,15 +34,15 @@
                     </div>
                     <div class="form-question-stack">
                         <div class="form-question-vertical-align">
-                            <label th:for="${minuteInputName}"
+                            <label th:for="${minuteInputName + '-input'}"
                                    th:text="#{'general.minute'}"
-                                   th:id="${minuteInputName}"
+                                   th:id="${minuteInputName + '-label'}"
                                    th:class="spacing-below-5"
                             ></label>
                             <input type="text" class="time-input"
                                    inputmode="numeric"
                                    minlength="1" maxlength="2"
-                                   th:id="${minuteInputName}"
+                                   th:id="${minuteInputName + '-input'}"
                                    th:name="${minuteInputName}"
                                    th:place
                                    th:attr="aria-describedby=${hasAriaDescribedByLabel ? minuteInputName+ ' ' + ariaDescribedBy : minuteInputName}"
@@ -51,14 +51,14 @@
                     </div>
                     <div class="form-question-stack">
                         <div class="form-question-vertical-align">
-                            <label th:for="${amPmInputName}"
+                            <label th:for="${amPmInputName + '-select'}"
                                    th:text="#{'general.amOrPM'}"
-                                   th:id="${amPmInputName}"
+                                   th:id="${amPmInputName + '-label'}"
                                    th:class="spacing-below-5"
                             ></label>
                             <div class="select">
                                 <select class="select__element"
-                                        th:id="${amPmInputName}"
+                                        th:id="${amPmInputName + '-select'}"
                                         th:name="${amPmInputName}"
                                         th:attr="aria-describedby=${hasAriaDescribedByLabel ? amPmInputName + ' ' + ariaDescribedBy : amPmInputName}">
                                     <option value="" selected disabled hidden></option>

--- a/src/main/resources/templates/fragments/inputs/timeSelect.html
+++ b/src/main/resources/templates/fragments/inputs/timeSelect.html
@@ -6,76 +6,73 @@
         th:assert="
           ${hasGroupName}">
     <div th:class="'question-group'">
-        <fieldset th:id="${inputGroupName}">
-            <th:block
-                    th:with="hourInputName=${inputGroupName+'Hour'}, minuteInputName=${inputGroupName+'Minute'}, amPmInputName=${inputGroupName+'AmPm'}">
-                <div class="steps-box spacing-below-35">
-                    <div class="form-question-stack">
-                        <div class="form-question-vertical-align">
-                            <label th:for="${hourInputName + '-select'}"
-                                   th:text="#{'general.hour'}"
-                                   th:id="${hourInputName + '-label'}"
-                                   th:class="spacing-below-5"
-                            ></label>
-                            <div class="select">
-                                <select class="select__element"
-                                        th:id="${hourInputName + '-select'}"
-                                        th:name="${hourInputName}"
-                                        th:attr="aria-describedby=${hasAriaDescribedByLabel ? hourInputName + ' ' + ariaDescribedBy : 'hourInputName'}">
-                                    <option value="" selected disabled hidden></option>
+        <th:block
+                th:with="hourInputName=${inputGroupName+'Hour'}, minuteInputName=${inputGroupName+'Minute'}, amPmInputName=${inputGroupName+'AmPm'}">
+            <div class="steps-box spacing-below-35">
+                <div class="form-question-stack">
+                    <div class="form-question-vertical-align">
+                        <label th:for="${hourInputName + '-select'}"
+                               th:text="#{'general.hour'}"
+                               th:id="${hourInputName + '-label'}"
+                               th:class="spacing-below-5"
+                        ></label>
+                        <div class="select">
+                            <select class="select__element"
+                                    th:id="${hourInputName + '-select'}"
+                                    th:name="${hourInputName}"
+                                    th:attr="aria-describedby=${hasAriaDescribedByLabel ? ariaDescribedBy : 'hourInputName'}">
+                                <option value="" selected disabled hidden></option>
+                                <th:block
+                                        th:each="hour : ${T(org.ilgcc.app.utils.HourSelectOption).values()}">
                                     <th:block
-                                            th:each="hour : ${T(org.ilgcc.app.utils.HourSelectOption).values()}">
-                                        <th:block
-                                                th:replace="~{fragments/inputs/selectOption :: selectOption(value=${hour.getLabel()}, optionText=${hour.getLabel()}, inputName=${hourInputName})}"/>
-                                    </th:block>
-                                </select>
-                            </div>
+                                            th:replace="~{fragments/inputs/selectOption :: selectOption(value=${hour.getLabel()}, optionText=${hour.getLabel()}, inputName=${hourInputName})}"/>
+                                </th:block>
+                            </select>
                         </div>
-                    </div>
-                    <div class="form-question-stack">
-                        <div class="form-question-vertical-align">
-                            <label th:for="${minuteInputName + '-input'}"
-                                   th:text="#{'general.minute'}"
-                                   th:id="${minuteInputName + '-label'}"
-                                   th:class="spacing-below-5"
-                            ></label>
-                            <input type="text" class="time-input"
-                                   inputmode="numeric"
-                                   minlength="1" maxlength="2"
-                                   th:id="${minuteInputName + '-input'}"
-                                   th:name="${minuteInputName}"
-                                   th:place
-                                   th:attr="aria-describedby=${hasAriaDescribedByLabel ? minuteInputName+ ' ' + ariaDescribedBy : minuteInputName}"
-                                   th:value="${fieldData.getOrDefault(minuteInputName, '00')}">
-                        </div>
-                    </div>
-                    <div class="form-question-stack">
-                        <div class="form-question-vertical-align">
-                            <label th:for="${amPmInputName + '-select'}"
-                                   th:text="#{'general.amOrPM'}"
-                                   th:id="${amPmInputName + '-label'}"
-                                   th:class="spacing-below-5"
-                            ></label>
-                            <div class="select">
-                                <select class="select__element"
-                                        th:id="${amPmInputName + '-select'}"
-                                        th:name="${amPmInputName}"
-                                        th:attr="aria-describedby=${hasAriaDescribedByLabel ? amPmInputName + ' ' + ariaDescribedBy : amPmInputName}">
-                                    <option value="" selected disabled hidden></option>
-                                    <th:block
-                                            th:each="amPM : ${T(org.ilgcc.app.utils.AmPmSelectOption).values()}">
-                                        <th:block
-                                                th:replace="~{fragments/inputs/selectOption :: selectOption(value=${amPM.toString()}, optionText=${amPM.toString()}, inputName=${amPmInputName})}"/>
-                                    </th:block>
-                                </select>
-                            </div>
-                        </div>
-
                     </div>
                 </div>
+                <div class="form-question-stack">
+                    <div class="form-question-vertical-align">
+                        <label th:for="${minuteInputName + '-input'}"
+                               th:text="#{'general.minute'}"
+                               th:id="${minuteInputName + '-label'}"
+                               th:class="spacing-below-5"
+                        ></label>
+                        <input type="text" class="time-input"
+                               inputmode="numeric"
+                               minlength="1" maxlength="2"
+                               th:id="${minuteInputName + '-input'}"
+                               th:name="${minuteInputName}"
+                               th:place
+                               th:attr="aria-describedby=${hasAriaDescribedByLabel ? ariaDescribedBy : minuteInputName}"
+                               th:value="${fieldData.getOrDefault(minuteInputName, '00')}">
+                    </div>
+                </div>
+                <div class="form-question-stack">
+                    <div class="form-question-vertical-align">
+                        <label th:for="${amPmInputName + '-select'}"
+                               th:text="#{'general.amOrPM'}"
+                               th:id="${amPmInputName + '-label'}"
+                               th:class="spacing-below-5"
+                        ></label>
+                        <div class="select">
+                            <select class="select__element"
+                                    th:id="${amPmInputName + '-select'}"
+                                    th:name="${amPmInputName}"
+                                    th:attr="aria-describedby=${hasAriaDescribedByLabel ? ariaDescribedBy : amPmInputName}">
+                                <option value="" selected disabled hidden></option>
+                                <th:block
+                                        th:each="amPM : ${T(org.ilgcc.app.utils.AmPmSelectOption).values()}">
+                                    <th:block
+                                            th:replace="~{fragments/inputs/selectOption :: selectOption(value=${amPM.toString()}, optionText=${amPM.toString()}, inputName=${amPmInputName})}"/>
+                                </th:block>
+                            </select>
+                        </div>
+                    </div>
 
-            </th:block>
-        </fieldset>
+                </div>
+            </div>
 
+        </th:block>
     </div>
 </th:block>

--- a/src/test/java/org/ilgcc/app/submission/actions/SetClassWeeklyScheduleGroupTest.java
+++ b/src/test/java/org/ilgcc/app/submission/actions/SetClassWeeklyScheduleGroupTest.java
@@ -1,6 +1,13 @@
 package org.ilgcc.app.submission.actions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 import formflow.library.data.Submission;
+import java.util.List;
+import java.util.stream.Stream;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -8,14 +15,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.springframework.context.MessageSource;
-
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 class SetClassWeeklyScheduleGroupTest {
 
@@ -28,6 +27,12 @@ class SetClassWeeklyScheduleGroupTest {
 
     Stream.of("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
         .forEach(d -> when(messageSource.getMessage(eq("general.week." + d), any(), any())).thenReturn(d));
+
+      when(messageSource.getMessage(eq("general.week.day-range"), any(), any()))
+              .thenAnswer(methodCalled -> {
+                  Object[] args = methodCalled.getArgument(1, Object[].class);
+                  return args[0] + " through " + args[1]; // e.g., "Monday through Friday"
+              });
   }
 
   @ParameterizedTest
@@ -65,10 +70,10 @@ class SetClassWeeklyScheduleGroupTest {
 
   private static Stream<Arguments> consecutiveDaysArgs() {
     return Stream.of(
-        Arguments.of(List.of("Monday", "Tuesday", "Wednesday"), "Monday-Wednesday"),
-        Arguments.of(List.of("Wednesday", "Thursday", "Friday", "Saturday"), "Wednesday-Saturday"),
-        Arguments.of(List.of("Friday", "Saturday", "Sunday"), "Friday-Sunday"),
-        Arguments.of(List.of("Tuesday", "Wednesday"), "Tuesday-Wednesday")
+        Arguments.of(List.of("Monday", "Tuesday", "Wednesday"), "Monday through Wednesday"),
+        Arguments.of(List.of("Wednesday", "Thursday", "Friday", "Saturday"), "Wednesday through Saturday"),
+        Arguments.of(List.of("Friday", "Saturday", "Sunday"), "Friday through Sunday"),
+        Arguments.of(List.of("Tuesday", "Wednesday"), "Tuesday through Wednesday")
     );
   }
 
@@ -84,9 +89,9 @@ class SetClassWeeklyScheduleGroupTest {
   private static Stream<Arguments> unsortedDays() {
     return Stream.of(
         Arguments.of(List.of("Friday", "Wednesday"), "Wednesday, Friday"),
-        Arguments.of(List.of("Wednesday", "Thursday", "Tuesday"), "Tuesday-Thursday"),
-        Arguments.of(List.of("Sunday", "Saturday", "Friday"), "Friday-Sunday"),
-        Arguments.of(List.of("Tuesday", "Monday"), "Monday-Tuesday")
+        Arguments.of(List.of("Wednesday", "Thursday", "Tuesday"), "Tuesday through Thursday"),
+        Arguments.of(List.of("Sunday", "Saturday", "Friday"), "Friday through Sunday"),
+        Arguments.of(List.of("Tuesday", "Monday"), "Monday through Tuesday")
     );
   }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1318, CCAP-1319

#### ✍️ Description
CCAP-1318 - For all places where we collect schedule data with hours/minutes/AM-PM inputs, the html id attributes need to be unique.

CCAP-1319 - Legend fields should be inside the fieldset tags instead of outside.

#### Manual Testing

Tested using WebAim WAVE Accessibility plugin

**Fieldset / Legend Issues Before**

<img width="1905" height="923" alt="Screenshot 2025-09-02 at 3 49 29 PM" src="https://github.com/user-attachments/assets/9a3d94f6-fc2c-470d-9d9e-9419f67c21ec" />


**Fieldset / Legend Issues After**

<img width="1912" height="933" alt="Screenshot 2025-09-02 at 3 44 10 PM" src="https://github.com/user-attachments/assets/121168af-40b3-4c09-a751-92599c5c7c0b" />

We go from 27 reported issues to 3 non-related / not actual issues. 

** Unique IDs**

<img width="1916" height="501" alt="Screenshot 2025-09-02 at 3 52 51 PM" src="https://github.com/user-attachments/assets/b2813781-da42-4fae-85a4-cc675543e961" />
