### PR TITLE
[CCAP-1376] Fixes an issue with UserFileTransaction saving - Merge after 1289

### DIFF
--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -111,7 +111,6 @@ public class CCMSTransactionPayloadService {
                         providerSubmission -> allFiles.addAll(findAllFiles(providerSubmission)));
             }
         }
-        
 
         List<UserFile> userFiles = findAllFiles(familySubmission);
 

--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -111,6 +111,7 @@ public class CCMSTransactionPayloadService {
                         providerSubmission -> allFiles.addAll(findAllFiles(providerSubmission)));
             }
         }
+        
 
         List<UserFile> userFiles = findAllFiles(familySubmission);
 

--- a/src/main/java/org/ilgcc/app/data/ccms/TransactionFile.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/TransactionFile.java
@@ -24,11 +24,12 @@ public class TransactionFile {
     public TransactionFile(
             @JsonProperty("name") String fileName,
             @JsonProperty("type") String fileType,
-            @JsonProperty("payload") String filePayload) {
+            @JsonProperty("payload") String filePayload,
+            UserFile userFile) {
         this.fileName = fileName;
         this.fileType = fileType;
         this.filePayload = filePayload;
-        this.userFile = null;
+        this.userFile = userFile;
     }
     
     @JsonProperty("name")

--- a/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
+++ b/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
@@ -61,7 +61,8 @@ public class CCMSTransactionPayloadServiceTest {
 
     private Submission familySubmission;
     private Submission providerSubmission;
-
+    
+    private final UserFile testFilledCcapPdf = new UserFile();
     private final UserFile testConvertedJpegPdf = new UserFile();
     private final UserFile testConvertedPngPdf = new UserFile();
     private final UserFile testProviderUploadedPdf1 = new UserFile();
@@ -90,6 +91,11 @@ public class CCMSTransactionPayloadServiceTest {
                 .submittedAt(OffsetDateTime.now())
                 .inputData(familyInputData)
                 .build();
+
+        testFilledCcapPdf.setMimeType(PDF_CONTENT_TYPE);
+        testFilledCcapPdf.setFileId(UUID.randomUUID());
+        testFilledCcapPdf.setRepositoryPath("testFilledCcapPath");
+        testFilledCcapPdf.setSubmission(familySubmission);
         
         testConvertedJpegPdf.setMimeType(PDF_CONTENT_TYPE);
         testConvertedJpegPdf.setFileId(UUID.randomUUID());
@@ -138,23 +144,23 @@ public class CCMSTransactionPayloadServiceTest {
                 new TransactionFile(
                         String.format("%s-CCAP-Application-Form.pdf", familySubmission.getId()),
                         TransactionFile.FileTypeId.APPLICATION_PDF.getValue(),
-                        Base64.getEncoder().encodeToString(Files.readAllBytes(testFilledCcapPdfPath))),
+                        Base64.getEncoder().encodeToString(Files.readAllBytes(testFilledCcapPdfPath)), testFilledCcapPdf),
                 new TransactionFile(
                         String.format("%s-Supporting-Document-%d-of-%d.pdf", familySubmission.getId(), 1, 4),
                         FileTypeId.UPLOADED_DOCUMENT.getValue(),
-                        Base64.getEncoder().encodeToString("testBase64String1".getBytes())),
+                        Base64.getEncoder().encodeToString("testBase64String1".getBytes()), testProviderUploadedPdf1),
                 new TransactionFile(
                         String.format("%s-Supporting-Document-%d-of-%d.pdf", familySubmission.getId(), 2, 4),
                         FileTypeId.UPLOADED_DOCUMENT.getValue(),
-                        Base64.getEncoder().encodeToString("testBase64String2".getBytes())),
+                        Base64.getEncoder().encodeToString("testBase64String2".getBytes()), testProviderUploadedPdf2),
                 new TransactionFile(
                         String.format("%s-Supporting-Document-%d-of-%d.pdf", familySubmission.getId(), 3, 4),
                         FileTypeId.UPLOADED_DOCUMENT.getValue(),
-                        Base64.getEncoder().encodeToString(Files.readAllBytes(testConvertedPngPath))),
+                        Base64.getEncoder().encodeToString(Files.readAllBytes(testConvertedPngPath)), testConvertedPngPdf),
                 new TransactionFile(
                         String.format("%s-Supporting-Document-%d-of-%d.pdf", familySubmission.getId(), 4, 4),
                         FileTypeId.UPLOADED_DOCUMENT.getValue(),
-                        Base64.getEncoder().encodeToString(Files.readAllBytes(testConvertedJpegPath)))
+                        Base64.getEncoder().encodeToString(Files.readAllBytes(testConvertedJpegPath)), testConvertedJpegPdf)
         );
 
         Optional<CCMSTransaction> ccmsTransactionOptional = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission);

--- a/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
+++ b/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
@@ -94,26 +94,31 @@ public class CCMSTransactionPayloadServiceTest {
 
         testFilledCcapPdf.setMimeType(PDF_CONTENT_TYPE);
         testFilledCcapPdf.setFileId(UUID.randomUUID());
+        testFilledCcapPdf.setOriginalName("CCAP-Application-Form.pdf");
         testFilledCcapPdf.setRepositoryPath("testFilledCcapPath");
         testFilledCcapPdf.setSubmission(familySubmission);
         
         testConvertedJpegPdf.setMimeType(PDF_CONTENT_TYPE);
         testConvertedJpegPdf.setFileId(UUID.randomUUID());
+        testConvertedJpegPdf.setOriginalName("testJpeg.jpg");
         testConvertedJpegPdf.setRepositoryPath("testConvertedJpegPath");
         testConvertedJpegPdf.setSubmission(familySubmission);
         
         testConvertedPngPdf.setMimeType(PDF_CONTENT_TYPE);
         testConvertedPngPdf.setFileId(UUID.randomUUID());
+        testConvertedPngPdf.setOriginalName("testPng.png");
         testConvertedPngPdf.setRepositoryPath("testConvertedPngPath");
         testConvertedPngPdf.setSubmission(familySubmission);
         
         testProviderUploadedPdf1.setMimeType(PDF_CONTENT_TYPE);
         testProviderUploadedPdf1.setFileId(UUID.randomUUID());
+        testProviderUploadedPdf1.setOriginalName("testProviderUploaded1.pdf");
         testProviderUploadedPdf1.setRepositoryPath("testProviderUploadedPdf1Path");
         testProviderUploadedPdf1.setSubmission(providerSubmission);
         
         testProviderUploadedPdf2.setMimeType(PDF_CONTENT_TYPE);
         testProviderUploadedPdf2.setFileId(UUID.randomUUID());
+        testProviderUploadedPdf2.setOriginalName("testProviderUploaded2.pdf");
         testProviderUploadedPdf2.setRepositoryPath("testProviderUploadedPdf2Path");
         testProviderUploadedPdf2.setSubmission(providerSubmission);
 


### PR DESCRIPTION
#### ✍️ Description
[Fixes an issue were UserFileTransaction records were failing to be created here.
](https://codeforamerica.sentry.io/issues/6903738840/?alert_rule_id=15385157&alert_type=issue&notification_uuid=4c95e0a5-31ea-4150-968e-a4cec6d80e3d&project=4506815935545344&referrer=slack)

The issue is because we need UserFile IDs to be created for each file we sent to CCMS, which now includes the application PDF. This means we need to now create a user file for the application PDFs when they are generated, upload them to S3 for storage in case we need to resubmit them later, and then save the corresponding transaction and userfile id to the UserFileTransaction table. 

This change means that we need to throw if uploading to S3 fails since this step is now important for resubmission. Additionally, if the send job fails, we want to first check if the PDF is already in S3 before reuploading / resaving to the DB. 
