### PR TITLE
[CCAP-1289] Add TransactionType to Transaction

### DIFF
--- a/src/main/java/org/ilgcc/app/data/Transaction.java
+++ b/src/main/java/org/ilgcc/app/data/Transaction.java
@@ -2,10 +2,7 @@ package org.ilgcc.app.data;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.UUID;
@@ -15,7 +12,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.ilgcc.app.utils.enums.TransactionType;
 
 
 @Entity
@@ -30,13 +26,12 @@ public class Transaction {
     private UUID transactionId;
     
     @Column(name = "transaction_type")
-    @Enumerated(EnumType.STRING)
-    private TransactionType transactionType;
+    private String transactionType;
     
     @Column(name = "work_item_id")
     private String workItemId;
     
-    @JoinColumn(name = "submission_id")
+    @Column(name = "submission_id")
     private UUID submissionId;
     
     @CreationTimestamp

--- a/src/main/java/org/ilgcc/app/data/Transaction.java
+++ b/src/main/java/org/ilgcc/app/data/Transaction.java
@@ -2,6 +2,8 @@ package org.ilgcc.app.data;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
@@ -13,7 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.springframework.stereotype.Component;
+import org.ilgcc.app.utils.enums.TransactionType;
 
 
 @Entity
@@ -22,11 +24,14 @@ import org.springframework.stereotype.Component;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Component
 public class Transaction {
     
     @Id
     private UUID transactionId;
+    
+    @Column(name = "transaction_type")
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
     
     @Column(name = "work_item_id")
     private String workItemId;

--- a/src/main/java/org/ilgcc/app/data/TransactionRepositoryService.java
+++ b/src/main/java/org/ilgcc/app/data/TransactionRepositoryService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.ilgcc.app.utils.enums.TransactionType;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -79,17 +80,12 @@ public class TransactionRepositoryService {
         }
     }
 
-    public Transaction createTransaction(UUID transactionId, UUID submissionId, String workItemId) {
+    public Transaction createTransaction(UUID transactionId, UUID submissionId, String workItemId, TransactionType transactionType) {
         Transaction transaction = new Transaction();
         transaction.setTransactionId(transactionId);
         transaction.setSubmissionId(submissionId);
         transaction.setWorkItemId(workItemId);
-        return transactionRepository.save(transaction);
-    }
-
-    public Transaction setWorkItemId(UUID transactionId, String workItemId) {
-        Transaction transaction = transactionRepository.findByTransactionId(transactionId);
-        transaction.setWorkItemId(workItemId);
+        transaction.setTransactionType(transactionType);
         return transactionRepository.save(transaction);
     }
 }

--- a/src/main/java/org/ilgcc/app/data/TransactionRepositoryService.java
+++ b/src/main/java/org/ilgcc/app/data/TransactionRepositoryService.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.ilgcc.app.utils.enums.TransactionType;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -80,7 +79,7 @@ public class TransactionRepositoryService {
         }
     }
 
-    public Transaction createTransaction(UUID transactionId, UUID submissionId, String workItemId, TransactionType transactionType) {
+    public Transaction createTransaction(UUID transactionId, UUID submissionId, String workItemId, String transactionType) {
         Transaction transaction = new Transaction();
         transaction.setTransactionId(transactionId);
         transaction.setSubmissionId(submissionId);

--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -111,7 +111,6 @@ public class CCMSTransactionPayloadService {
                         providerSubmission -> allFiles.addAll(findAllFiles(providerSubmission)));
             }
         }
-        
 
         List<UserFile> userFiles = findAllFiles(familySubmission);
 

--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -111,6 +111,7 @@ public class CCMSTransactionPayloadService {
                         providerSubmission -> allFiles.addAll(findAllFiles(providerSubmission)));
             }
         }
+        
 
         List<UserFile> userFiles = findAllFiles(familySubmission);
 

--- a/src/main/java/org/ilgcc/app/utils/enums/TransactionType.java
+++ b/src/main/java/org/ilgcc/app/utils/enums/TransactionType.java
@@ -1,6 +1,15 @@
 package org.ilgcc.app.utils.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum TransactionType {
-    APPLICATION,
-    RESUBMISSION
+    APPLICATION("application"),
+    RESUBMISSION("resubmit-app");
+
+    private final String value;
+
+    TransactionType(String value) {
+        this.value = value;
+    }
 }

--- a/src/main/java/org/ilgcc/app/utils/enums/TransactionType.java
+++ b/src/main/java/org/ilgcc/app/utils/enums/TransactionType.java
@@ -1,0 +1,6 @@
+package org.ilgcc.app.utils.enums;
+
+public enum TransactionType {
+    APPLICATION,
+    RESUBMISSION
+}

--- a/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
+++ b/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
@@ -283,7 +283,7 @@ public class CCMSSubmissionPayloadTransactionJob {
 
                             UUID transactionId = UUID.fromString(response.get("transactionId").asText());
                             Transaction transaction = transactionRepositoryService.createTransaction(transactionId, submissionId,
-                                    workItemId, TransactionType.APPLICATION);
+                                    workItemId, TransactionType.APPLICATION.getValue());
                             List<UserFile> userFiles = ccmsTransaction.getFiles().stream().map(TransactionFile::getUserFile).collect(
                                     Collectors.toCollection(ArrayList::new));
                             userFiles.addAll(backupPdfFiles);

--- a/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
+++ b/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
@@ -42,6 +42,7 @@ import org.ilgcc.app.pdf.MultiProviderPDFService;
 import org.ilgcc.app.utils.ByteArrayMultipartFile;
 import org.ilgcc.app.utils.SubmissionUtilities;
 import org.ilgcc.app.utils.enums.TransactionStatus;
+import org.ilgcc.app.utils.enums.TransactionType;
 import org.jobrunr.jobs.JobId;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.scheduling.JobScheduler;
@@ -282,7 +283,7 @@ public class CCMSSubmissionPayloadTransactionJob {
 
                             UUID transactionId = UUID.fromString(response.get("transactionId").asText());
                             Transaction transaction = transactionRepositoryService.createTransaction(transactionId, submissionId,
-                                    workItemId);
+                                    workItemId, TransactionType.APPLICATION);
                             List<UserFile> userFiles = ccmsTransaction.getFiles().stream().map(TransactionFile::getUserFile).collect(
                                     Collectors.toCollection(ArrayList::new));
                             userFiles.addAll(backupPdfFiles);

--- a/src/main/resources/db/migration/V2025.09.24.13.32.46__Add_transaction_type_column_to_transactions_table.sql
+++ b/src/main/resources/db/migration/V2025.09.24.13.32.46__Add_transaction_type_column_to_transactions_table.sql
@@ -13,7 +13,7 @@ $$
 
             -- Backfill existing rows with APPLICATION
             UPDATE transactions
-            SET transaction_type = 'APPLICATION'
+            SET transaction_type = 'application'
             WHERE transaction_type IS NULL;
 
             -- Now make the column NOT NULL

--- a/src/main/resources/db/migration/V2025.09.24.13.32.46__Add_transaction_type_column_to_transactions_table.sql
+++ b/src/main/resources/db/migration/V2025.09.24.13.32.46__Add_transaction_type_column_to_transactions_table.sql
@@ -1,0 +1,24 @@
+DO
+$$
+    BEGIN
+        -- Add transaction_type column if it doesn't exist
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'transactions'
+              AND column_name = 'transaction_type'
+        ) THEN
+            -- Add column as nullable first
+            ALTER TABLE transactions
+                ADD COLUMN transaction_type TEXT;
+
+            -- Backfill existing rows with APPLICATION
+            UPDATE transactions
+            SET transaction_type = 'APPLICATION'
+            WHERE transaction_type IS NULL;
+
+            -- Now make the column NOT NULL
+            ALTER TABLE transactions
+                ALTER COLUMN transaction_type SET NOT NULL;
+        END IF;
+    END
+$$;

--- a/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
@@ -106,4 +106,21 @@ class CCMSSubmissionPayloadTransactionJobTest {
         assertThat(transaction).isNotNull();
         assertThat(uft.getTransaction().getTransactionId()).isEqualTo(transaction.getTransactionId());
     }
+
+    @Test
+    void sendCCMSTransaction_createsTransactionAndSetsTransactionTypeToApplication() throws Exception {
+        byte[] pdf = "fake-pdf".getBytes();
+        when(pdfService.generatePDFs(any(Submission.class))).thenReturn(Map.of("application.pdf", pdf));
+        doNothing().when(cloudFileRepository).upload(anyString(), any());
+        
+        CCMSTransaction txPayload = org.mockito.Mockito.mock(CCMSTransaction.class);
+        when(txPayload.getFiles()).thenReturn(List.of());
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(Optional.of(txPayload));
+
+        job.sendCCMSTransaction(submissionId);
+
+        Transaction transaction = transactionRepositoryService.getBySubmissionId(submissionId);
+        assertThat(transaction).isNotNull();
+        assertThat(transaction.getTransactionType().toString()).isEqualTo("APPLICATION");
+    }
 }

--- a/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
@@ -121,6 +121,6 @@ class CCMSSubmissionPayloadTransactionJobTest {
 
         Transaction transaction = transactionRepositoryService.getBySubmissionId(submissionId);
         assertThat(transaction).isNotNull();
-        assertThat(transaction.getTransactionType().toString()).isEqualTo("APPLICATION");
+        assertThat(transaction.getTransactionType().toString()).isEqualTo("application");
     }
 }

--- a/src/test/java/org/ilgcc/jobs/DailyNewApplicationsProviderEmailRecurringJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/DailyNewApplicationsProviderEmailRecurringJobTest.java
@@ -18,6 +18,7 @@ import org.ilgcc.app.data.TransactionRepository;
 import org.ilgcc.app.data.TransactionRepositoryService;
 import org.ilgcc.app.email.ILGCCEmail;
 import org.ilgcc.app.utils.SubmissionTestBuilder;
+import org.ilgcc.app.utils.enums.TransactionType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ public class DailyNewApplicationsProviderEmailRecurringJobTest {
 
         for (int i = 0; i < allSubmissions.size(); i++) {
             transactionRepositoryService.createTransaction(UUID.randomUUID(), allSubmissions.get(i).getId(),
-                    String.format("WI-000%s", i));
+                    String.format("WI-000%s", i), TransactionType.APPLICATION);
         }
     }
 

--- a/src/test/java/org/ilgcc/jobs/DailyNewApplicationsProviderEmailRecurringJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/DailyNewApplicationsProviderEmailRecurringJobTest.java
@@ -96,7 +96,7 @@ public class DailyNewApplicationsProviderEmailRecurringJobTest {
 
         for (int i = 0; i < allSubmissions.size(); i++) {
             transactionRepositoryService.createTransaction(UUID.randomUUID(), allSubmissions.get(i).getId(),
-                    String.format("WI-000%s", i), TransactionType.APPLICATION);
+                    String.format("WI-000%s", i), TransactionType.APPLICATION.getValue());
         }
     }
 


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1289

#### ✍️ Description
Adds a migration to add TransactionType to the Transaction DB table.

Updates transaction related code to set transaction type to APPLICATION on new transactions created by sendToCCMS method.

