### PR TITLE
Potential fix for code scanning alert no. 1010: Use of default toString()

### DIFF
--- a/src/main/java/org/ilgcc/app/data/UserFileTransaction.java
+++ b/src/main/java/org/ilgcc/app/data/UserFileTransaction.java
@@ -62,4 +62,17 @@ public class UserFileTransaction {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private OffsetDateTime updatedAt;
+
+    @Override
+    public String toString() {
+        return "UserFileTransaction{" +
+            "transactionFileId=" + transactionFileId +
+            ", userFile=" + (userFile != null ? userFile.getUserFileId() : null) +
+            ", transaction=" + (transaction != null ? transaction.getTransactionId() : null) +
+            ", submission=" + (submission != null ? submission.getId() : null) +
+            ", transactionStatus=" + transactionStatus +
+            ", createdAt=" + createdAt +
+            ", updatedAt=" + updatedAt +
+            '}';
+    }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/codeforamerica/il-gcc-form-flow/security/code-scanning/1010](https://github.com/codeforamerica/il-gcc-form-flow/security/code-scanning/1010)

The correct fix is to add an explicit, human-readable `toString()` method to the `UserFileTransaction` class. This method should return a string containing the most important fields of the entity, such as unique identifiers and status, while avoiding the potential for triggering expensive lazy loading. Specifically, we should include primitive fields and IDs to avoid recursive or unnecessary detail — for associated entities, it's typically best to print their IDs (e.g., `userFileId`, `transactionId`, `submissionId`) rather than their entire objects. The new method should be placed near the end of the class (above the closing brace), and imports are not required for basic string concatenation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
