### PR TITLE
[CCAP-193]-Fix JAWS Screen Reader Announcement for Uploaded File Names

### DIFF
--- a/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
+++ b/src/main/resources/templates/fragments/inputs/overrides/fileUploader.html
@@ -44,7 +44,7 @@
            th:text="#{general.files.uploaded-documents}"></p>
       </div>
       <div th:id="${'file-preview-template-' + inputName}" class="file-preview-template">
-        <div class="preview-container"></div>
+        <div class="preview-container" role="list" aria-label="Uploaded files"></div>
       </div>
     </div>
   </div>
@@ -261,7 +261,7 @@
                     <img class="dz-thumb" data-dz-thumbnail aria-hidden="true" />
                 </div>
                 <div class="file">
-                    <div class="dz-filename"><div class="filename-text" data-dz-name></div></div>
+                    <div class="dz-filename"><div class="filename-text" data-dz-name tabindex="0"></div></div>
                     <div class="display-flex body-gray file-details">
                         <div class="dz-size" data-dz-size></div>
                         <span class="file-details-delimiter" aria-hidden="true">•</span>
@@ -291,10 +291,14 @@
           var removeLink = file.previewElement.getElementsByClassName("dz-remove")[0];
           var thumbnail = file.previewElement.getElementsByClassName("dz-thumb")[0];
           fileNameSpan.setAttribute('aria-label', fileNameSpan.innerText);
-          fileNameSpan.innerHTML = "<span class='filename-text-name' aria-hidden='true'>"
+          fileNameSpan.innerHTML = "<span class='filename-text-name'>"
               + fileNameComponents[0] + "</span>" +
-              "<span class='filename-text-ext' aria-hidden='true'>" + fileNameComponents[1]
+              "<span class='filename-text-ext'>" + fileNameComponents[1]
               + "</span>";
+            var announceDiv = document.getElementById('file-announcements-' + [[${inputName}]]);
+            if (announceDiv) {
+                announceDiv.textContent = 'File added: ' + file.name;
+            }
           mixpanel.track('initiate_file_upload', {
             'page_name': window.location.pathname,
             'file_format': file.type,


### PR DESCRIPTION
🔗 Jira ticket
(https://codeforamerica.atlassian.net/browse/CCAP-193?

✍️ `Description`
1) Fixed JAWS screen reader not announcing uploaded file names while other screen readers like VoiceOver worked correctly.
2) The root cause was accessibility barriers preventing JAWS from reading filename content in the file upload component.
3) Implemented targeted accessibility improvements to ensure JAWS can properly access and announce uploaded file names.
4) Testing confirms JAWS now properly announces file names when navigating through uploaded files with no regression in other screen readers.

<img width="1897" height="962" alt="image" src="https://github.com/user-attachments/assets/7cb4db7f-8e81-468f-9dc2-06076a8496b6" />



