### PR TITLE
[CCAP-1437] Reduce noise and kill job when multiple retries will never ever matter

### DIFF
--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -53,29 +53,20 @@ public class CCMSTransactionPayloadService {
     }
 
     public Optional<CCMSTransaction> generateSubmissionTransactionPayload(Submission familySubmission) {
-        if (familySubmission == null) {
-            log.error("generateSubmissionTransactionPayload error: familySubmission is null");
-            return Optional.empty();
-        }
-        try {
-            return Optional.of(new CCMSTransaction(
-                    "application",
-                    familySubmission.getId(),
-                    familySubmission.getShortCode(),
-                    familySubmission.getInputData().get("organizationId").toString(),
-                    FileNameUtility.removeNonSpaceOrDashCharacters(
-                            familySubmission.getInputData().get("parentFirstName").toString()),
-                    FileNameUtility.removeNonSpaceOrDashCharacters(
-                            familySubmission.getInputData().get("parentLastName").toString()),
-                    familySubmission.getInputData().get("parentBirthDate").toString(),
-                    getTransactionFiles(familySubmission),
-                    DateUtilities.formatDateToYearMonthDayHourCSTWithOffset(OffsetDateTime.now()),
-                    DateUtilities.formatDateToYearMonthDayHourCSTWithOffset(familySubmission.getSubmittedAt())
-            ));
-        } catch (Exception e) {
-            log.error("generateSubmissionTransactionPayload error for submission {}", familySubmission.getId(), e);
-            return Optional.empty();
-        }
+        return Optional.of(new CCMSTransaction(
+                "application",
+                familySubmission.getId(),
+                familySubmission.getShortCode(),
+                familySubmission.getInputData().get("organizationId").toString(),
+                FileNameUtility.removeNonSpaceOrDashCharacters(
+                        familySubmission.getInputData().get("parentFirstName").toString()),
+                FileNameUtility.removeNonSpaceOrDashCharacters(
+                        familySubmission.getInputData().get("parentLastName").toString()),
+                familySubmission.getInputData().get("parentBirthDate").toString(),
+                getTransactionFiles(familySubmission),
+                DateUtilities.formatDateToYearMonthDayHourCSTWithOffset(OffsetDateTime.now()),
+                DateUtilities.formatDateToYearMonthDayHourCSTWithOffset(familySubmission.getSubmittedAt())
+        ));
     }
 
     private List<TransactionFile> getTransactionFiles(Submission familySubmission) {

--- a/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadService.java
@@ -52,8 +52,8 @@ public class CCMSTransactionPayloadService {
         this.allowPdfModification = allowPdfModification;
     }
 
-    public Optional<CCMSTransaction> generateSubmissionTransactionPayload(Submission familySubmission) {
-        return Optional.of(new CCMSTransaction(
+    public CCMSTransaction generateSubmissionTransactionPayload(Submission familySubmission) {
+        return new CCMSTransaction(
                 "application",
                 familySubmission.getId(),
                 familySubmission.getShortCode(),
@@ -66,7 +66,7 @@ public class CCMSTransactionPayloadService {
                 getTransactionFiles(familySubmission),
                 DateUtilities.formatDateToYearMonthDayHourCSTWithOffset(OffsetDateTime.now()),
                 DateUtilities.formatDateToYearMonthDayHourCSTWithOffset(familySubmission.getSubmittedAt())
-        ));
+        );
     }
 
     private List<TransactionFile> getTransactionFiles(Submission familySubmission) {

--- a/src/main/java/org/ilgcc/app/exception/FatalJobrunrErrorDoNotRetryException.java
+++ b/src/main/java/org/ilgcc/app/exception/FatalJobrunrErrorDoNotRetryException.java
@@ -1,0 +1,14 @@
+package org.ilgcc.app.exception;
+
+import org.jobrunr.JobRunrException;
+
+public class FatalJobrunrErrorDoNotRetryException extends JobRunrException {
+
+    public FatalJobrunrErrorDoNotRetryException(String message) {
+        super(message, true);
+    }
+
+    public FatalJobrunrErrorDoNotRetryException(String message, Exception e) {
+        super(message, true, e);
+    }
+}

--- a/src/main/java/org/ilgcc/app/exception/S3ObjectNotFoundException.java
+++ b/src/main/java/org/ilgcc/app/exception/S3ObjectNotFoundException.java
@@ -1,7 +1,0 @@
-package org.ilgcc.app.exception;
-
-public class S3ObjectNotFoundException extends RuntimeException{
-    public S3ObjectNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/org/ilgcc/app/exception/S3ObjectNotScannedException.java
+++ b/src/main/java/org/ilgcc/app/exception/S3ObjectNotScannedException.java
@@ -1,7 +1,0 @@
-package org.ilgcc.app.exception;
-
-public class S3ObjectNotScannedException extends RuntimeException{
-    public S3ObjectNotScannedException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
+++ b/src/main/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJob.java
@@ -214,7 +214,7 @@ public class CCMSSubmissionPayloadTransactionJob {
                 if (submissionOptional.isPresent()) {
                     Submission submission = submissionOptional.get();
                     try {
-                        Optional<CCMSTransaction> ccmsTransactionOptional = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(
+                        CCMSTransaction ccmsTransaction = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(
                             submission);
                         boolean acquired = false;
                         try {
@@ -228,7 +228,6 @@ public class CCMSSubmissionPayloadTransactionJob {
                                 throw new IOException("Timeout waiting to acquire semaphore permit for transmitting to CCMS.");
                             }
 
-                            CCMSTransaction ccmsTransaction = ccmsTransactionOptional.get();
                             log.info("Sending submission {} to CCMS", submissionId);
                             JsonNode response = null;
                             if (enableV2Api) {
@@ -282,7 +281,7 @@ public class CCMSSubmissionPayloadTransactionJob {
                             }
                         }
 
-                    } catch (Exception e) {
+                    } catch (NullPointerException e) {
                         throw new FatalJobrunrErrorDoNotRetryException("Could not create CCMS payload for submission " + submission.getId(), e);
                     }
                 } else {

--- a/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
+++ b/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
@@ -168,11 +168,8 @@ public class CCMSTransactionPayloadServiceTest {
                         Base64.getEncoder().encodeToString(Files.readAllBytes(testConvertedJpegPath)), testConvertedJpegPdf)
         );
 
-        Optional<CCMSTransaction> ccmsTransactionOptional = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission);
-        assertThat(ccmsTransactionOptional.isPresent()).isTrue();
+        CCMSTransaction ccmsTransaction = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission);
 
-        CCMSTransaction ccmsTransaction = ccmsTransactionOptional.get();
-        
         assertThat(ccmsTransaction).isNotNull();
         assertThat(ccmsTransaction.getTransmissionType()).isEqualTo("application");
         assertThat(ccmsTransaction.getSubmissionId()).isEqualTo(familySubmission.getId());

--- a/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
@@ -104,7 +104,7 @@ class CCMSSubmissionPayloadTransactionJobTest {
         userFileRepositoryService.save(userFile);
         
         when(txPayload.getFiles()).thenReturn(List.of(new TransactionFile("application.pdf", "67936", "base64-payload", userFile)));
-        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(Optional.of(txPayload));
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(txPayload);
         
         job.sendCCMSTransaction(submissionId);
 
@@ -132,7 +132,7 @@ class CCMSSubmissionPayloadTransactionJobTest {
         
         CCMSTransaction txPayload = org.mockito.Mockito.mock(CCMSTransaction.class);
         when(txPayload.getFiles()).thenReturn(List.of());
-        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(Optional.of(txPayload));
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(txPayload);
 
         job.sendCCMSTransaction(submissionId);
 


### PR DESCRIPTION


#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/CCAP-1437

#### ✍️ Description
When we know the job will never succeed, we don't need to retry N times. This is a generic exception on top of the Jobrunr exception that will kill the job immediately.

Logs will now look like this:

<img width="1202" height="398" alt="Screenshot 2025-10-01 at 4 04 10 PM" src="https://github.com/user-attachments/assets/bfc763cc-5b3f-47d5-af5a-9e4068cd0169" />

And then within Jobrunr, there will be 1 failure and it'll look like this:

<img width="1155" height="567" alt="Screenshot 2025-10-01 at 4 04 40 PM" src="https://github.com/user-attachments/assets/86d2278f-84b8-4cc7-817e-e2d44e7db7a2" />

This means we will immediately get the alert for the retry failures, and then we will know the submission and jobrunr job to investigate.

#### 📷 Design reference
<!-- Figma link or screenshot if applicable -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria
