### PR TITLE
[CCAP-1287] Enable sending transactions to V2 CCMS endpoint

### DIFF
--- a/src/main/java/org/ilgcc/app/data/ccms/TransactionFile.java
+++ b/src/main/java/org/ilgcc/app/data/ccms/TransactionFile.java
@@ -1,35 +1,44 @@
 package org.ilgcc.app.data.ccms;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import formflow.library.data.UserFile;
+import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionFile {
     
     private final String fileName;
     private final String fileType;
     private final String filePayload;
+    private final UUID userFileId;
     
     @Getter
     @Setter
     @JsonIgnore
     private UserFile userFile;
     
-    @JsonCreator
     public TransactionFile(
-            @JsonProperty("name") String fileName,
-            @JsonProperty("type") String fileType,
-            @JsonProperty("payload") String filePayload,
+            String fileName,
+            String fileType,
+            String filePayload,
+            UUID userFileId,
             UserFile userFile) {
         this.fileName = fileName;
         this.fileType = fileType;
         this.filePayload = filePayload;
+        this.userFileId = userFileId;
         this.userFile = userFile;
+    }
+    
+    // Overloaded constructor without userFileId -- can be removed when v2 API is productized
+    public TransactionFile(String fileName, String fileType, String filePayload, UserFile userFile) {
+        this(fileName, fileType, filePayload, null, userFile);
     }
     
     @JsonProperty("name")
@@ -46,6 +55,9 @@ public class TransactionFile {
     public String getFilePayload() {
         return filePayload;
     }
+
+    @JsonProperty("id")
+    public UUID getUserFileId() { return userFileId; }
 
     @Getter
     public enum FileTypeId {

--- a/src/main/java/org/ilgcc/app/utils/enums/CCMSEndpoints.java
+++ b/src/main/java/org/ilgcc/app/utils/enums/CCMSEndpoints.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum CCMSEndpoints {
 
     APP_SUBMISSION_ENDPOINT("appSubmission"),
+    APP_SUBMISSION_V2_ENDPOINT("v2/appSubmission"),
     WORK_ITEM_LOOKUP_ENDPOINT("fetch");
 
     private final String value;

--- a/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
+++ b/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
@@ -168,7 +168,7 @@ public class CCMSTransactionPayloadServiceTest {
                         Base64.getEncoder().encodeToString(Files.readAllBytes(testConvertedJpegPath)), testConvertedJpegPdf)
         );
 
-        CCMSTransaction ccmsTransaction = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission);
+        CCMSTransaction ccmsTransaction = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission, false);
 
         assertThat(ccmsTransaction).isNotNull();
         assertThat(ccmsTransaction.getTransmissionType()).isEqualTo("application");

--- a/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
+++ b/src/test/java/org/ilgcc/app/data/ccms/CCMSTransactionPayloadServiceTest.java
@@ -201,10 +201,7 @@ public class CCMSTransactionPayloadServiceTest {
     
     @Test
     void shouldIncludeFileIdInCCMSTransactionWhenV2FlagIsSet() {
-        Optional<CCMSTransaction> ccmsTransactionOptional = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission, true);
-        assertThat(ccmsTransactionOptional.isPresent()).isTrue();
-
-        CCMSTransaction ccmsTransaction = ccmsTransactionOptional.get();
+        CCMSTransaction ccmsTransaction = ccmsTransactionPayloadService.generateSubmissionTransactionPayload(familySubmission, true);
         
         assertThat(ccmsTransaction).isNotNull();
         assertThat(ccmsTransaction.getFiles().size()).isEqualTo(5);

--- a/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
@@ -104,7 +104,7 @@ class CCMSSubmissionPayloadTransactionJobTest {
         userFileRepositoryService.save(userFile);
         
         when(txPayload.getFiles()).thenReturn(List.of(new TransactionFile("application.pdf", "67936", "base64-payload", userFile)));
-        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(txPayload);
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class), false)).thenReturn(txPayload);
         
         job.sendCCMSTransaction(submissionId);
 
@@ -132,7 +132,7 @@ class CCMSSubmissionPayloadTransactionJobTest {
         
         CCMSTransaction txPayload = org.mockito.Mockito.mock(CCMSTransaction.class);
         when(txPayload.getFiles()).thenReturn(List.of());
-        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class))).thenReturn(txPayload);
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class), false)).thenReturn(txPayload);
 
         job.sendCCMSTransaction(submissionId);
 

--- a/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
+++ b/src/test/java/org/ilgcc/jobs/CCMSSubmissionPayloadTransactionJobTest.java
@@ -3,6 +3,7 @@ package org.ilgcc.jobs;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -104,7 +105,8 @@ class CCMSSubmissionPayloadTransactionJobTest {
         userFileRepositoryService.save(userFile);
         
         when(txPayload.getFiles()).thenReturn(List.of(new TransactionFile("application.pdf", "67936", "base64-payload", userFile)));
-        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class), false)).thenReturn(txPayload);
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class), eq(false)))
+                .thenReturn(txPayload);
         
         job.sendCCMSTransaction(submissionId);
 
@@ -132,7 +134,8 @@ class CCMSSubmissionPayloadTransactionJobTest {
         
         CCMSTransaction txPayload = org.mockito.Mockito.mock(CCMSTransaction.class);
         when(txPayload.getFiles()).thenReturn(List.of());
-        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class), false)).thenReturn(txPayload);
+        when(payloadService.generateSubmissionTransactionPayload(any(Submission.class), eq(false)))
+                .thenReturn(txPayload);
 
         job.sendCCMSTransaction(submissionId);
 


### PR DESCRIPTION
#### 🔗 Jira ticket
CCAP-1287

#### ✍️ Description
Update the ILGCC application submission workflow so that when the ENABLE_CCMS_APPLICATION_V2 feature flag is enabled, application payloads are routed through the new v2/appSubmission API endpoint.

#### Proof of Work

**V2 Api returns correct files after sending submission to V2 Endpoint**
<img width="2034" height="1526" alt="screenshot_2025-10-01_at_7 42 45___pm" src="https://github.com/user-attachments/assets/8aa4f93f-ad6a-4760-8466-40fb9ea5ebca" />

**CCMS Correct creates entries when v2 endpoint is hit**
<img width="2766" height="1486" alt="screenshot_2025-10-01_at_7 43 09___pm" src="https://github.com/user-attachments/assets/95f8050b-9cad-4547-85f9-e09cebfba818" />

**User File Transaction shows correct rows for PDF and 2 additional provider PDFs**
<img width="1636" height="236" alt="Screenshot 2025-10-01 at 4 44 01 PM" src="https://github.com/user-attachments/assets/6803964f-f2a1-4dfa-a02e-6fce9b3fefc9" />


