### PR TITLE
Ccap 868 inform provider when response has already been sent

### DIFF
--- a/src/main/java/org/ilgcc/app/submission/actions/ProviderResponseIsAfterThreeDayWindow.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ProviderResponseIsAfterThreeDayWindow.java
@@ -1,6 +1,5 @@
 package org.ilgcc.app.submission.actions;
 
-import formflow.library.config.submission.Action;
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
@@ -10,7 +9,7 @@ import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 
 
 public class ProviderResponseIsAfterThreeDayWindow implements Condition {
-  private final SubmissionRepositoryService submissionRepositoryService;
+  SubmissionRepositoryService submissionRepositoryService;
 
   public ProviderResponseIsAfterThreeDayWindow(SubmissionRepositoryService submissionRepositoryService) {
       this.submissionRepositoryService = submissionRepositoryService;

--- a/src/main/java/org/ilgcc/app/submission/actions/ProviderResponseIsAfterThreeDayWindow.java
+++ b/src/main/java/org/ilgcc/app/submission/actions/ProviderResponseIsAfterThreeDayWindow.java
@@ -1,0 +1,29 @@
+package org.ilgcc.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
+import java.util.Optional;
+import java.util.UUID;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
+
+
+public class ProviderResponseIsAfterThreeDayWindow implements Condition {
+  private final SubmissionRepositoryService submissionRepositoryService;
+
+  public ProviderResponseIsAfterThreeDayWindow(SubmissionRepositoryService submissionRepositoryService) {
+      this.submissionRepositoryService = submissionRepositoryService;
+  }
+
+  @Override
+  public Boolean run(Submission providerSubmission){
+    Optional<UUID> familySubmissionId = ProviderSubmissionUtilities.getFamilySubmissionId(providerSubmission);
+    if (familySubmissionId.isPresent()) {
+      //Placeholder
+      return false;
+    }
+    //Placeholder
+    return false;
+  }
+}

--- a/src/main/java/org/ilgcc/app/submission/conditions/ProviderResponseIsAfterThreeDayWindow.java
+++ b/src/main/java/org/ilgcc/app/submission/conditions/ProviderResponseIsAfterThreeDayWindow.java
@@ -1,13 +1,15 @@
-package org.ilgcc.app.submission.actions;
+package org.ilgcc.app.submission.conditions;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepositoryService;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
 import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 
-
+@Slf4j
 public class ProviderResponseIsAfterThreeDayWindow implements Condition {
   SubmissionRepositoryService submissionRepositoryService;
 
@@ -19,10 +21,14 @@ public class ProviderResponseIsAfterThreeDayWindow implements Condition {
   public Boolean run(Submission providerSubmission){
     Optional<UUID> familySubmissionId = ProviderSubmissionUtilities.getFamilySubmissionId(providerSubmission);
     if (familySubmissionId.isPresent()) {
-      //Placeholder
+      Optional<Submission> familySubmissionOptional = submissionRepositoryService.findById(familySubmissionId.get());
+      AtomicBoolean familySubmissionIsAfterThreeDays = new AtomicBoolean(false);
+      familySubmissionOptional.ifPresent(familySubmission -> {
+        familySubmissionIsAfterThreeDays.set(ProviderSubmissionUtilities.providerApplicationHasExpired(familySubmission));
+      });
+      return familySubmissionIsAfterThreeDays.get();
+    }else{
       return false;
     }
-    //Placeholder
-    return false;
   }
 }

--- a/src/test/java/org/ilgcc/app/submission/conditions/ProviderResponseIsAfterThreeDayWindowTest.java
+++ b/src/test/java/org/ilgcc/app/submission/conditions/ProviderResponseIsAfterThreeDayWindowTest.java
@@ -1,22 +1,80 @@
 package org.ilgcc.app.submission.conditions;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepositoryService;
 import java.time.OffsetDateTime;
+import java.util.List;
+import org.ilgcc.app.utils.ProviderSubmissionUtilities;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
 import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
+@SpringBootTest
 class ProviderResponseIsAfterThreeDayWindowTest {
+ @Autowired
+ SubmissionRepositoryService submissionRepositoryService;
+
+  private Submission familySubmission;
+  private Submission providerSubmission;
+  ProviderResponseIsAfterThreeDayWindow providerResponseIsAfterThreeDayWindow;
+
   @Test
   void shouldReturnFalseIfResponseIsBeforeThreeDayWindow() {
-    //build a family submission with a submitted at time
-    //add a provider
-    //add a child and multi-provider schedule
-    //create a provider submission
-    //pass in the provider submission into ProviderResponseIsAfterThreeDayWindowTest
-    Submission familySubmission = new SubmissionTestBuilder()
+    providerResponseIsAfterThreeDayWindow = new ProviderResponseIsAfterThreeDayWindow(submissionRepositoryService);
+    familySubmission = new SubmissionTestBuilder()
         .withParentBasicInfo()
-        .withSubmittedAtDate(OffsetDateTime.now().minusDays(1)).build();
+        .withSubmittedAtDate(ProviderSubmissionUtilities.threeBusinessDaysBeforeDate(OffsetDateTime.now().plusDays(1)))
+        .withChild("First", "Child", "true")
+        .withChild("Second", "Child", "true")
+        .withProvider("DayCareOne", "1")
+        .withMultipleChildcareSchedulesAllBelongingToTheSameProvider(List.of("first-child", "second-child"), "daycareone-1")
+        .build();
+
+    submissionRepositoryService.save(familySubmission);
+
+    providerSubmission = new SubmissionTestBuilder()
+        .withFlow("providerresponse")
+        .with("familySubmissionId", familySubmission.getId().toString())
+        .with("providerResponseFirstName", "ProviderFirst")
+        .with("providerResponseLastName", "ProviderLast")
+        .with("providerResponseBusinessName", "DayCare Place")
+        .with("providerResponseContactPhoneNumber", "(111) 222-3333")
+        .with("providerResponseContactEmail", "mail@daycareplace.org")
+        .with("providerPaidCcap", "true")
+        .with("currentProviderUuid", "daycareone-1")
+        .build();
+    assertThat(providerResponseIsAfterThreeDayWindow.run(providerSubmission)).isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueIfResponseIsAfterThreeDayWindow() {
+    providerResponseIsAfterThreeDayWindow = new ProviderResponseIsAfterThreeDayWindow(submissionRepositoryService);
+    familySubmission = new SubmissionTestBuilder()
+        .withParentBasicInfo()
+        .withSubmittedAtDate(ProviderSubmissionUtilities.threeBusinessDaysBeforeDate(OffsetDateTime.now().minusDays(1)))
+        .withChild("First", "Child", "true")
+        .withChild("Second", "Child", "true")
+        .withProvider("DayCareOne", "1")
+        .withMultipleChildcareSchedulesAllBelongingToTheSameProvider(List.of("first-child", "second-child"), "daycareone-1")
+        .build();
+
+    submissionRepositoryService.save(familySubmission);
+
+    providerSubmission = new SubmissionTestBuilder()
+        .withFlow("providerresponse")
+        .with("familySubmissionId", familySubmission.getId().toString())
+        .with("providerResponseFirstName", "ProviderFirst")
+        .with("providerResponseLastName", "ProviderLast")
+        .with("providerResponseBusinessName", "DayCare Place")
+        .with("providerResponseContactPhoneNumber", "(111) 222-3333")
+        .with("providerResponseContactEmail", "mail@daycareplace.org")
+        .with("providerPaidCcap", "true")
+        .with("currentProviderUuid", "daycareone-1")
+        .build();
+    assertThat(providerResponseIsAfterThreeDayWindow.run(providerSubmission)).isTrue();
   }
 }

--- a/src/test/java/org/ilgcc/app/submission/conditions/ProviderResponseIsAfterThreeDayWindowTest.java
+++ b/src/test/java/org/ilgcc/app/submission/conditions/ProviderResponseIsAfterThreeDayWindowTest.java
@@ -1,0 +1,22 @@
+package org.ilgcc.app.submission.conditions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import formflow.library.data.Submission;
+import java.time.OffsetDateTime;
+import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.junit.jupiter.api.Test;
+
+class ProviderResponseIsAfterThreeDayWindowTest {
+  @Test
+  void shouldReturnFalseIfResponseIsBeforeThreeDayWindow() {
+    //build a family submission with a submitted at time
+    //add a provider
+    //add a child and multi-provider schedule
+    //create a provider submission
+    //pass in the provider submission into ProviderResponseIsAfterThreeDayWindowTest
+    Submission familySubmission = new SubmissionTestBuilder()
+        .withParentBasicInfo()
+        .withSubmittedAtDate(OffsetDateTime.now().minusDays(1)).build();
+  }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-868

#### ✍️ Description

##### Acceptance criteria
- [ ] When a provider is able to start a provider response within the 3 business day period, but the application is sent before they complete, show an error when they get to the submission step

#### 📷 Design reference

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
