### PR TITLE
[CCAP-1344] Add parent-info-review.preferred-name property for prefer…

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -506,7 +506,6 @@ parent-info-review.mailing.address=Mailing Address
 parent-info-review.mailing.address.link=Edit your mailing address
 parent-info-review.contact.info=Contact Info
 parent-info-review.contact.info.link=Edit your contact info
-parent-info-review.preferred.name=preferred name
 #parent-have-a-partner
 parent-have-a-partner.title=Parent Has a Partner
 parent-have-a-partner.header=Do you live with a significant other, partner, or spouse?
@@ -1678,8 +1677,6 @@ registration-household-add-person-delete.title=Remove a person
 registration-household-add-person-delete.header=Are you sure you want to remove {0} from the application?
 registration-household-add-person-delete.button.yes-delete=Yes, remove
 registration-household-add-person-delete.button.no-keep=No, keep them
-
-
 # registration-family-response-intro
 registration-family-response-intro.title=Respond to a family's application
 registration-family-response-intro.box.header=We'll ask about

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -506,7 +506,7 @@ parent-info-review.mailing.address=Mailing Address
 parent-info-review.mailing.address.link=Edit your mailing address
 parent-info-review.contact.info=Contact Info
 parent-info-review.contact.info.link=Edit your contact info
-
+parent-info-review.preferred.name=preferred name
 #parent-have-a-partner
 parent-have-a-partner.title=Parent Has a Partner
 parent-have-a-partner.header=Do you live with a significant other, partner, or spouse?
@@ -1678,6 +1678,7 @@ registration-household-add-person-delete.title=Remove a person
 registration-household-add-person-delete.header=Are you sure you want to remove {0} from the application?
 registration-household-add-person-delete.button.yes-delete=Yes, remove
 registration-household-add-person-delete.button.no-keep=No, keep them
+
 
 # registration-family-response-intro
 registration-family-response-intro.title=Respond to a family's application

--- a/src/main/resources/templates/gcc/parent-info-review.html
+++ b/src/main/resources/templates/gcc/parent-info-review.html
@@ -16,6 +16,8 @@
                             th:text="#{parent-info-review.personal.information}"></strong></p>
                     <ol class="list--bulleted">
                         <li th:text="|${inputData.get('parentFirstName')} ${inputData.get('parentLastName')}|"></li>
+                        <li th:if="${!#strings.isEmpty(inputData.get('parentPreferredName'))}"
+                            th:text="|#{parent-info-review.preferred.name}: ${inputData.get('parentPreferredName')}|"></li>
                         <li th:text="|${inputData.get('parentBirthMonth')}/${inputData.get('parentBirthDay')}/${inputData.get('parentBirthYear')}|"></li>
                     </ol>
                     <a id="edit-parent-info-basic" th:href="|/flow/${flow}/parent-info-basic-1|"

--- a/src/main/resources/templates/gcc/parent-info-review.html
+++ b/src/main/resources/templates/gcc/parent-info-review.html
@@ -17,7 +17,7 @@
                     <ol class="list--bulleted">
                         <li th:text="|${inputData.get('parentFirstName')} ${inputData.get('parentLastName')}|"></li>
                         <li th:if="${!#strings.isEmpty(inputData.get('parentPreferredName'))}"
-                            th:text="|#{parent-info-review.preferred.name}: ${inputData.get('parentPreferredName')}|"></li>
+                            th:utext="${inputData.get('parentPreferredName')}"></li>
                         <li th:text="|${inputData.get('parentBirthMonth')}/${inputData.get('parentBirthDay')}/${inputData.get('parentBirthYear')}|"></li>
                     </ol>
                     <a id="edit-parent-info-basic" th:href="|/flow/${flow}/parent-info-basic-1|"


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1344?

#### ✍️ Description
This PR adds support for displaying an applicant’s preferred name on the parent-info-review screen. If an applicant has provided a preferred name, it will be shown below their legal first and last name. If no preferred name has been provided, the additional line will not be displayed.
<img width="419" height="460" alt="image" src="https://github.com/user-attachments/assets/175c5997-e649-4762-ab0d-957eda8d8a57" />



 📷 Design reference
[<!-- Figma link or screenshot if applicable -->](https://www.figma.com/design/1oRFY7p6tdGogBJk7Ugle8/IL-CCAP-Families-Application?node-id=22417-28656&t=V1qbi5yGQtcjSC5Y-4)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
